### PR TITLE
Add GoReleaser config and GitHub workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,26 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Deps
+        run: sudo apt-get update -qq && sudo apt-get install gcc-multilib libc6-dev-i386-cross
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --snapshot --skip-publish --skip-sign --rm-dist

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# GoReleaser Dist / Release
+dist/
+
 # Dependency directories (remove the comment below to include it)
 vendor/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,79 @@
+before:
+  hooks:
+    - go mod download
+builds:
+  - id: "owncast"
+    env:
+      - GO111MODULE=on
+      - CGO_ENABLED=1
+    binary: owncast
+    flags:
+      - -trimpath
+    ldflags: -s -w -X main.Version={{ .Version }} -X main.CommitSHA={{ .Commit }}
+    goos:
+      - linux
+      # - freebsd
+      # - openbsd
+      # - darwin
+      # - windows
+    goarch:
+      - amd64
+      # - arm64
+      - 386
+      # - arm
+    goarm:
+      - 6
+      - 7
+
+archives:
+  - id: default
+    builds:
+      - owncast
+    # format_overrides:
+    #  - goos: windows
+    #    format: zip
+    replacements:
+      # windows: Windows
+      # darwin: Darwin
+      386: i386
+      amd64: x86_64
+
+nfpms:
+  - builds:
+      - owncast
+    vendor: owncast
+    homepage: "https://owncast.online/"
+    maintainer: "Christian Muehlhaeuser <muesli@gmail.com>"
+    description: "Owncast streaming server"
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
+    bindir: /usr/bin
+
+brews:
+  - goarm: 6
+    tap:
+      owner: owncast
+      name: homebrew-tap
+    commit_author:
+      name: "Christian Muehlhaeuser"
+      email: "muesli@gmail.com"
+    homepage: "https://owncast.online/"
+    description: "Owncast streaming server"
+    # skip_upload: true
+
+signs:
+  - artifacts: checksum
+
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
This automatically builds new packages / binaries for:

- Linux (amd64 & x86)
- Debian packages (amd64 & x86)
- RPM packages (amd64 & x86)
- Alpine/APK packages (amd64 & x86)
- Brew formula

It also adds a GitHub workflow that automatically tries to build a new snapshot on push/PR, verifying that the current state of git would be releaseable.

You can try building a new snapshot release locally yourself, just run:

```bash
goreleaser release --snapshot --rm-dist --skip-publish
```

To do a proper release, you would typically first tag the release, then run GoReleaser like this:

```bash
git tag -a -s -m "v1.2.3" "v1.2.3"
goreleaser release --rm-dist
```

This will publish the tag on git, build all the packages / binaries, generate a ChangeLog, and eventually create a new GitHub release that all those assets get uploaded to.