### PR TITLE
Variable collisions; Possible use of nil value

### DIFF
--- a/controllers/admin/hardware.go
+++ b/controllers/admin/hardware.go
@@ -9,8 +9,8 @@ import (
 
 // GetHardwareStats will return hardware utilization over time
 func GetHardwareStats(w http.ResponseWriter, r *http.Request) {
-	metrics := metrics.Metrics
+	m := metrics.Metrics
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(metrics)
+	json.NewEncoder(w).Encode(m)
 }

--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -15,13 +15,13 @@ import (
 
 // Make this path configurable if somebody has a valid reason
 // to need it to be.  The config is getting a bit bloated.
-const emojiPath = "/img/emoji" // Relative to webroot
+const emojiDir = "/img/emoji" // Relative to webroot
 
 //GetCustomEmoji returns a list of custom emoji via the API
 func GetCustomEmoji(w http.ResponseWriter, r *http.Request) {
 	emojiList := make([]models.CustomEmoji, 0)
 
-	fullPath := filepath.Join(config.WebRoot, emojiPath)
+	fullPath := filepath.Join(config.WebRoot, emojiDir)
 	files, err := ioutil.ReadDir(fullPath)
 	if err != nil {
 		log.Errorln(err)
@@ -34,8 +34,8 @@ func GetCustomEmoji(w http.ResponseWriter, r *http.Request) {
 	// the server to add emoji?
 	for _, f := range files {
 		name := strings.TrimSuffix(f.Name(), path.Ext(f.Name()))
-		path := filepath.Join(emojiPath, f.Name())
-		singleEmoji := models.CustomEmoji{name, path}
+		emojiPath := filepath.Join(emojiDir, f.Name())
+		singleEmoji := models.CustomEmoji{name, emojiPath}
 		emojiList = append(emojiList, singleEmoji)
 	}
 

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -64,7 +64,13 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	tmpl := template.Must(template.ParseFiles(path.Join("static", "metadata.html")))
 
 	fullURL, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, r.URL.Path))
+	if err != nil {
+		log.Panicln(err)
+	}
 	imageURL, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, config.Config.InstanceDetails.Logo.Large))
+	if err != nil {
+		log.Panicln(err)
+	}
 
 	status := core.GetStatus()
 
@@ -74,8 +80,10 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 		thumbnail, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, "/thumbnail.jpg"))
 		if err != nil {
 			log.Errorln(err)
+			thumbnailURL = imageURL.String()
+		} else {
+			thumbnailURL = thumbnail.String()
 		}
-		thumbnailURL = thumbnail.String()
 	} else {
 		thumbnailURL = imageURL.String()
 	}

--- a/core/chat/persistence.go
+++ b/core/chat/persistence.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/models"
 	"github.com/owncast/owncast/utils"
