### PR TITLE
Explicitly ignore io.Copy's return values

### DIFF
--- a/core/ffmpeg/fileWriterReceiverService.go
+++ b/core/ffmpeg/fileWriterReceiverService.go
@@ -55,8 +55,9 @@ func (s *FileWriterReceiverService) uploadHandler(w http.ResponseWriter, r *http
 	writePath := filepath.Join(config.PrivateHLSStoragePath, path)
 
 	var buf bytes.Buffer
-	io.Copy(&buf, r.Body)
+	_, _ = io.Copy(&buf, r.Body)
 	data := buf.Bytes()
+
 	f, err := os.Create(writePath)
 	if err != nil {
 		returnError(err, w, r)


### PR DESCRIPTION
We're probably ignoring any errors here, since we're writing to a memory
buffer here. Let's make it clear we didn't just forget to check, but
really want to ignore these values.