### PR TITLE
Add webfinger

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -1,5 +1,9 @@
 # See https://owncast.online/docs/configuration/ for more details
 
+federation:
+  site: https://stream.myserver.org
+  username: owncast
+
 instanceDetails:
   name: Owncast
   title: Owncast

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -2,33 +2,37 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
+	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/models"
 )
 
 type j map[string]interface{}
 
-func internalErrorHandler(w http.ResponseWriter, err error) {
+func errorResponseHandler(statusCode int, w http.ResponseWriter, err error) {
 	if err == nil {
 		return
 	}
 
-	w.WriteHeader(http.StatusInternalServerError)
+	w.WriteHeader(statusCode)
+
 	if err := json.NewEncoder(w).Encode(j{"error": err.Error()}); err != nil {
 		internalErrorHandler(w, err)
 	}
 }
 
-func badRequestHandler(w http.ResponseWriter, err error) {
-	if err == nil {
-		return
-	}
+func internalErrorHandler(w http.ResponseWriter, err error) {
+	errorResponseHandler(http.StatusInternalServerError, w, err)
+}
 
-	w.WriteHeader(http.StatusBadRequest)
-	if err := json.NewEncoder(w).Encode(j{"error": err.Error()}); err != nil {
-		internalErrorHandler(w, err)
-	}
+func badRequestHandler(w http.ResponseWriter, err error) {
+	errorResponseHandler(http.StatusBadRequest, w, err)
+}
+
+func notFoundHandler(w http.ResponseWriter, err error) {
+	errorResponseHandler(http.StatusNotFound, w, err)
 }
 
 func WriteSimpleResponse(w http.ResponseWriter, success bool, message string) {
@@ -40,4 +44,8 @@ func WriteSimpleResponse(w http.ResponseWriter, success bool, message string) {
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		internalErrorHandler(w, err)
 	}
+}
+
+func urlFor(path string) string {
+	return fmt.Sprintf("%s%s", config.Config.Federation.Site, path)
 }

--- a/controllers/federation.go
+++ b/controllers/federation.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/owncast/owncast/config"
+	"github.com/owncast/owncast/models"
+)
+
+var (
+	asContext = []string{"https://www.w3.org/ns/activitystreams", "https://w3id.org/security/v1"}
+)
+
+func GetActor(w http.ResponseWriter, r *http.Request) {
+	actor := models.Actor{
+		Context:           asContext,
+		Id:                urlFor("/actor"),
+		Type:              "Person",
+		PreferredUsername: config.Config.Federation.Username,
+		Name:              config.Config.InstanceDetails.Name,
+		Summary:           config.Config.InstanceDetails.Summary,
+		URL:               urlFor("/"),
+		Inbox:             urlFor("/inbox"),
+		Outbox:            urlFor("/outbox"),
+		Following:         urlFor("/following"),
+		Followers:         urlFor("/followers"),
+	}
+
+	if err := json.NewEncoder(w).Encode(actor); err != nil {
+		internalErrorHandler(w, err)
+	}
+}

--- a/controllers/webfinger.go
+++ b/controllers/webfinger.go
@@ -1,0 +1,50 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/owncast/owncast/config"
+	"github.com/owncast/owncast/models"
+)
+
+func GetWebfinger(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/jrd+json")
+
+	resource := r.URL.Query().Get("resource")
+
+	if resource == "" {
+		badRequestHandler(w, errors.New("Required parameter `resource` not supplied"))
+		return
+	}
+
+	subject, err := config.Config.Federation.GetSubject()
+
+	if err != nil {
+		internalErrorHandler(w, err)
+		return
+	}
+
+	if resource != subject {
+		notFoundHandler(w, errors.New("Unrecognized resource requested"))
+		return
+	}
+
+	links := []models.WebfingerLink{
+		{
+			Rel:  "self",
+			Type: "application/activity+json",
+			Href: urlFor("/actor"),
+		},
+	}
+
+	webfinger := models.Webfinger{
+		Subject: subject,
+		Links:   links,
+	}
+
+	if err := json.NewEncoder(w).Encode(webfinger); err != nil {
+		internalErrorHandler(w, err)
+	}
+}

--- a/models/actor.go
+++ b/models/actor.go
@@ -1,0 +1,22 @@
+package models
+
+type Actor struct {
+	Context           []string  `json:"@context"`
+	Id                string    `json:"id"`
+	Type              string    `json:"type"`
+	PreferredUsername string    `json:"preferredUsername"`
+	Name              string    `json:"name"`
+	Summary           string    `json:"summary"`
+	URL               string    `json:"url"`
+	Inbox             string    `json:"inbox"`
+	Outbox            string    `json:"outbox"`
+	Following         string    `json:"following"`
+	Followers         string    `json:"followers"`
+	PublicKey         PublicKey `json:"publicKey"`
+}
+
+type PublicKey struct {
+	Id           string `json:"id"`
+	Owner        string `json:"owner"`
+	PublicKeyPem string `json:"publicKeyPem"`
+}

--- a/models/webfinger.go
+++ b/models/webfinger.go
@@ -1,0 +1,12 @@
+package models
+
+type Webfinger struct {
+	Subject string          `json:"subject"`
+	Links   []WebfingerLink `json:"links"`
+}
+
+type WebfingerLink struct {
+	Rel  string `json:"rel"`
+	Type string `json:"type"`
+	Href string `json:"href"`
+}

--- a/router/router.go
+++ b/router/router.go
@@ -22,6 +22,9 @@ func Start() error {
 	// admin static files
 	http.HandleFunc("/admin/", middleware.RequireAdminAuth(admin.ServeAdmin))
 
+	// webfinger
+	http.HandleFunc("/.well-known/webfinger", controllers.GetWebfinger)
+
 	// status of the system
 	http.HandleFunc("/api/status", controllers.GetStatus)
 

--- a/router/router.go
+++ b/router/router.go
@@ -22,8 +22,9 @@ func Start() error {
 	// admin static files
 	http.HandleFunc("/admin/", middleware.RequireAdminAuth(admin.ServeAdmin))
 
-	// webfinger
+	// federation
 	http.HandleFunc("/.well-known/webfinger", controllers.GetWebfinger)
+	http.HandleFunc("/actor", controllers.GetActor)
 
 	// status of the system
 	http.HandleFunc("/api/status", controllers.GetStatus)


### PR DESCRIPTION
Part of #458 :warning: **Work in progress**

Adds a webfinger endpoint along with some new required configuration:

```yaml
federation:
  site: https://stream.myserver.org
  username: owncast
```

The webfinger endpoint responds only to queries for this pre-configured actor. It uses the site to generate URLs.