### PR TITLE
example with TLS wrapper (RTMPS) and traefik

### DIFF
--- a/examples/docker-compose.tls-rtmp.yaml
+++ b/examples/docker-compose.tls-rtmp.yaml
@@ -10,20 +10,26 @@ services:
     command: /app/owncast -configFile=config.yaml -database=/db/chat.db
     ports:
     - 8080:8080
-    - 1935:1935
     labels:
       - "traefik.enable=false"
       - "traefik.http.routers.owncast.rule=Host(`live.your.org`)"
       - "traefik.http.routers.owncast.entrypoints=web,websecure"
       - "traefik.http.routers.owncast.tls.certresolver=mytlschallenge"
+      - "traefik.tcp.routers.rtmpcast.entrypoints=rtmp"
+      - "traefik.tcp.routers.rtmpcast.rule=HostSNI(`live.your.org`)"
+      - "traefik.tcp.routers.rtmpcast.service=rtmpcast"
+      - "traefik.tcp.routers.rtmpcast.tls=true"
+      - "traefik.tcp.routers.rtmpcast.tls.certresolver=mytlschallenge"
+      - "traefik.tcp.services.rtmpcast.loadbalancer.server.port=1935"
   traefik:
     image: traefik:latest
     restart: unless-stopped
-    command: 
+    command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
+      - --entrypoints.rtmp.address=:1935
       - --certificatesresolvers.mytlschallenge.acme.tlschallenge=true
       # CHANGE THE ADDRESS BELOW TO YOUR ADDRESS
       - --certificatesresolvers.mytlschallenge.acme.email=postmaster@mydomain.com
@@ -36,7 +42,8 @@ services:
     ports:
     - 80:80
     - 443:443
-    
+    - 1935:1935
+
 volumes:
   owncast_db:
   traefik_certs:

--- a/examples/docker-compose.with-minio.yaml
+++ b/examples/docker-compose.with-minio.yaml
@@ -1,0 +1,80 @@
+version: '3.1'
+
+services:
+  owncast:
+    image: gabekangas/owncast:latest
+    restart: unless-stopped
+    volumes:
+      - ${PWD}/config-example.yaml:/app/config.yaml # Adjust once you create your own config.yaml
+      - owncast_db:/db # Remove if you don't want chat persistant
+    command: /app/owncast -configFile=config.yaml -database=/db/chat.db
+    ports:
+    - 8080:8080
+    labels:
+      - "traefik.enable=false"
+      - "traefik.http.routers.owncast.rule=Host(`live.your.org`)"
+      - "traefik.http.routers.owncast.entrypoints=web,websecure"
+      - "traefik.http.routers.owncast.tls.certresolver=mytlschallenge"
+      - "traefik.tcp.routers.rtmpcast.entrypoints=rtmp"
+      - "traefik.tcp.routers.rtmpcast.rule=HostSNI(`live.your.org`)"
+      - "traefik.tcp.routers.rtmpcast.service=rtmpcast"
+      - "traefik.tcp.routers.rtmpcast.tls=true"
+      - "traefik.tcp.routers.rtmpcast.tls.certresolver=mytlschallenge"
+      - "traefik.tcp.services.rtmpcast.loadbalancer.server.port=1935"
+  traefik:
+    image: traefik:latest
+    restart: unless-stopped
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.rtmp.address=:1935
+      - --certificatesresolvers.mytlschallenge.acme.tlschallenge=true
+      # CHANGE THE ADDRESS BELOW TO YOUR ADDRESS
+      - --certificatesresolvers.mytlschallenge.acme.email=postmaster@mydomain.com
+      # COMMENT OUT THE LINE BELOW TO GET LIVE CERT
+      - --certificatesresolvers.mytlschallenge.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
+      - --certificatesresolvers.mytlschallenge.acme.storage=/letsencrypt/acme.json
+    volumes:
+      - traefik_certs:/letsencrypt/
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+    - 80:80
+    - 443:443
+    - 1935:1935
+   
+  # optionally serving your chunks yourself.
+  minio:
+    image: minio/minio
+    volumes:
+      - minio_data:/data
+    secrets:
+      - access_key
+      - secret_key
+    environment:
+      - MINIO_ACCESS_KEY_FILE=access_key
+      - MINIO_SECRET_KEY_FILE=secret_key
+    command: server /data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.minio.rule=Host(`s3-storage.your.org`)"
+      - "traefik.http.routers.minio.service=minio"
+      - "traefik.http.services.minio.loadbalancer.server.port=9000"
+      - "traefik.http.routers.minio.entryPoints=websecure"
+      - "traefik.http.routers.minio.tls=true"
+      - "traefik.http.routers.minio.middlewares=livecors"
+      - "traefik.http.routers.minio.tls.certresolver=mytlschallenge"
+      - "traefik.http.middlewares.livecors.headers.accesscontrolallowmethods=GET,OPTIONS"
+      - "traefik.http.middlewares.livecors.headers.allowedhosts=https://s3-storage.your.org"
+
+volumes:
+  owncast_db:
+  traefik_certs:
+  minio_data:
+
+secrets:
+  secret_key:
+    file: minio_secret.key
+  access_key:
+    file: minio_access.key

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -10,20 +10,26 @@ services:
     command: /app/owncast -configFile=config.yaml -database=/db/chat.db
     ports:
     - 8080:8080
