### PR TITLE
Use a multistage Docker build to slim down the image a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
-FROM golang:alpine
-EXPOSE 8080 1935
-RUN mkdir /app 
-ADD . /app
+# Builder
+FROM golang:alpine AS builder
+
+RUN apk update && \
+    apk add --no-cache gcc build-base linux-headers
+
 WORKDIR /app
-RUN apk add --no-cache ffmpeg ffmpeg-libs
-RUN apk update && apk add --no-cache gcc build-base linux-headers
+COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owncast .
+
+# Actual image
+FROM alpine
+
+RUN apk update && \
+    apk add --no-cache ffmpeg ffmpeg-libs
+
+COPY --from=builder /app /app
+
+EXPOSE 8080 1935
 WORKDIR /app
-CMD ["/app/owncast"]
+ENTRYPOINT /app/owncast


### PR DESCRIPTION
This uses a separate stage for building, so we don't drag in gcc, build-base, and linux-headers into the final Owncast image.