### PR TITLE
Fix chat not coming back after server comes back. 

### DIFF
--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -44,7 +44,7 @@ export default class App extends Component {
     this.state = {
       websocket: new Websocket(),
       displayChat: getLocalStorage(KEY_CHAT_DISPLAYED) || true, // chat panel state
-      chatEnabled: false, // chat input box state
+      chatInputEnabled: false, // chat input box state
       username: getLocalStorage(KEY_USERNAME) || generateUsername(),
       userAvatarImage:
         getLocalStorage(KEY_AVATAR) ||
@@ -283,7 +283,7 @@ export default class App extends Component {
     this.setState({
       playerActive: true,
       streamOnline: true,
-      chatEnabled: true,
+      chatInputEnabled: true,
       streamStatusMessage: MESSAGE_ONLINE,
     });
   }
@@ -323,7 +323,7 @@ export default class App extends Component {
 
   disableChatInput() {
     this.setState({
-      chatEnabled: false,
+      chatInputEnabled: false,
     });
   }
 
@@ -340,7 +340,7 @@ export default class App extends Component {
 
   render(props, state) {
     const {
-      chatEnabled,
+      chatInputEnabled,
       configData,
       displayChat,
       extraUserContent,
@@ -538,7 +538,7 @@ export default class App extends Component {
           websocket=${websocket}
           username=${username}
           userAvatarImage=${userAvatarImage}
-          chatEnabled=${chatEnabled}
+          chatInputEnabled=${chatInputEnabled}
         />
       </div>
     `;

--- a/webroot/js/components/chat/chat.js
+++ b/webroot/js/components/chat/chat.js
@@ -144,18 +144,6 @@ export default class Chat extends Component {
 		this.websocket.send(message);
   }
 
-  disableChat() {
-    this.setState({
-      inputEnabled: false,
-    });
-	}
-
-	enableChat() {
-    this.setState({
-      inputEnabled: true,
-    });
-	}
-
   updateAuthorList(message) {
     const { type } = message;
     const nameList = this.state.chatUserNames;
@@ -175,7 +163,7 @@ export default class Chat extends Component {
 
 
   render(props, state) {
-    const { username, messagesOnly, chatEnabled } = props;
+    const { username, messagesOnly, chatInputEnabled } = props;
     const { messages, inputEnabled, chatUserNames } = state;
 
     const messageList = messages.map((message) => (html`<${Message} message=${message} username=${username} key=${message.id} />`));
@@ -193,25 +181,27 @@ export default class Chat extends Component {
       `);
     }
 
-    return (
-      html`
-        <section id="chat-container-wrap" class="flex flex-col">
-          <div id="chat-container" class="bg-gray-800 flex flex-col justify-end overflow-auto">
-            <div
-              id="messages-container"
-              ref=${this.scrollableMessagesContainer}
-              class="py-1 overflow-auto z-10"
-            >
-              ${messageList}
-            </div>
-            <${ChatInput}
-              chatUserNames=${chatUserNames}
-              inputEnabled=${chatEnabled && inputEnabled}
-              handleSendMessage=${this.submitChat}
-            />
+    return html`
+      <section id="chat-container-wrap" class="flex flex-col">
+        <div
+          id="chat-container"
+          class="bg-gray-800 flex flex-col justify-end overflow-auto"
+        >
+          <div
+            id="messages-container"
+            ref=${this.scrollableMessagesContainer}
+            class="py-1 overflow-auto z-10"
+          >
+            ${messageList}
           </div>
-        </section>
-    `);
+          <${ChatInput}
+            chatUserNames=${chatUserNames}
+            inputEnabled=${chatInputEnabled}
+            handleSendMessage=${this.submitChat}
+          />
+        </div>
+      </section>
+    `;
   }
 
 }


### PR DESCRIPTION
This fixes #136, when a server goes offline, and the chat disables, the chat didn't re-enable when the server came back up.

* Renamed `chatEnabled` to `chatInputEnabled`.
* Removed `disableChat` and `enableChat`.
* Made `ChatInput` enabled if `chatInputEnabled` is enabled and no longer uses `inputEnabled`.