### PR TITLE
Auto play when stream is live

### DIFF
--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -85,7 +85,11 @@ class OwncastPlayer {
 
     this.vjsPlayer.volume(getLocalStorage(PLAYER_VOLUME) || 1);
     this.vjsPlayer.src(source);
-    // this.vjsPlayer.play();
+    this.vjsPlayer.play().catch(() => {
+      // Autoplay was prevented. Start playback without sound.
+      this.vjsPlayer.muted(true);
+      this.vjsPlayer.play();
+    });
   }
 
   handleReady() {


### PR DESCRIPTION
Currently video is not autoplaying when stream is live. This is workaround to play the video without sound. User must unmute by herself. 