### PR TITLE
Use a dynamic system port for internal HLS writes. Closes #577

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,3 +17,5 @@ var WebServerPortOverride = 8080
 var RTMPServerPortOverride = 1935
 
 var HighestQualityStreamIndex = 0
+
+var InternalHLSListenerPort = "8927"

--- a/core/ffmpeg/fileWriterReceiverService.go
+++ b/core/ffmpeg/fileWriterReceiverService.go
@@ -47,10 +47,9 @@ func (s *FileWriterReceiverService) SetupFileWriterReceiverService(callbacks Fil
 		log.Traceln("Transcoder response service listening on: " + listenerPort)
 
 		if err := http.Serve(listener, httpServer); err != nil {
-			panic(err)
+			log.Fatalln("Unable to start internal video writing service", err)
 		}
 	}()
-
 }
 
 func (s *FileWriterReceiverService) uploadHandler(w http.ResponseWriter, r *http.Request) {

--- a/core/ffmpeg/transcoder.go
+++ b/core/ffmpeg/transcoder.go
@@ -28,7 +28,7 @@ type Transcoder struct {
 	appendToStream       bool
 	ffmpegPath           string
 	segmentIdentifier    string
-	internalListenerPort int
+	internalListenerPort string
 	videoOnly            bool // If true ignore any audio, if any
 	TranscoderCompleted  func(error)
 }
@@ -105,8 +105,8 @@ func (t *Transcoder) Start() {
 }
 
 func (t *Transcoder) getString() string {
-	var port = data.GetHTTPPortNumber() + 1
-	localListenerAddress := "http://127.0.0.1:" + strconv.Itoa(port)
+	var port = t.internalListenerPort
+	localListenerAddress := "http://127.0.0.1:" + port
 
 	hlsOptionFlags := []string{}
 
@@ -199,6 +199,7 @@ func NewTranscoder() *Transcoder {
 	transcoder := new(Transcoder)
 	transcoder.ffmpegPath = data.GetFfMpegPath()
 	transcoder.hlsPlaylistLength = int(data.GetVideoSegmentsInPlaylist())
+	transcoder.internalListenerPort = config.InternalHLSListenerPort
 
 	var outputPath string
 	if data.GetS3Config().Enabled {
@@ -388,7 +389,7 @@ func (t *Transcoder) SetIdentifier(output string) {
 	t.segmentIdentifier = output
 }
 
-func (t *Transcoder) SetInternalHTTPPort(port int) {
+func (t *Transcoder) SetInternalHTTPPort(port string) {
 	t.internalListenerPort = port
 }
 

--- a/core/ffmpeg/transcoder_test.go
+++ b/core/ffmpeg/transcoder_test.go
@@ -12,7 +12,7 @@ func TestFFmpegCommand(t *testing.T) {
 	transcoder.SetOutputPath("fakeOutput")
 	transcoder.SetHLSPlaylistLength(10)
 	transcoder.SetIdentifier("jdofFGg")
-	transcoder.SetInternalHTTPPort(8123)
+	transcoder.SetInternalHTTPPort("8123")
 
 	variant := HLSVariant{}
 	variant.videoBitrate = 1200


### PR DESCRIPTION
Small extra hoop needs to be jumped through, you have to create a separate tcp listener and then create the web server with it in order to gain access to the port, but it works.

Ignore the test failure, that's due to the WIP datastore branch this is being merged into.