### PR TITLE
emoji picker updates #612

### DIFF
--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -68,12 +68,19 @@ export default class ChatInput extends Component {
           custom: json,
           initialCategory: 'custom',
           showPreview: false,
+          autoHide: false,
+          autoFocusSearch: false,
+          showAnimation: false,
           emojiSize: '24px',
           position: 'right-start',
           strategy: 'absolute',
         });
         this.emojiPicker.on('emoji', emoji => {
           this.handleEmojiSelected(emoji);
+        });
+        this.emojiPicker.on('hidden', () => {
+          this.formMessageInput.current.focus();
+          replaceCaret(this.formMessageInput.current);
         });
       })
       .catch(error => {

--- a/webroot/styles/chat.css
+++ b/webroot/styles/chat.css
@@ -75,6 +75,9 @@
 
 /******************************/
 /* EMOJI PICKER OVERRIDES */
+.emoji-picker__wrapper {
+  margin-top: -30px !important;
+}
 .emoji-picker.owncast {
   --secondary-text-color: rgba(255, 255, 255, 0.5);
   --category-button-color: rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
- don't close picker after selecting emoji,  so we can pick multiple emojis in a row 
- move up picker div to see emojis inputted into textfield
- restore focus into textfield after picker closes