### PR TITLE
[316] HLS playlist and segment desync monitor.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -25,7 +25,7 @@ var (
 	_broadcaster *models.Broadcaster
 )
 
-var handler ffmpeg.HLSHandler
+var handler *ffmpeg.HLSHandler = &ffmpeg.HLSHandler{}
 var fileWriter = ffmpeg.FileWriterReceiverService{}
 
 //Start starts up the core processing
@@ -45,9 +45,8 @@ func Start() error {
 	// The HLS handler takes the written HLS playlists and segments
 	// and makes storage decisions.  It's rather simple right now
 	// but will play more useful when recordings come into play.
-	handler = ffmpeg.HLSHandler{}
-	handler.Storage = _storage
-	fileWriter.SetupFileWriterReceiverService(&handler)
+	handler = ffmpeg.NewHLSHandler(_storage, config.Config.GetVideoSegmentSecondsLength())
+	fileWriter.SetupFileWriterReceiverService(handler)
 
 	if err := createInitialOfflineState(); err != nil {
 		log.Error("failed to create the initial offline state")

--- a/core/ffmpeg/hlsHandler.go
+++ b/core/ffmpeg/hlsHandler.go
@@ -1,22 +1,44 @@
 package ffmpeg
 
 import (
+	"context"
+	"path/filepath"
+	"time"
+
 	"github.com/owncast/owncast/models"
+	log "github.com/sirupsen/logrus"
 )
 
 // HLSHandler gets told about available HLS playlists and segments
 type HLSHandler struct {
 	Storage models.StorageProvider
+	Monitor *hlsVariantWriteMonitor
+}
+
+// NewHLSHandler returns an initialized HLSHandler with monitor running.
+func NewHLSHandler(storage models.StorageProvider, segmentLength int) *HLSHandler {
+	monitor := newHlsVariantWriteMonitor(
+		context.TODO(),
+		log.StandardLogger(),
+		time.Duration(segmentLength*3)*time.Second,
+	)
+
+	return &HLSHandler{
+		Storage: storage,
+		Monitor: monitor,
+	}
 }
 
 // SegmentWritten is fired when a HLS segment is written to disk
 func (h *HLSHandler) SegmentWritten(localFilePath string) {
 	h.Storage.SegmentWritten(localFilePath)
+	h.Monitor.SegmentWritten(filepath.Dir(localFilePath), time.Now())
 }
 
 // VariantPlaylistWritten is fired when a HLS variant playlist is written to disk
 func (h *HLSHandler) VariantPlaylistWritten(localFilePath string) {
 	h.Storage.VariantPlaylistWritten(localFilePath)
+	h.Monitor.VariantPlaylistWritten(filepath.Dir(localFilePath), time.Now())
 }
 
 // MasterPlaylistWritten is fired when a HLS master playlist is written to disk

--- a/core/ffmpeg/hlsVariantWriteMonitor.go
+++ b/core/ffmpeg/hlsVariantWriteMonitor.go
@@ -1,0 +1,95 @@
+package ffmpeg
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+type hlsVariantWriteMonitor struct {
+	playlistEvents chan hlsWriteEvent
+	segmentEvents  chan hlsWriteEvent
+	logger         *log.Logger
+}
+
+type hlsWriteEvent struct {
+	Dir  string
+	Time time.Time
+}
+
+func newHlsVariantWriteMonitor(ctx context.Context, logger *log.Logger, notificationThreshold time.Duration) *hlsVariantWriteMonitor {
+	h := &hlsVariantWriteMonitor{make(chan hlsWriteEvent), make(chan hlsWriteEvent), logger}
+	go h.run(ctx, notificationThreshold)
+	return h
+}
+
+func (h *hlsVariantWriteMonitor) SegmentWritten(dir string, when time.Time) {
+	select {
+	case h.segmentEvents <- hlsWriteEvent{dir, when}:
+	case <-time.After(50 * time.Millisecond):
+		h.logger.Errorf("unable to monitor segment write %q / %v", dir, when)
+	}
+}
+
+func (h *hlsVariantWriteMonitor) VariantPlaylistWritten(dir string, when time.Time) {
+	select {
+	case h.playlistEvents <- hlsWriteEvent{dir, when}:
+	case <-time.After(50 * time.Millisecond):
+		h.logger.Errorf("unable to monitor playlist write %q / %v", dir, when)
+	}
+}
+
+type hlsVariantWriteHistory struct {
+	lastSegmentWrite  time.Time
+	lastPlaylistWrite time.Time
+}
+
+// Run watches the handler traffic for lagging playlist writes
+func (h *hlsVariantWriteMonitor) run(ctx context.Context, notificationThreshold time.Duration) {
+	var (
+		event  hlsWriteEvent
+		drift  time.Duration
+		viable bool
+
+		variant  *hlsVariantWriteHistory
+		ok       bool
+		variants map[string]*hlsVariantWriteHistory = make(map[string]*hlsVariantWriteHistory)
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case event = <-h.playlistEvents:
+			variant, ok = variants[event.Dir]
+			if !ok {
+				variant = &hlsVariantWriteHistory{event.Time, event.Time}
+			} else {
+				variant.lastPlaylistWrite = event.Time
+			}
+			variants[event.Dir] = variant
+			drift = 0
+			viable = false
+			continue
+
+		case event = <-h.segmentEvents:
+			variant, ok = variants[event.Dir]
+			if !ok {
+				variant = &hlsVariantWriteHistory{event.Time, event.Time}
+				drift = 0
+			} else {
+				drift = event.Time.Sub(variant.lastPlaylistWrite)
+				viable = event.Time.Sub(variant.lastSegmentWrite) < notificationThreshold
+				variant.lastSegmentWrite = event.Time
+			}
+			variants[event.Dir] = variant
+
+		}
+
+		if drift >= notificationThreshold && viable {
+			h.logger.Warnf("HLS playlist at %q not updated with recent segments (%v drift)", event.Dir, drift)
+		}
+	}
+}

--- a/core/ffmpeg/hlsVariantWriteMonitor_test.go
+++ b/core/ffmpeg/hlsVariantWriteMonitor_test.go
@@ -1,0 +1,141 @@
+package ffmpeg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+// time.Sleep calls in this file are present to allow for synchronization
+// to reproduce effects consistently.
+
+func Test_hlsVariantWriteMonitor_playlistLagging(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	moment, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	monitor := newHlsVariantWriteMonitor(ctx, logger, time.Second*5)
+
+	monitor.VariantPlaylistWritten("hls/0", moment)
+	monitor.SegmentWritten("hls/0", moment)
+	monitor.SegmentWritten("hls/0", moment.Add(time.Second*4))
+	monitor.SegmentWritten("hls/0", moment.Add(time.Second*8))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if len(hook.Entries) != 1 {
+		t.Fatalf("wrong number of log entries\nexpected: 1\n  actual: %d", len(hook.Entries))
+	}
+
+	if hook.LastEntry().Level != logrus.WarnLevel {
+		t.Errorf("incorrect log error level output: %v", hook.LastEntry().Level)
+	}
+
+	expected := `HLS playlist at "hls/0" not updated with recent segments (8s drift)`
+	if hook.LastEntry().Message != expected {
+		t.Errorf("log message does not match\nexpected: %q\n  actual: %q", expected, hook.LastEntry().Message)
+	}
+}
+
+func Test_hlsVariantWriteMonitor_segmentDelay(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	moment, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	monitor := newHlsVariantWriteMonitor(ctx, logger, time.Second*5)
+
+	monitor.VariantPlaylistWritten("hls/0", moment)
+	monitor.SegmentWritten("hls/0", moment)
+	monitor.SegmentWritten("hls/0", moment.Add(time.Second*20))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if len(hook.Entries) != 0 {
+		t.Fatalf("wrong number of log entries\nexpected: 0\n  actual: %d", len(hook.Entries))
+	}
+}
+
+func Test_hlsVariantWriteMonitor_multiplePlaylists(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	moment, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	monitor := newHlsVariantWriteMonitor(ctx, logger, time.Second*5)
+
+	monitor.VariantPlaylistWritten("hls/0", moment)
+	monitor.SegmentWritten("hls/0", moment)
+	monitor.SegmentWritten("hls/0", moment.Add(time.Second*4))
+
+	monitor.VariantPlaylistWritten("hls/1", moment)
+	monitor.SegmentWritten("hls/1", moment)
+	monitor.SegmentWritten("hls/1", moment.Add(time.Second*4))
+	monitor.SegmentWritten("hls/1", moment.Add(time.Second*8))
+
+	time.Sleep(50 * time.Millisecond)
+
+	if len(hook.Entries) != 1 {
+		t.Fatalf("wrong number of log entries\nexpected: 1\n  actual: %d", len(hook.Entries))
+	}
+
+	if hook.LastEntry().Level != logrus.WarnLevel {
+		t.Errorf("incorrect log error level output: %v", hook.LastEntry().Level)
+	}
+
+	expected := `HLS playlist at "hls/1" not updated with recent segments (8s drift)`
+	if hook.LastEntry().Message != expected {
+		t.Errorf("log message does not match\nexpected: %q\n  actual: %q", expected, hook.LastEntry().Message)
+	}
+}
+
+func Test_hlsVariantWriteMonitor_writeTimeouts(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	moment, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	monitor := newHlsVariantWriteMonitor(ctx, logger, time.Second*5)
+	cancel() // stop the run loop
+	time.Sleep(50 * time.Millisecond)
+
+	monitor.VariantPlaylistWritten("hls/0", moment)
+	time.Sleep(25 * time.Millisecond)
+	monitor.SegmentWritten("hls/0", moment)
+	time.Sleep(100 * time.Millisecond)
+
+	if len(hook.Entries) != 2 {
+		t.Log(hook.Entries)
+		t.Fatalf("wrong number of log entries\nexpected: 2\n  actual: %d", len(hook.Entries))
+	}
+
+	expectedLogs := []struct {
+		Level   logrus.Level
+		Message string
+	}{
+		{
+			logrus.ErrorLevel,
+			`unable to monitor playlist write "hls/0" / 2000-01-01 00:00:00 +0000 UTC`,
+		},
+		{
+			logrus.ErrorLevel,
+			`unable to monitor segment write "hls/0" / 2000-01-01 00:00:00 +0000 UTC`,
+		},
+	}
+
+	for i, expected := range expectedLogs {
+		if hook.Entries[i].Level != expected.Level {
+			t.Errorf("incorrect log error level for entry %d\nexpected: %v\n  actual: %v", i, expected.Level, hook.Entries[i].Level)
+		}
+		if hook.Entries[i].Message != expected.Message {
+			t.Errorf("incorrect log message for entry %d\nexpected: %v\n  actual: %v", i, expected.Message, hook.Entries[i].Message)
+		}
+	}
+}


### PR DESCRIPTION
Uses the HLS handler to monitor for segment writes that do not update the playlist.

Closes #316 