-	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -50,6 +50,9 @@ func createTable(db *sql.DB) {
 
 func addMessage(message models.ChatMessage) {
 	tx, err := _db.Begin()
+	if err != nil {
+		log.Fatal(err)
+	}
 	stmt, err := tx.Prepare("INSERT INTO messages(id, author, body, messageType, visible, timestamp) values(?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		log.Fatal(err)

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -69,9 +69,9 @@ func (v *VideoSize) getString() string {
 
 func (t *Transcoder) Stop() {
 	log.Traceln("Transcoder STOP requested.")
-	error := _commandExec.Process.Kill()
-	if error != nil {
-		log.Errorln(error)
+	err := _commandExec.Process.Kill()
+	if err != nil {
+		log.Errorln(err)
 	}
 }
 

--- a/core/rtmp/rtmp.go
+++ b/core/rtmp/rtmp.go
@@ -34,8 +34,8 @@ func Start() {
 	port := 1935
 	s := rtmp.NewServer()
 	var lis net.Listener
-	var error error
-	if lis, error = net.Listen("tcp", fmt.Sprintf(":%d", port)); error != nil {
+	var err error
+	if lis, err = net.Listen("tcp", fmt.Sprintf(":%d", port)); err != nil {
 		return
 	}
 
@@ -46,8 +46,8 @@ func Start() {
 
 	s.HandleConn = HandleConn
 
-	if error != nil {
-		log.Panicln(error)
+	if err != nil {
+		log.Panicln(err)
 	}
 	log.Infof("RTMP server is listening for incoming stream on port: %d", port)
 

--- a/core/storageproviders/local.go
+++ b/core/storageproviders/local.go
@@ -26,9 +26,9 @@ func (s *LocalStorage) SegmentWritten(localFilePath string) {
 
 // VariantPlaylistWritten is called when a variant hls playlist is written
 func (s *LocalStorage) VariantPlaylistWritten(localFilePath string) {
-	_, error := s.Save(localFilePath, 0)
-	if error != nil {
-		log.Errorln(error)
+	_, err := s.Save(localFilePath, 0)
+	if err != nil {
+		log.Errorln(err)
 		return
 	}
 }

--- a/core/storageproviders/s3Storage.go
+++ b/core/storageproviders/s3Storage.go
@@ -73,9 +73,9 @@ func (s *S3Storage) SegmentWritten(localFilePath string) {
 	utils.StartPerformanceMonitor(performanceMonitorKey)
 
 	// Upload the segment
-	_, error := s.Save(localFilePath, 0)
-	if error != nil {
-		log.Errorln(error)
+	_, err := s.Save(localFilePath, 0)
+	if err != nil {
+		log.Errorln(err)
 		return
 	}
 	averagePerformance := utils.GetAveragePerformance(performanceMonitorKey)
@@ -92,10 +92,10 @@ func (s *S3Storage) SegmentWritten(localFilePath string) {
 	// so the segments and the HLS playlist referencing
 	// them are in sync.
 	playlistPath := filepath.Join(filepath.Dir(localFilePath), "stream.m3u8")
-	_, error = s.Save(playlistPath, 0)
-	if error != nil {
+	_, err = s.Save(playlistPath, 0)
+	if err != nil {
 		_queuedPlaylistUpdates[playlistPath] = playlistPath
-		if pErr, ok := error.(*os.PathError); ok {
+		if pErr, ok := err.(*os.PathError); ok {
 			log.Debugln(pErr.Path, "does not yet exist locally when trying to upload to S3 storage.")
 			return
 		}
@@ -108,9 +108,9 @@ func (s *S3Storage) VariantPlaylistWritten(localFilePath string) {
 	// to make sure we're not refering to files in a playlist that don't
 	// yet exist.  See SegmentWritten.
 	if _, ok := _queuedPlaylistUpdates[localFilePath]; ok {
-		_, error := s.Save(localFilePath, 0)
-		if error != nil {
-			log.Errorln(error)
+		_, err := s.Save(localFilePath, 0)
+		if err != nil {
+			log.Errorln(err)
 			_queuedPlaylistUpdates[localFilePath] = localFilePath
 		}
 		delete(_queuedPlaylistUpdates, localFilePath)

--- a/core/storageproviders/s3Storage.go
+++ b/core/storageproviders/s3Storage.go
@@ -91,10 +91,10 @@ func (s *S3Storage) SegmentWritten(localFilePath string) {
 	// Upload the variant playlist for this segment
 	// so the segments and the HLS playlist referencing
 	// them are in sync.
-	playlist := filepath.Join(filepath.Dir(localFilePath), "stream.m3u8")
-	_, error = s.Save(playlist, 0)
+	playlistPath := filepath.Join(filepath.Dir(localFilePath), "stream.m3u8")
+	_, error = s.Save(playlistPath, 0)
 	if error != nil {
-		_queuedPlaylistUpdates[playlist] = playlist
+		_queuedPlaylistUpdates[playlistPath] = playlistPath
 		if pErr, ok := error.(*os.PathError); ok {
 			log.Debugln(pErr.Path, "does not yet exist locally when trying to upload to S3 storage.")
 			return

--- a/core/streamState.go
+++ b/core/streamState.go
@@ -68,10 +68,10 @@ func SetStreamAsDisconnected() {
 
 		if utils.DoesFileExists(playlistFilePath) {
 			f, err := os.OpenFile(playlistFilePath, os.O_CREATE|os.O_RDWR, os.ModePerm)
-			defer f.Close()
 			if err != nil {
 				log.Errorln(err)
 			}
+			defer f.Close()
 
 			playlist, _, err := m3u8.DecodeFrom(bufio.NewReader(f), true)
 			variantPlaylist := playlist.(*m3u8.MediaPlaylist)

--- a/yp/yp.go
+++ b/yp/yp.go
@@ -108,12 +108,11 @@ func (yp *YP) ping() {
 
 func (yp *YP) writeSavedKey(key string) {
 	f, err := os.Create(".yp.key")
-	defer f.Close()
-
 	if err != nil {
 		log.Errorln(err)
 		return
 	}
+	defer f.Close()
 
 	_, err = f.WriteString(key)
 	if err != nil {


### PR DESCRIPTION
Renamed a few variable which had a collision shadowing a package or interface name and added/moved a few error checks to ensure `nil` values do not get used resulting in a nil pointer panic