### PR TITLE
Reset the directories when the stream gets disconnected

### DIFF
--- a/core/status.go
+++ b/core/status.go
@@ -27,6 +27,8 @@ func GetStatus() models.Status {
 
 //SetStreamAsConnected sets the stream as connected
 func SetStreamAsConnected() {
+	stopCleanupTimer()
+
 	_stats.StreamConnected = true
 	_stats.LastConnectTime = utils.NullTime{time.Now(), true}
 	_stats.LastDisconnectTime = utils.NullTime{time.Now(), false}
@@ -50,5 +52,5 @@ func SetStreamAsDisconnected() {
 	_stats.LastDisconnectTime = utils.NullTime{time.Now(), true}
 
 	ffmpeg.ShowStreamOfflineState()
-	resetDirectories()
+	startCleanupTimer()
 }

--- a/core/status.go
+++ b/core/status.go
@@ -50,4 +50,5 @@ func SetStreamAsDisconnected() {
 	_stats.LastDisconnectTime = utils.NullTime{time.Now(), true}
 
 	ffmpeg.ShowStreamOfflineState()
+	resetDirectories()
 }


### PR DESCRIPTION
Whenever the stream goes offline, reset all the directories. Although, this might be a breaking change and we could potentially have this be configurable?