### PR TITLE
Simplify config, remove custom paths and add constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,15 +15,12 @@ var _default config
 
 type config struct {
 	ChatDatabaseFilePath string          `yaml:"chatDatabaseFile"`
-	DisableWebFeatures   bool            `yaml:"disableWebFeatures"`
 	EnableDebugFeatures  bool            `yaml:"-"`
 	FFMpegPath           string          `yaml:"ffmpegPath"`
 	Files                files           `yaml:"files"`
 	InstanceDetails      InstanceDetails `yaml:"instanceDetails"`
-	PrivateHLSPath       string          `yaml:"privateHLSPath"`
-	PublicHLSPath        string          `yaml:"publicHLSPath"`
 	S3                   S3              `yaml:"s3"`
-	VersionInfo          string          `yaml:"-"`
+	VersionInfo          string          `yaml:"-"` // For storing the version/build number
 	VideoSettings        videoSettings   `yaml:"videoSettings"`
 	WebServerPort        int             `yaml:"webServerPort"`
 	YP                   yp              `yaml:"yp"`
@@ -156,22 +153,6 @@ func (c *config) GetVideoSegmentSecondsLength() int {
 	}
 
 	return _default.GetVideoSegmentSecondsLength()
-}
-
-func (c *config) GetPublicHLSSavePath() string {
-	if c.PublicHLSPath != "" {
-		return c.PublicHLSPath
-	}
-
-	return _default.PublicHLSPath
-}
-
-func (c *config) GetPrivateHLSSavePath() string {
-	if c.PrivateHLSPath != "" {
-		return c.PrivateHLSPath
-	}
-
-	return _default.PrivateHLSPath
 }
 
 func (c *config) GetPublicWebServerPort() int {

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,0 +1,12 @@
+package config
+
+import "path/filepath"
+
+const (
+	WebRoot               = "webroot"
+	PrivateHLSStoragePath = "hls"
+)
+
+var (
+	PublicHLSStoragePath = filepath.Join(WebRoot, "hls")
+)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -12,8 +12,6 @@ func getDefaults() config {
 	defaults.FFMpegPath = getDefaultFFMpegPath()
 	defaults.VideoSettings.ChunkLengthInSeconds = 4
 	defaults.Files.MaxNumberInPlaylist = 5
-	defaults.PublicHLSPath = "webroot/hls"
-	defaults.PrivateHLSPath = "hls"
 	defaults.VideoSettings.OfflineContent = "static/offline.m4v"
 	defaults.InstanceDetails.ExtraInfoFile = "/static/content.md"
 	defaults.YP.Enabled = false

--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gabek/owncast/config"
 	"github.com/gabek/owncast/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -20,7 +21,7 @@ const emojiPath = "/img/emoji" // Relative to webroot
 func GetCustomEmoji(w http.ResponseWriter, r *http.Request) {
 	emojiList := make([]models.CustomEmoji, 0)
 
-	fullPath := filepath.Join("webroot", emojiPath)
+	fullPath := filepath.Join(config.WebRoot, emojiPath)
 	files, err := ioutil.ReadDir(fullPath)
 	if err != nil {
 		log.Errorln(err)

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -30,13 +31,6 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 
 	isIndexRequest := r.URL.Path == "/" || r.URL.Path == "/index.html"
 
-	// Reject requests for the web UI if it's disabled.
-	if isIndexRequest && config.Config.DisableWebFeatures {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("404 - y u ask 4 this?  If this is an error let us know: https://github.com/owncast/owncast/issues"))
-		return
-	}
-
 	// For search engine bots and social scrapers return a special
 	// server-rendered page.
 	if utils.IsUserAgentABot(r.UserAgent()) && isIndexRequest {
@@ -60,7 +54,7 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 	// Set a cache control max-age header
 	middleware.SetCachingHeaders(w, r)
 
-	http.ServeFile(w, r, path.Join("webroot", r.URL.Path))
+	http.ServeFile(w, r, path.Join(config.WebRoot, r.URL.Path))
 }
 
 // Return a basic HTML page with server-rendered metadata from the config file
@@ -75,7 +69,7 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 
 	// If the thumbnail does not exist or we're offline then just use the logo image
 	var thumbnailURL string
-	if status.Online && utils.DoesFileExists("webroot/thumbnail.jpg") {
+	if status.Online && utils.DoesFileExists(filepath.Join(config.WebRoot, "thumbnail.jpg")) {
 		thumbnail, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, "/thumbnail.jpg"))
 		if err != nil {
 			log.Errorln(err)

--- a/core/core.go
+++ b/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -56,8 +57,8 @@ func Start() error {
 
 func createInitialOfflineState() error {
 	// Provide default files
-	if !utils.DoesFileExists("webroot/thumbnail.jpg") {
-		if err := utils.Copy("static/logo.png", "webroot/thumbnail.jpg"); err != nil {
+	if !utils.DoesFileExists(filepath.Join(config.WebRoot, "thumbnail.jpg")) {
+		if err := utils.Copy("static/logo.png", filepath.Join(config.WebRoot, "thumbnail.jpg")); err != nil {
 			return err
 		}
 	}
@@ -93,22 +94,22 @@ func resetDirectories() {
 	log.Trace("Resetting file directories to a clean slate.")
 
 	// Wipe the public, web-accessible hls data directory
-	os.RemoveAll(config.Config.GetPublicHLSSavePath())
-	os.RemoveAll(config.Config.GetPrivateHLSSavePath())
-	os.MkdirAll(config.Config.GetPublicHLSSavePath(), 0777)
-	os.MkdirAll(config.Config.GetPrivateHLSSavePath(), 0777)
+	os.RemoveAll(config.PublicHLSStoragePath)
+	os.RemoveAll(config.PrivateHLSStoragePath)
+	os.MkdirAll(config.PublicHLSStoragePath, 0777)
+	os.MkdirAll(config.PrivateHLSStoragePath, 0777)
 
 	// Remove the previous thumbnail
-	os.Remove("webroot/thumbnail.jpg")
+	os.Remove(filepath.Join(config.WebRoot, "thumbnail.jpg"))
 
 	// Create private hls data dirs
 	if len(config.Config.VideoSettings.StreamQualities) != 0 {
 		for index := range config.Config.VideoSettings.StreamQualities {
-			os.MkdirAll(path.Join(config.Config.GetPrivateHLSSavePath(), strconv.Itoa(index)), 0777)
-			os.MkdirAll(path.Join(config.Config.GetPublicHLSSavePath(), strconv.Itoa(index)), 0777)
+			os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(index)), 0777)
+			os.MkdirAll(path.Join(config.PublicHLSStoragePath, strconv.Itoa(index)), 0777)
 		}
 	} else {
-		os.MkdirAll(path.Join(config.Config.GetPrivateHLSSavePath(), strconv.Itoa(0)), 0777)
-		os.MkdirAll(path.Join(config.Config.GetPublicHLSSavePath(), strconv.Itoa(0)), 0777)
+		os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(0)), 0777)
+		os.MkdirAll(path.Join(config.PublicHLSStoragePath, strconv.Itoa(0)), 0777)
 	}
 }

--- a/core/ffmpeg/thumbnailGenerator.go
+++ b/core/ffmpeg/thumbnailGenerator.go
@@ -39,8 +39,8 @@ func StartThumbnailGenerator(chunkPath string, variantIndex int) {
 
 func fireThumbnailGenerator(chunkPath string, variantIndex int) error {
 	// JPG takes less time to encode than PNG
-	outputFile := path.Join("webroot", "thumbnail.jpg")
-	previewGifFile := path.Join("webroot", "preview.gif")
+	outputFile := path.Join(config.WebRoot, "thumbnail.jpg")
+	previewGifFile := path.Join(config.WebRoot, "preview.gif")
 
 	framePath := path.Join(chunkPath, strconv.Itoa(variantIndex))
 	files, err := ioutil.ReadDir(framePath)

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -188,15 +188,15 @@ func NewTranscoder() Transcoder {
 	var outputPath string
 	if config.Config.S3.Enabled {
 		// Segments are not available via the local HTTP server
-		outputPath = config.Config.GetPrivateHLSSavePath()
+		outputPath = config.PrivateHLSStoragePath
 	} else {
 		// Segments are available via the local HTTP server
-		outputPath = config.Config.GetPublicHLSSavePath()
+		outputPath = config.PublicHLSStoragePath
 	}
 
 	transcoder.segmentOutputPath = outputPath
 	// Playlists are available via the local HTTP server
-	transcoder.playlistOutputPath = config.Config.GetPublicHLSSavePath()
+	transcoder.playlistOutputPath = config.PublicHLSStoragePath
 
 	transcoder.input = utils.GetTemporaryPipePath()
 	transcoder.segmentLengthSeconds = config.Config.GetVideoSegmentSecondsLength()

--- a/core/playlist/monitor.go
+++ b/core/playlist/monitor.go
@@ -26,7 +26,7 @@ var (
 func StartVideoContentMonitor(storage models.ChunkStorageProvider) error {
 	_storage = storage
 
-	pathToMonitor := config.Config.GetPrivateHLSSavePath()
+	pathToMonitor := config.PrivateHLSStoragePath
 
 	// Create at least one structure to store the segments for the different stream variants
 	variants = make([]models.Variant, len(config.Config.VideoSettings.StreamQualities))
@@ -63,11 +63,9 @@ func StartVideoContentMonitor(storage models.ChunkStorageProvider) error {
 					continue
 				}
 
-				// fmt.Println(event.Op, relativePath)
-
 				// Handle updates to the master playlist by copying it to webroot
-				if relativePath == path.Join(config.Config.GetPrivateHLSSavePath(), "stream.m3u8") {
-					utils.Copy(event.Path, path.Join(config.Config.GetPublicHLSSavePath(), "stream.m3u8"))
+				if relativePath == path.Join(config.PrivateHLSStoragePath, "stream.m3u8") {
+					utils.Copy(event.Path, path.Join(config.PublicHLSStoragePath, "stream.m3u8"))
 
 				} else if filepath.Ext(event.Path) == ".m3u8" {
 					// Handle updates to playlists, but not the master playlist
@@ -82,7 +80,7 @@ func StartVideoContentMonitor(storage models.ChunkStorageProvider) error {
 
 					newObjectPathChannel := make(chan string, 1)
 					go func() {
-						newObjectPath, err := storage.Save(path.Join(config.Config.GetPrivateHLSSavePath(), segment.RelativeUploadPath), 0)
+						newObjectPath, err := storage.Save(path.Join(config.PrivateHLSStoragePath, segment.RelativeUploadPath), 0)
 						if err != nil {
 							log.Errorln("failed to save the file to the chunk storage.", err)
 						}
@@ -155,5 +153,5 @@ func updateVariantPlaylist(fullPath string) error {
 	playlistString := string(playlistBytes)
 	playlistString = _storage.GenerateRemotePlaylist(playlistString, variant)
 
-	return WritePlaylist(playlistString, path.Join(config.Config.GetPublicHLSSavePath(), relativePath))
+	return WritePlaylist(playlistString, path.Join(config.PublicHLSStoragePath, relativePath))
 }

--- a/core/status.go
+++ b/core/status.go
@@ -33,9 +33,9 @@ func SetStreamAsConnected() {
 	_stats.LastConnectTime = utils.NullTime{time.Now(), true}
 	_stats.LastDisconnectTime = utils.NullTime{time.Now(), false}
 
-	chunkPath := config.Config.GetPublicHLSSavePath()
+	chunkPath := config.PublicHLSStoragePath
 	if usingExternalStorage {
-		chunkPath = config.Config.GetPrivateHLSSavePath()
+		chunkPath = config.PrivateHLSStoragePath
 	}
 
 	if _yp != nil {

--- a/core/storageproviders/s3Storage.go
+++ b/core/storageproviders/s3Storage.go
@@ -28,7 +28,7 @@ type S3Storage struct {
 	s3Bucket          string
 	s3AccessKey       string
 	s3Secret          string
- 	s3ACL             string
+	s3ACL             string
 }
 
 //Setup sets up the s3 storage for saving the video to s3
@@ -94,7 +94,7 @@ func (s *S3Storage) GenerateRemotePlaylist(playlist string, variant models.Varia
 			if fullRemotePath == nil {
 				line = ""
 			} else if s.s3ServingEndpoint != "" {
-				line = fmt.Sprintf("%s/%s/%s", s.s3ServingEndpoint, config.Config.GetPrivateHLSSavePath(), fullRemotePath.RelativeUploadPath)
+				line = fmt.Sprintf("%s/%s/%s", s.s3ServingEndpoint, config.PrivateHLSStoragePath, fullRemotePath.RelativeUploadPath)
 			} else {
 				line = fullRemotePath.RemoteID
 			}

--- a/router/router.go
+++ b/router/router.go
@@ -30,24 +30,22 @@ func Start() error {
 	// custom emoji supported in the chat
 	http.HandleFunc("/api/emoji", controllers.GetCustomEmoji)
 
-	if !config.Config.DisableWebFeatures {
-		// websocket chat server
-		go chat.Start()
+	// websocket chat server
+	go chat.Start()
 
-		// chat rest api
-		http.HandleFunc("/api/chat", controllers.GetChatMessages)
+	// chat rest api
+	http.HandleFunc("/api/chat", controllers.GetChatMessages)
 
-		// web config api
-		http.HandleFunc("/api/config", controllers.GetWebConfig)
+	// web config api
+	http.HandleFunc("/api/config", controllers.GetWebConfig)
 
-		// chat embed
-		http.HandleFunc("/embed/chat", controllers.GetChatEmbed)
+	// chat embed
+	http.HandleFunc("/embed/chat", controllers.GetChatEmbed)
 
-		// video embed
-		http.HandleFunc("/embed/video", controllers.GetVideoEmbed)
+	// video embed
+	http.HandleFunc("/embed/video", controllers.GetVideoEmbed)
 
-		http.HandleFunc("/api/yp", yp.GetYPResponse)
-	}
+	http.HandleFunc("/api/yp", yp.GetYPResponse)
 
 	// Authenticated admin requests
 


### PR DESCRIPTION
As discussed when we met today, this change simplifies paths by hard-coding them in a new constants file.  In the future we can make an actual effort to support completely custom locations for storing things on disk, but as it stands was only half-way respecting things.

I also removed the `DisableWebFeatures` config option, as it was just another thing that was overly niche.  If people don't want to use the web app they don't have to.