### PR TITLE
Disconnect stream Admin API + HTTP Basic Auth

### DIFF
--- a/controllers/admin.go
+++ b/controllers/admin.go
@@ -1,0 +1,13 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gabek/owncast/core/rtmp"
+)
+
+// DisconnectInboundConnection will force-disconnect an inbound stream
+func DisconnectInboundConnection(w http.ResponseWriter, r *http.Request) {
+	rtmp.Disconnect()
+	w.WriteHeader(http.StatusOK)
+}

--- a/controllers/admin.go
+++ b/controllers/admin.go
@@ -3,11 +3,17 @@ package controllers
 import (
 	"net/http"
 
+	"github.com/gabek/owncast/core"
 	"github.com/gabek/owncast/core/rtmp"
 )
 
 // DisconnectInboundConnection will force-disconnect an inbound stream
 func DisconnectInboundConnection(w http.ResponseWriter, r *http.Request) {
+	if !core.GetStatus().Online {
+		writeSimpleResponse(w, false, "no inbound stream connected")
+		return
+	}
+
 	rtmp.Disconnect()
-	w.WriteHeader(http.StatusOK)
+	writeSimpleResponse(w, true, "inbound stream disconnected")
 }

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/gabek/owncast/models"
 )
 
 type j map[string]interface{}
@@ -23,4 +25,13 @@ func badRequestHandler(w http.ResponseWriter, err error) {
 
 	w.WriteHeader(http.StatusBadRequest)
 	json.NewEncoder(w).Encode(j{"error": err.Error()})
+}
+
+func writeSimpleResponse(w http.ResponseWriter, success bool, message string) {
+	response := models.BaseAPIResponse{
+		Success: success,
+		Message: message,
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
 }

--- a/models/baseAPIResponse.go
+++ b/models/baseAPIResponse.go
@@ -1,0 +1,7 @@
+package models
+
+// BaseAPIResponse is a simple response to API requests.
+type BaseAPIResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}

--- a/router/middleware/auth.go
+++ b/router/middleware/auth.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/gabek/owncast/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// RequireAdminAuth wraps a handler requiring HTTP basic auth for it using the given
+// the stream key as the password and and a hardcoded "admin" for username.
+func RequireAdminAuth(handler http.HandlerFunc) http.HandlerFunc {
+	username := "admin"
+	password := config.Config.VideoSettings.StreamingKey
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		user, pass, ok := r.BasicAuth()
+		realm := "Owncast Authenticated Request"
+
+		// Failed
+		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(username)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(password)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			log.Warnln("Failed authentication for", r.URL.Path, "from", r.RemoteAddr, r.UserAgent())
+			return
+		}
+
+		// Success
+		log.Traceln("Authenticated request OK for", r.URL.Path, "from", r.RemoteAddr, r.UserAgent())
+		handler(w, r)
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gabek/owncast/controllers"
 	"github.com/gabek/owncast/core/chat"
 	"github.com/gabek/owncast/core/rtmp"
+	"github.com/gabek/owncast/router/middleware"
 )
 
 //Start starts the router for the http, ws, and rtmp
@@ -42,6 +43,11 @@ func Start() error {
 		// video embed
 		http.HandleFunc("/embed/video", controllers.GetVideoEmbed)
 	}
+
+	// Authenticated admin requests
+
+	// Disconnect inbound stream
+	http.HandleFunc("/api/admin/disconnect", middleware.RequireAdminAuth(controllers.DisconnectInboundConnection))
 
 	port := config.Config.GetPublicWebServerPort()
 


### PR DESCRIPTION
This adds:

* Middleware for HTTP Basic Auth to authenticate Admin requests.
* Simple API to end the inbound RTMP connection to end the current live stream.  `/api/admin/disconnect`

