### PR TITLE
align the chat-views position to the bottom of the page to overcome view-height bugs

### DIFF
--- a/webroot/styles/chat.css
+++ b/webroot/styles/chat.css
@@ -3,7 +3,7 @@
 #chat-container {
   position: fixed;
   z-index: 9;
-  top: var(--header-height);
+  bottom: 0;
   right: 0;
   width: var(--right-col-width);
 

--- a/webroot/styles/chat.css
+++ b/webroot/styles/chat.css
@@ -10,6 +10,12 @@
   height: calc(100vh - var(--header-height));
 }
 
+@media screen and (max-width: 729px) {
+  #chat-container {
+    top: var(--header-height);
+  }
+}
+
 #message-input-container {
   width: var(--right-col-width);
 }


### PR DESCRIPTION
This is a possible fix for the problem described in #572. Since `vh` problems seem to be common in Safari on mobile devices, aligning the chat-views position to the bottom is a possible solution which seems to work on other devices too.