### PR TITLE
Websocket fixes

### DIFF
--- a/metrics/hardware.go
+++ b/metrics/hardware.go
@@ -6,6 +6,8 @@ import (
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Max number of metrics we want to keep.
@@ -18,7 +20,8 @@ func collectCPUUtilization() {
 
 	v, err := cpu.Percent(0, false)
 	if err != nil {
-		panic(err)
+		log.Errorln(err)
+		return
 	}
 
 	metricValue := timestampedValue{time.Now(), int(v[0])}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Owncast
   description: Owncast is a self-hosted live video and web chat server for use with existing popular broadcasting software.  The following APIs represent the state in the development master branch.
-  version: '0.0.3'
+  version: '0.0.4-development'
   contact:
     name: Gabe Kangas
     email: gabek@real-ity.com

--- a/test/websocketTest.yaml
+++ b/test/websocketTest.yaml
@@ -7,8 +7,8 @@ config:
     maxErrorRate: 1
 
   phases:
-    - duration: 30
-      arrivalRate: 10
+    - duration: 100
+      arrivalRate: 15
   ws:
     subprotocols:
       - json
@@ -21,4 +21,4 @@ scenarios:
     flow:
     - function: "createTestMessageObject"
     - send: "{{ data }}"
-    - think: 5
+    - think: 10


### PR DESCRIPTION
1. Centralize client disconnect logic.
2. Fire client disconnect on client errors.
3. Fix possible concurrent read crash reading from `clients`.
4. Update websocket load test to be more aggressive. 