### PR TITLE
Handle filepath.Walk errors

### DIFF
--- a/core/ffmpeg/hlsFilesystemCleanup.go
+++ b/core/ffmpeg/hlsFilesystemCleanup.go
@@ -46,9 +46,8 @@ func getAllFilesRecursive(baseDirectory string) (map[string][]os.FileInfo, error
 	var files = make(map[string][]os.FileInfo)
 
 	var directory string
-	filepath.Walk(baseDirectory, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(baseDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			log.Fatalf(err.Error())
 			return err
 		}
 
@@ -62,6 +61,11 @@ func getAllFilesRecursive(baseDirectory string) (map[string][]os.FileInfo, error
 
 		return nil
 	})
+
+	if err != nil {
+		log.Fatalf(err.Error())
+		return nil, err
+	}
 
 	// Sort by date so we can delete old files
 	for directory := range files {


### PR DESCRIPTION
It's probably a good idea to handle all errors returned from `filepath.Walk` in one place and to bubble up any errors we're encountering inside the `Walk`.