### PR TITLE
Use 'os' instead of the deprecated 'platform' in build matrix

### DIFF
--- a/.github/workflows/buildmaster.yaml
+++ b/.github/workflows/buildmaster.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version: [~1.13, ^1]
-        platform: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.platform }}
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Install go


### PR DESCRIPTION
Should have caught that in the first PR, but just spotted it when you merged my previous one.