### PR TITLE
Stop rtmp from reaching back into core

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -11,6 +11,7 @@ import (
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/core/chat"
 	"github.com/owncast/owncast/core/ffmpeg"
+	"github.com/owncast/owncast/core/rtmp"
 	"github.com/owncast/owncast/models"
 	"github.com/owncast/owncast/utils"
 	"github.com/owncast/owncast/yp"
@@ -60,6 +61,9 @@ func Start() error {
 	}
 
 	chat.Setup(ChatListenerImpl{})
+
+	// start the rtmp server
+	go rtmp.Start(SetStreamAsConnected, SetBroadcaster)
 
 	return nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -63,7 +63,7 @@ func Start() error {
 	chat.Setup(ChatListenerImpl{})
 
 	// start the rtmp server
-	go rtmp.Start(SetStreamAsConnected, SetBroadcaster)
+	go rtmp.Start(setStreamAsConnected, setBroadcaster)
 
 	return nil
 }

--- a/core/rtmp/broadcaster.go
+++ b/core/rtmp/broadcaster.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/nareix/joy5/format/flv/flvio"
-	"github.com/owncast/owncast/core"
 	"github.com/owncast/owncast/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -31,5 +30,5 @@ func setCurrentBroadcasterInfo(t flvio.Tag, remoteAddr string) {
 		},
 	}
 
-	core.SetBroadcaster(broadcaster)
+	_setBroadcaster(broadcaster)
 }

--- a/core/status.go
+++ b/core/status.go
@@ -20,8 +20,8 @@ func GetStatus() models.Status {
 	}
 }
 
-// SetBroadcaster will store the current inbound broadcasting details
-func SetBroadcaster(broadcaster models.Broadcaster) {
+// setBroadcaster will store the current inbound broadcasting details
+func setBroadcaster(broadcaster models.Broadcaster) {
 	_broadcaster = &broadcaster
 }
 

--- a/core/streamState.go
+++ b/core/streamState.go
@@ -23,8 +23,8 @@ var _offlineCleanupTimer *time.Timer
 // While a stream takes place cleanup old HLS content every N min.
 var _onlineCleanupTicker *time.Ticker
 
-//SetStreamAsConnected sets the stream as connected
-func SetStreamAsConnected() {
+//setStreamAsConnected sets the stream as connected
+func setStreamAsConnected() {
 	_stats.StreamConnected = true
 	_stats.LastConnectTime = utils.NullTime{time.Now(), true}
 	_stats.LastDisconnectTime = utils.NullTime{time.Now(), false}
@@ -64,6 +64,7 @@ func SetStreamAsDisconnected() {
 
 	ffmpeg.StopThumbnailGenerator()
 	rtmp.Disconnect()
+
 	if _yp != nil {
 		_yp.Stop()
 	}

--- a/core/streamState.go
+++ b/core/streamState.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/core/ffmpeg"
+	"github.com/owncast/owncast/core/rtmp"
 	"github.com/owncast/owncast/utils"
 
 	"github.com/grafov/m3u8"
@@ -62,6 +63,7 @@ func SetStreamAsDisconnected() {
 	offlineFilePath := "static/" + offlineFilename
 
 	ffmpeg.StopThumbnailGenerator()
+	rtmp.Disconnect()
 	if _yp != nil {
 		_yp.Stop()
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -10,16 +10,12 @@ import (
 	"github.com/owncast/owncast/controllers"
 	"github.com/owncast/owncast/controllers/admin"
 	"github.com/owncast/owncast/core/chat"
-	"github.com/owncast/owncast/core/rtmp"
 	"github.com/owncast/owncast/router/middleware"
 	"github.com/owncast/owncast/yp"
 )
 
 //Start starts the router for the http, ws, and rtmp
 func Start() error {
-	// start the rtmp server
-	go rtmp.Start()
-
 	// static files
 	http.HandleFunc("/", controllers.IndexHandler)
 


### PR DESCRIPTION
This change addresses the issue where the `rtmp` package reaches back into `core`, therefore making it impossible, due to cyclical imports, to do things like reach into `rtmp` to fire `Disconnect` from core.

To work around this I'm doing the following:

* When starting `rtmp` pass along the two methods `rtmp` would need (`SetStreamAsConnected`, `SetBroadcaster`) as callbacks, so it can call them without reaching into `core`.
* `rtmp` keeps references to these functions and calls them just like it used to.

This is probably not the most Go'ish way of doing this, but admittedly I prefer it to packages randomly reaching into other packages and breaking the separations of concerns.  In this scenario now rtmp only has access what what is specifically passed to it as dependancies and nothing more.  And as a benefit these functions can be un-exported.

The core issue behind this one is #198, and this PR fixes that.

Let me know what you think.