### PR TITLE
Remove additional viewer counts from status bar.

### DIFF
--- a/webroot/js/app-video-only.js
+++ b/webroot/js/app-video-only.js
@@ -31,8 +31,6 @@ export default class VideoOnly extends Component {
       //status
       streamStatusMessage: MESSAGE_OFFLINE,
       viewerCount: '',
-      sessionMaxViewerCount: '',
-      overallMaxViewerCount: '',
     };
 
     // timers
@@ -131,8 +129,6 @@ export default class VideoOnly extends Component {
     }
     const {
       viewerCount,
-      sessionMaxViewerCount,
-      overallMaxViewerCount,
       online,
     } = status;
 
@@ -153,8 +149,6 @@ export default class VideoOnly extends Component {
     }
     this.setState({
       viewerCount,
-      sessionMaxViewerCount,
-      overallMaxViewerCount,
       streamOnline: online,
     });
   }
@@ -215,8 +209,6 @@ export default class VideoOnly extends Component {
       configData,
 
       viewerCount,
-      sessionMaxViewerCount,
-      overallMaxViewerCount,
       playerActive,
       streamOnline,
       streamStatusMessage,
@@ -256,8 +248,6 @@ export default class VideoOnly extends Component {
           <section id="stream-info" aria-label="Stream status" class="flex text-center flex-row justify-between items-center font-mono py-2 px-8 bg-gray-900 text-indigo-200">
             <span>${streamStatusMessage}</span>
             <span>${viewerCount} ${pluralize('viewer', viewerCount)}.</span>
-            <span>Max ${pluralize('viewer', sessionMaxViewerCount)}.</span>
-            <span>${overallMaxViewerCount} overall.</span>
           </section>
         </main>
     `);

--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -64,8 +64,6 @@ export default class App extends Component {
       // status
       streamStatusMessage: MESSAGE_OFFLINE,
       viewerCount: '',
-      sessionMaxViewerCount: '',
-      overallMaxViewerCount: '',
 
       // dom
       windowWidth: window.innerWidth,
@@ -208,8 +206,6 @@ export default class App extends Component {
     }
     const {
       viewerCount,
-      sessionMaxViewerCount,
-      overallMaxViewerCount,
       online,
       lastConnectTime,
     } = status;
@@ -231,8 +227,6 @@ export default class App extends Component {
     }
     this.setState({
       viewerCount,
-      sessionMaxViewerCount,
-      overallMaxViewerCount,
       lastConnectTime,
       streamOnline: online,
     });
@@ -357,9 +351,7 @@ export default class App extends Component {
       displayChat,
       extraUserContent,
       orientation,
-      overallMaxViewerCount,
       playerActive,
-      sessionMaxViewerCount,
       streamOnline,
       streamStatusMessage,
       userAvatarImage,
@@ -483,12 +475,6 @@ export default class App extends Component {
           >
             <span>${streamStatusMessage}</span>
             <span>${viewerCount} ${pluralize('viewer', viewerCount)}.</span>
-            <span>
-              Max ${sessionMaxViewerCount} ${" "} ${pluralize('viewer', sessionMaxViewerCount)} this stream.
-            </span>
-            <span>
-              ${overallMaxViewerCount} all time.
-            </span>
           </section>
         </main>
 


### PR DESCRIPTION
These values will be displayed in the admin, and there's no real need for regular users to know these counts.  They were confusing to people anyway.