### PR TITLE
Manually bust m3u8 caches

### DIFF
--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -57,13 +57,15 @@ class OwncastPlayer {
   }
 
   init() {
-    this.vjsPlayer = videojs(VIDEO_ID, VIDEO_OPTIONS);
-
-    this.vjsPlayer.beforeRequest = function (options) {
-      const cachebuster = Math.round(new Date().getTime() / 1000);
-      options.uri = `${options.uri}?cachebust=${cachebuster}`;
+    videojs.Vhs.xhr.beforeRequest = options => {
+      if (options.uri.match('m3u8')) {
+        const cachebuster = Math.round(new Date().getTime() / 1000);
+        options.uri = `${options.uri}?cachebust=${cachebuster}`;
+      }
       return options;
     };
+
+    this.vjsPlayer = videojs(VIDEO_ID, VIDEO_OPTIONS);
 
     this.addAirplay();
     this.vjsPlayer.ready(this.handleReady);


### PR DESCRIPTION
This reimplements the `beforeRequest` videojs hook to add query params to make each playlist request unique. I'm not sure when it stopped working, but the API appears to have changed [with this commit](https://github.com/videojs/http-streaming/commit/22af0b29e56e8a25d55737b0148da0ab5e4d461b).

This fixes #567 and lets us avoid taking more specific implementations to cache-bust on various CDNs.