-    - 1935:1935
     labels:
       - "traefik.enable=false"
       - "traefik.http.routers.owncast.rule=Host(`live.your.org`)"
       - "traefik.http.routers.owncast.entrypoints=web,websecure"
       - "traefik.http.routers.owncast.tls.certresolver=mytlschallenge"
+      - "traefik.tcp.routers.rtmpcast.entrypoints=rtmp"
+      - "traefik.tcp.routers.rtmpcast.rule=HostSNI(`live.your.org`)"
+      - "traefik.tcp.routers.rtmpcast.service=rtmpcast"
+      - "traefik.tcp.routers.rtmpcast.tls=true"
+      - "traefik.tcp.routers.rtmpcast.tls.certresolver=mytlschallenge"
+      - "traefik.tcp.services.rtmpcast.loadbalancer.server.port=1935"
   traefik:
     image: traefik:latest
     restart: unless-stopped
-    command: 
+    command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
+      - --entrypoints.rtmp.address=:1935
       - --certificatesresolvers.mytlschallenge.acme.tlschallenge=true
       # CHANGE THE ADDRESS BELOW TO YOUR ADDRESS
       - --certificatesresolvers.mytlschallenge.acme.email=postmaster@mydomain.com
@@ -36,8 +42,9 @@ services:
     ports:
     - 80:80
     - 443:443
-    
+    - 1935:1935
+
 volumes:
   owncast_db:
   traefik_certs:
-  
+

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -44,7 +44,37 @@ services:
     - 443:443
     - 1935:1935
 
+  # optionally serving your chunks yourself.
+  minio:
+    image: minio/minio
+    volumes:
+      - minio_data:/data
+    secrets:
+      - access_key
+      - secret_key
+    environment:
+      - MINIO_ACCESS_KEY_FILE=access_key
+      - MINIO_SECRET_KEY_FILE=secret_key
+    command: server /data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.minio.rule=Host(`s3-storage.your.org`)"
+      - "traefik.http.routers.minio.service=minio"
+      - "traefik.http.services.minio.loadbalancer.server.port=9000"
+      - "traefik.http.routers.minio.entryPoints=websecure"
+      - "traefik.http.routers.minio.tls=true"
+      - "traefik.http.routers.minio.middlewares=livecors"
+      - "traefik.http.routers.minio.tls.certresolver=mytlschallenge"
+      - "traefik.http.middlewares.livecors.headers.accesscontrolallowmethods=GET,OPTIONS"
+      - "traefik.http.middlewares.livecors.headers.allowedhosts=https://s3-storage.your.org"
+
 volumes:
   owncast_db:
   traefik_certs:
+  minio_data:
 
+secrets:
+  secret_key:
+    file: minio_secret.key
+  access_key:
+    file: minio_access.key


### PR DESCRIPTION
While the example captures the setup where the website and outgoing stream is secured, it is also important to secure the incoming RTMP stream with a TLS wrapper.
Traefik is able to wrap bare TCP streams and this pull request demonstrates an example configuration. 