### PR TITLE
Check if inbound details properly set before use

### DIFF
--- a/core/rtmp/broadcaster.go
+++ b/core/rtmp/broadcaster.go
@@ -15,11 +15,6 @@ func setCurrentBroadcasterInfo(t flvio.Tag, remoteAddr string) {
 		return
 	}
 
-	if data.VideoCodec == nil {
-		log.Traceln("Broadcaster flag does not include video codec, ignoring")
-		return
-	}
-
 	broadcaster := models.Broadcaster{
 		RemoteAddr: remoteAddr,
 		Time:       time.Now(),

--- a/core/rtmp/broadcaster.go
+++ b/core/rtmp/broadcaster.go
@@ -15,6 +15,11 @@ func setCurrentBroadcasterInfo(t flvio.Tag, remoteAddr string) {
 		return
 	}
 
+	if data.VideoCodec == nil {
+		log.Traceln("Broadcaster flag does not include video codec, ignoring")
+		return
+	}
+
 	broadcaster := models.Broadcaster{
 		RemoteAddr: remoteAddr,
 		Time:       time.Now(),

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/nareix/joy5/format/flv/flvio"
 	"github.com/owncast/owncast/models"
@@ -12,6 +13,9 @@ import (
 
 func getInboundDetailsFromMetadata(metadata []interface{}) (models.RTMPStreamMetadata, error) {
 	metadataComponentsString := fmt.Sprintf("%+v", metadata)
+	if !strings.Contains(metadataComponentsString, "@setDataFrame") {
+		return models.RTMPStreamMetadata{}, errors.New("Not a setDataFrame message")
+	}
 	re := regexp.MustCompile(`\{(.*?)\}`)
 	submatchall := re.FindAllString(metadataComponentsString, 1)
 


### PR DESCRIPTION
This validates a critical value is parsed from the metadata packet before trying to set broadcaster details.

I was hoping to identify badly formatted messages in `rtmp.go` but wasn't able to find a means to make it happen. I'd like to take one more run at it before merging this in.

In any case, this change does enable my Mevo device to connect and broadcast; albeit after 8,456 junk data packets :no_mouth: 

Fixes #340