### PR TITLE
Add Javascript update Github Actions workflow

### DIFF
--- a/.github/workflows/javascript-packages.yaml
+++ b/.github/workflows/javascript-packages.yaml
@@ -1,0 +1,28 @@
+name: javascript-packages
+on:
+  push:
+    paths:
+      - build/javascript/package.json
+
+jobs:
+  run:
+    name: npm run build
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repo
+          uses: actions/checkout@v2
+
+        - name: Install dependencies
+          run: |
+            cd build/javascript
+            npm run build
+
+        - name: Commit changes
+          uses: EndBug/add-and-commit@v5
+          with:
+            author_name: Owncast
+            author_email: owncast@owncast.online
+            message: "Commit updated Javascript packages"
+            add: "build/javascript/package* webroot/js/web_modules"
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/javascript/package.json
+++ b/build/javascript/package.json
@@ -34,6 +34,6 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm install && npx snowpack install && cp node_modules/video.js/dist/video-js.min.css web_modules/videojs && cp -R web_modules ../../webroot/js"
   },
-  "author": "",
+  "author": "Owncast",
   "license": "ISC"
 }

--- a/webroot/js/web_modules/@justinribeiro/lite-youtube.js
+++ b/webroot/js/web_modules/@justinribeiro/lite-youtube.js
@@ -193,6 +193,7 @@ class LiteYTEmbed extends HTMLElement {
                     if (this.domRefFrame.classList.contains('lyt-activated')) {
                         this.domRefFrame.classList.remove('lyt-activated');
                         this.shadowRoot.querySelector('iframe').remove();
+                        this.iframeLoaded = false;
                     }
                 }
                 break;


### PR DESCRIPTION
@mattdsteele 

I was having issues last night, but I recreated this from scratch with minor tweaks and things seem to be ok today.

Last night I saw it erroring out and committing all of `node_modules`, but I think the later was a problem with the actual workflow, and even after I fixed it pending PRs were still using the old workflow, so when they merged in they brought all those bogus commits with them.

So I _think_ this is what we want?  Let me know if this looks good to you.

Test commits: https://github.com/owncast/owncast/commits/gek/js-workflow