### PR TITLE
Create release docker image without shipping source and go toolchain.

### DIFF
--- a/scripts/Dockerfile-build
+++ b/scripts/Dockerfile-build
@@ -18,6 +18,11 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 # Create the image by copying the result of the build into a new alpine image
 FROM alpine
 RUN apk add --no-cache ffmpeg ffmpeg-libs
+
+# Certs
+RUN apk update && apk add ca-certificates && update-ca-certificates
+
+# Copy owncast assets
 WORKDIR /app
 COPY --from=build /build/owncast /app/owncast
 COPY --from=build /build/config.yaml /app/config.yaml

--- a/scripts/Dockerfile-build
+++ b/scripts/Dockerfile-build
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 
 # Create the image by copying the result of the build into a new alpine image
 FROM alpine
-RUN apk update && apk add ca-certificates && update-ca-certificates && apk add --no-cache ffmpeg ffmpeg-libs
+RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs ca-certificates && update-ca-certificates
 
 # Copy owncast assets
 WORKDIR /app

--- a/scripts/Dockerfile-build
+++ b/scripts/Dockerfile-build
@@ -17,10 +17,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 
 # Create the image by copying the result of the build into a new alpine image
 FROM alpine
-RUN apk add --no-cache ffmpeg ffmpeg-libs
-
-# Certs
-RUN apk update && apk add ca-certificates && update-ca-certificates
+RUN apk update && apk add ca-certificates && update-ca-certificates && apk add --no-cache ffmpeg ffmpeg-libs
 
 # Copy owncast assets
 WORKDIR /app

--- a/scripts/Dockerfile-build
+++ b/scripts/Dockerfile-build
@@ -1,9 +1,9 @@
-FROM golang:alpine
+# Perform a build
+FROM golang:alpine AS build
 EXPOSE 8080 1935
-RUN mkdir /app
-ADD . /app
-WORKDIR /app
-RUN apk add --no-cache ffmpeg ffmpeg-libs
+RUN mkdir /build
+ADD . /build
+WORKDIR /build
 RUN apk update && apk add --no-cache gcc build-base linux-headers
 
 ARG VERSION
@@ -15,5 +15,13 @@ ENV NAME=${NAME}
 
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflags \"-static\" -s -w -X main.GitCommit=$GIT_COMMIT -X main.BuildVersion=$VERSION -X main.BuildType=$NAME" -o owncast .
 
+# Create the image by copying the result of the build into a new alpine image
+FROM alpine
+RUN apk add --no-cache ffmpeg ffmpeg-libs
 WORKDIR /app
+COPY --from=build /build/owncast /app/owncast
+COPY --from=build /build/config.yaml /app/config.yaml
+COPY --from=build /build/webroot /app/webroot
+COPY --from=build /build/static /app/static
+
 CMD ["/app/owncast"]


### PR DESCRIPTION
This changes the Docker image build process.  The build takes place in one step, and then the result gets copied into the distribution image.

Now we don't have to ship the source code that nobody would use, and the Go toolchain doesn't need to be shipped just for the initial build.

@geekgonecrazy let me know if you have any thoughts on this change.