### PR TITLE
optimize docker build and image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.vscode
+
+config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
-FROM golang:alpine
+# BUILD STEP
+
+FROM golang:alpine as build
+
+RUN set -ex && apk add --no-cache gcc build-base linux-headers
+
+RUN mkdir /build
+WORKDIR /build
+
+COPY go.mod /build
+COPY go.sum /build
+RUN CGO_ENABLED=1 GOOS=linux go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-s -w -extldflags "-static"' -o owncast .
+
+# COMMAND STEP
+
+FROM alpine:latest as final
 EXPOSE 8080 1935
+
+RUN set -ex && apk add --no-cache ffmpeg ffmpeg-libs
+	
+RUN mkdir /app
 WORKDIR /app
-ADD . .
-RUN set -ex && \
-    apk add --no-cache ffmpeg ffmpeg-libs && \
-    apk add --no-cache gcc build-base linux-headers && \ 
-    CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owncast .
+COPY --from=build /build/owncast ./owncast
+COPY . .
+
 CMD ["/app/owncast"]


### PR DESCRIPTION
Makes use of multistage docker builds and caching of go modules to improve image build times.

This forces to volume mount a `config.yaml` manually though.

```sh
# Build it
docker build -t owncast .
# Run it
docker run -p 8080:8080 -p 1935:1935 -it -v ${pwd}/config.yaml:/app/config.yaml owncast
```

This results in a 100 MB image size currently.
Can probably be optimized even further, but that would be out of scope for this PR currently.

We can improve this further by separating the go source from the required static assets / explicitly listing the COPY directories/files