### PR TITLE
optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM golang:alpine
 EXPOSE 8080 1935
-RUN mkdir /app 
-ADD . /app
 WORKDIR /app
-RUN apk add --no-cache ffmpeg ffmpeg-libs
-RUN apk update && apk add --no-cache gcc build-base linux-headers
-RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owncast .
-WORKDIR /app
+ADD . .
+RUN set -ex && \
+    apk add --no-cache ffmpeg ffmpeg-libs && \
+    apk add --no-cache gcc build-base linux-headers && \ 
+    CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owncast .
 CMD ["/app/owncast"]


### PR DESCRIPTION
Hi all:

I modified the Dockerfile a bit to make it more consistent

1.   as the [docker documentation](https://docs.docker.com/engine/reference/builder/#workdir) says: If the WORKDIR doesn’t exist, it will be created, so there is no need to use `RUN mkdir /app`

2.  `apk update`  is useless since we have already added  **--no-cache**  in  `apk add --no-cache gcc build-base linux-headers` , if keep `apk update` it just make image size bigger, to prove this, I do it on a alpine container 

just run `apk add --no-cache gcc build-base linux-headers` 
```sh
/ # apk add --no-cache gcc build-base linux-headers
fetch http://mirrors.tools.huawei.com/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://mirrors.tools.huawei.com/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
OK: 269 MiB in 82 packages
/ # ls -al /var/cache/apk/
total 12
drwxr-xr-x    2 root     root          4096 Oct 21 09:23 .
drwxr-xr-x    1 root     root          4096 Dec  3 02:13 ..
```
run `apk update && apk add --no-cache gcc build-base linux-headers`
```sh
/ # apk update && apk add --no-cache gcc build-base linux-headers
fetch http://mirrors.tools.huawei.com/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://mirrors.tools.huawei.com/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
v3.12.0-429-gb9df8c9616 [http://mirrors.tools.huawei.com/alpine/v3.12/main]
v3.12.0-430-gc0f4e9959c [http://mirrors.tools.huawei.com/alpine/v3.12/community]
OK: 12744 distinct packages available
fetch http://mirrors.tools.huawei.com/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://mirrors.tools.huawei.com/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
OK: 269 MiB in 82 packages
/ # ls -al /var/cache/apk/
total 1752
drwxr-xr-x    1 root     root          4096 Dec  3 02:15 .
drwxr-xr-x    1 root     root          4096 Dec  3 02:13 ..
-rw-r--r--    1 root     root       1145321 Dec  3 02:15 APKINDEX.18b70b67.tar.gz
-rw-r--r--    1 root     root        634615 Dec  3 02:15 APKINDEX.99eadc54.tar.gz
```
it produce index files , **we don't need this in our image**

and we can save 2MB  disk sapce
```
docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
owncast/owncast     v0.2                c7e1b722a174        42 minutes ago      973MB
owncast/owncast     v0.1                e917e7dae6b9        About an hour ago   975MB
```

3. we can [Minimize the number of layers](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers) by merge some command with &&

4. to test it works or not, I packed a config.json into image, `docker build -t owncast/owncast:v0.2 .` 
and then run `docker container run --rm -p 8082:8080 -p 1937:1935 -v d:\\config.yaml:/config.yaml owncast/owncast:v0.2`
the output it produces is
```sh
time="2020-12-03T02:36:02Z" level=info msg="Owncast v0.0.0-localdev (unknown)"
time="2020-12-03T02:36:03Z" level=info msg="Web server is listening on port 8080, RTMP is accepting inbound streams on port 1935."
time="2020-12-03T02:36:03Z" level=info msg="The web admin interface is available at /admin."
```
and go to http://localhost:8082/ , it works!



































