### PR TITLE
Make websocket and stream use constants

### DIFF
--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -3,10 +3,9 @@
 import videojs from '/js/web_modules/videojs/core.js';
 import '/js/web_modules/@videojs/http-streaming/dist/videojs-http-streaming.min.js';
 import { getLocalStorage, setLocalStorage } from '../utils/helpers.js';
-import { PLAYER_VOLUME } from '../utils/constants.js';
+import { PLAYER_VOLUME, URL_STREAM } from '../utils/constants.js';
 
 const VIDEO_ID = 'video';
-const URL_STREAM = `/hls/stream.m3u8`;
 
 // Video setup
 const VIDEO_SRC = {

--- a/webroot/js/utils/websocket.js
+++ b/webroot/js/utils/websocket.js
@@ -1,3 +1,4 @@
+import { URL_WEBSOCKET } from './constants.js';
 /**
  * These are the types of messages that we can handle with the websocket.
  * Mostly used by `websocket.js` but if other components need to handle
@@ -17,7 +18,6 @@ export const CALLBACKS = {
   WEBSOCKET_DISCONNECTED: 'websocketDisconnected',
 }
 
-const URL_WEBSOCKET = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/entry`;
 const TIMER_WEBSOCKET_RECONNECT = 5000; // ms
 
 export default class Websocket {


### PR DESCRIPTION
Played around with tossing the frontend in a CDN to see what would happen.  

Found two variables not utilizing utils/contants.js