### PR TITLE
Add support for running frontend on URL paths other than root

### DIFF
--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -15,7 +15,7 @@ import (
 
 // Make this path configurable if somebody has a valid reason
 // to need it to be.  The config is getting a bit bloated.
-const emojiDir = "/img/emoji" // Relative to webroot
+const emojiDir = "./img/emoji" // Relative to webroot
 
 // GetCustomEmoji returns a list of custom emoji via the API.
 func GetCustomEmoji(w http.ResponseWriter, r *http.Request) {

--- a/static/metadata.html
+++ b/static/metadata.html
@@ -42,7 +42,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="/img/favicon/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png">
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="./manifest.json">
 
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/img/favicon/ms-icon-144x144.png">

--- a/webroot/index-standalone-chat.html
+++ b/webroot/index-standalone-chat.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
-    <link href="/js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
+    <link href="./js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
     <link href="./styles/chat.css" rel="stylesheet" />
     <link href="./styles/standalone-chat.css" rel="stylesheet" />
   </head>
@@ -12,8 +12,8 @@
     <div id="messages-only"></div>
 
     <script type="module">
-      import { h, render } from '/js/web_modules/preact.js';
-      import htm from '/js/web_modules/htm.js';
+      import { h, render } from './js/web_modules/preact.js';
+      import htm from './js/web_modules/htm.js';
       const html = htm.bind(h);
 
       import StandaloneChat from './js/app-standalone-chat.js';

--- a/webroot/index-video-only.html
+++ b/webroot/index-video-only.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
-    <link href="/js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
+    <link href="./js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
 
-    <link href="/js/web_modules/videojs/video-js.min.css" rel="stylesheet"/>
-    <link href="/js/web_modules/@videojs/themes/fantasy/index.css" rel="stylesheet" />
+    <link href="./js/web_modules/videojs/video-js.min.css" rel="stylesheet"/>
+    <link href="./js/web_modules/@videojs/themes/fantasy/index.css" rel="stylesheet" />
 
     <link href="./styles/video.css" rel="stylesheet" />
     <link href="./styles/video-only.css" rel="stylesheet" />

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -18,16 +18,16 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/img/favicon/favicon-96x96.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="./manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/img/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 
-    <link href="/js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
+    <link href="./js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
 
-    <link href="/js/web_modules/videojs/video-js.min.css" rel="stylesheet"/>
-    <link href="/js/web_modules/@videojs/themes/fantasy/index.css" rel="stylesheet" />
+    <link href="./js/web_modules/videojs/video-js.min.css" rel="stylesheet"/>
+    <link href="./js/web_modules/@videojs/themes/fantasy/index.css" rel="stylesheet" />
 
     <link href="./styles/video.css" rel="stylesheet" />
     <link href="./styles/chat.css" rel="stylesheet" />
@@ -39,8 +39,8 @@
     <div id="app"></div>
 
     <script type="module">
-      import { h, render } from '/js/web_modules/preact.js';
-      import htm from '/js/web_modules/htm.js';
+      import { h, render } from './js/web_modules/preact.js';
+      import htm from './js/web_modules/htm.js';
       const html = htm.bind(h);
 
       import App from './js/app.js';

--- a/webroot/js/app-standalone-chat.js
+++ b/webroot/js/app-standalone-chat.js
@@ -1,5 +1,5 @@
-import { h, Component } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component } from './web_modules/preact.js';
+import htm from './web_modules/htm.js';
 const html = htm.bind(h);
 
 import Chat from './components/chat/chat.js';

--- a/webroot/js/app-video-only.js
+++ b/webroot/js/app-video-only.js
@@ -1,5 +1,5 @@
-import { h, Component } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component } from './web_modules/preact.js';
+import htm from './web_modules/htm.js';
 const html = htm.bind(h);
 
 import VideoPoster from './components/video-poster.js';

--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -1,5 +1,5 @@
-import { h, Component } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component } from './web_modules/preact.js';
+import htm from './web_modules/htm.js';
 const html = htm.bind(h);
 
 import { OwncastPlayer } from './components/player.js';

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -1,8 +1,8 @@
-import { h, Component, createRef } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component, createRef } from '../../web_modules/preact.js';
+import htm from '../../web_modules/htm.js';
 const html = htm.bind(h);
 
-import { EmojiButton } from '/js/web_modules/@joeattardi/emoji-button.js';
+import { EmojiButton } from '../../web_modules/@joeattardi/emoji-button.js';
 
 import ContentEditable, { replaceCaret } from './content-editable.js';
 import { generatePlaceholderText, getCaretPosition, convertToText, convertOnPaste } from '../../utils/chat.js';
@@ -65,7 +65,13 @@ export default class ChatInput extends Component {
         this.emojiPicker = new EmojiButton({
           zIndex: 100,
           theme: 'owncast', // see chat.css
-          custom: json,
+          custom: json.map(emoji => {
+            return {
+
+              "name": emoji.name,
+              "emoji": emoji.emoji = `${location.protocol === 'https:' ? 'https' : 'http'}://${location.host}${location.pathname}` + emoji.emoji.slice(1)
+            }
+          }), // converting absolute paths returned from API to relative paths
           initialCategory: 'custom',
           showPreview: false,
           autoHide: false,
@@ -98,9 +104,8 @@ export default class ChatInput extends Component {
     const { inputHTML } = this.state;
     let content = '';
     if (emoji.url) {
-      const url = location.protocol + "//" + location.host + "/" + emoji.url;
-      const name = url.split('\\').pop().split('/').pop();
-      content = "<img class=\"emoji\" alt=\"" + name + "\" src=\"" + url + "\"/>";
+      const name = emoji.url.split('\\').pop().split('/').pop();
+      content = "<img class=\"emoji\" alt=\"" + name + "\" src=\"" + emoji.url + "\"/>";
     } else {
       content = emoji.emoji;
     }
@@ -304,7 +309,7 @@ export default class ChatInput extends Component {
                 style=${emojiButtonStyle}
                 onclick=${this.handleEmojiButtonClick}
                 disabled=${!inputEnabled}
-              ><img src="../../../img/smiley.png" /></button>
+              ><img src="${location.pathname}img/smiley.png" /></button>
 
               <span id="message-form-warning" class="text-red-600 text-xs">${inputCharsLeft}/${CHAT_MAX_MESSAGE_LENGTH}</span>
             </div>

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -306,7 +306,7 @@ export default class ChatInput extends Component {
                 style=${emojiButtonStyle}
                 onclick=${this.handleEmojiButtonClick}
                 disabled=${!inputEnabled}
-              ><img src="${location.pathname}img/smiley.png" /></button>
+              ><img src="img/smiley.png" /></button>
 
               <span id="message-form-warning" class="text-red-600 text-xs">${inputCharsLeft}/${CHAT_MAX_MESSAGE_LENGTH}</span>
             </div>

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -65,13 +65,7 @@ export default class ChatInput extends Component {
         this.emojiPicker = new EmojiButton({
           zIndex: 100,
           theme: 'owncast', // see chat.css
-          custom: json.map(emoji => {
-            return {
-
-              "name": emoji.name,
-              "emoji": emoji.emoji = `${location.protocol === 'https:' ? 'https' : 'http'}://${location.host}${location.pathname}` + emoji.emoji.slice(1)
-            }
-          }), // converting absolute paths returned from API to relative paths
+          custom: json,
           initialCategory: 'custom',
           showPreview: false,
           autoHide: false,
@@ -104,8 +98,11 @@ export default class ChatInput extends Component {
     const { inputHTML } = this.state;
     let content = '';
     if (emoji.url) {
-      const name = emoji.url.split('\\').pop().split('/').pop();
-      content = "<img class=\"emoji\" alt=\"" + name + "\" src=\"" + emoji.url + "\"/>";
+      const img = document.createElement('img');
+      img.src = emoji.url;
+      img.alt = emoji.name;
+      img.classList.add('emoji');
+      content = img.outerHTML;
     } else {
       content = emoji.emoji;
     }

--- a/webroot/js/components/chat/chat-message-view.js
+++ b/webroot/js/components/chat/chat-message-view.js
@@ -1,6 +1,6 @@
-import { h, Component } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
-import Mark from '/js/web_modules/markjs/dist/mark.es6.min.js';
+import { h, Component } from '../../web_modules/preact.js';
+import htm from '../../web_modules/htm.js';
+import Mark from '../../web_modules/markjs/dist/mark.es6.min.js';
 const html = htm.bind(h);
 
 import {

--- a/webroot/js/components/chat/chat.js
+++ b/webroot/js/components/chat/chat.js
@@ -1,8 +1,8 @@
-import { h, Component, createRef } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component, createRef } from '../../web_modules/preact.js';
+import htm from '../../web_modules/htm.js';
 const html = htm.bind(h);
 
-import '/js/web_modules/@justinribeiro/lite-youtube.js';
+import '../../web_modules/@justinribeiro/lite-youtube.js';
 
 import Message from './message.js';
 import ChatInput from './chat-input.js';

--- a/webroot/js/components/chat/content-editable.js
+++ b/webroot/js/components/chat/content-editable.js
@@ -6,7 +6,7 @@ and here:
 https://stackoverflow.com/questions/22677931/react-js-onchange-event-for-contenteditable/27255103#27255103
 
 */
-import { h, Component, createRef } from '/js/web_modules/preact.js';
+import { h, Component, createRef } from '../../web_modules/preact.js';
 
 export function replaceCaret(el) {
   // Place the caret at the end of the element

--- a/webroot/js/components/chat/message.js
+++ b/webroot/js/components/chat/message.js
@@ -1,5 +1,5 @@
-import { h } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h } from '../../web_modules/preact.js';
+import htm from '../../web_modules/htm.js';
 const html = htm.bind(h);
 
 import ChatMessageView from './chat-message-view.js';

--- a/webroot/js/components/chat/username.js
+++ b/webroot/js/components/chat/username.js
@@ -1,5 +1,5 @@
-import { h, Component, createRef } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component, createRef } from '../../web_modules/preact.js';
+import htm from '../../web_modules/htm.js';
 const html = htm.bind(h);
 
 import { setLocalStorage } from '../../utils/helpers.js';

--- a/webroot/js/components/platform-logos-list.js
+++ b/webroot/js/components/platform-logos-list.js
@@ -1,5 +1,5 @@
-import {h} from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import {h} from '../web_modules/preact.js';
+import htm from '../web_modules/htm.js';
 import {SOCIAL_PLATFORMS} from '../utils/platforms.js';
 import {classNames} from '../utils/helpers.js';
 

--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -1,7 +1,7 @@
 // https://docs.videojs.com/player
 
-import videojs from '/js/web_modules/videojs/core.js';
-import '/js/web_modules/@videojs/http-streaming/dist/videojs-http-streaming.min.js';
+import videojs from '../web_modules/videojs/core.js';
+import '../web_modules/@videojs/http-streaming/dist/videojs-http-streaming.min.js';
 import { getLocalStorage, setLocalStorage } from '../utils/helpers.js';
 import { PLAYER_VOLUME, URL_STREAM } from '../utils/constants.js';
 

--- a/webroot/js/components/video-poster.js
+++ b/webroot/js/components/video-poster.js
@@ -1,5 +1,5 @@
-import { h, Component } from '/js/web_modules/preact.js';
-import htm from '/js/web_modules/htm.js';
+import { h, Component } from '../web_modules/preact.js';
+import htm from '../web_modules/htm.js';
 const html = htm.bind(h);
 
 import { TEMP_IMAGE } from '../utils/constants.js';

--- a/webroot/js/utils/constants.js
+++ b/webroot/js/utils/constants.js
@@ -1,12 +1,12 @@
 // misc constants used throughout the app
 
-export const URL_STATUS = `${location.pathname}` + `api/status`;
-export const URL_CHAT_HISTORY = `${location.pathname}` + `api/chat`;
-export const URL_CUSTOM_EMOJIS = `${location.pathname}` + `api/emoji`;
-export const URL_CONFIG = `${location.pathname}` + `api/config`;
+export const URL_STATUS = `api/status`;
+export const URL_CHAT_HISTORY = `api/chat`;
+export const URL_CUSTOM_EMOJIS = `api/emoji`;
+export const URL_CONFIG =  `api/config`;
 
 // TODO: This directory is customizable in the config.  So we should expose this via the config API.
-export const URL_STREAM = `${location.pathname}` + `hls/stream.m3u8`;
+export const URL_STREAM = `hls/stream.m3u8`;
 export const URL_WEBSOCKET = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}${location.pathname}entry`;
 
 export const TIMER_STATUS_UPDATE = 5000; // ms
@@ -14,7 +14,7 @@ export const TIMER_DISABLE_CHAT_AFTER_OFFLINE = 5 * 60 * 1000; // 5 mins
 export const TIMER_STREAM_DURATION_COUNTER = 1000;
 export const TEMP_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-export const OWNCAST_LOGO_LOCAL = './img/logo.svg';
+export const OWNCAST_LOGO_LOCAL = 'img/logo.svg';
 
 export const MESSAGE_OFFLINE = 'Stream is offline.';
 export const MESSAGE_ONLINE = 'Stream is online.';

--- a/webroot/js/utils/constants.js
+++ b/webroot/js/utils/constants.js
@@ -1,20 +1,20 @@
 // misc constants used throughout the app
 
-export const URL_STATUS = `/api/status`;
-export const URL_CHAT_HISTORY = `/api/chat`;
-export const URL_CUSTOM_EMOJIS = `/api/emoji`;
-export const URL_CONFIG = `/api/config`;
+export const URL_STATUS = `${location.pathname}` + `api/status`;
+export const URL_CHAT_HISTORY = `${location.pathname}` + `api/chat`;
+export const URL_CUSTOM_EMOJIS = `${location.pathname}` + `api/emoji`;
+export const URL_CONFIG = `${location.pathname}` + `api/config`;
 
 // TODO: This directory is customizable in the config.  So we should expose this via the config API.
-export const URL_STREAM = `/hls/stream.m3u8`;
-export const URL_WEBSOCKET = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/entry`;
+export const URL_STREAM = `${location.pathname}` + `hls/stream.m3u8`;
+export const URL_WEBSOCKET = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}${location.pathname}entry`;
 
 export const TIMER_STATUS_UPDATE = 5000; // ms
 export const TIMER_DISABLE_CHAT_AFTER_OFFLINE = 5 * 60 * 1000; // 5 mins
 export const TIMER_STREAM_DURATION_COUNTER = 1000;
 export const TEMP_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-export const OWNCAST_LOGO_LOCAL = '/img/logo.svg';
+export const OWNCAST_LOGO_LOCAL = './img/logo.svg';
 
 export const MESSAGE_OFFLINE = 'Stream is offline.';
 export const MESSAGE_ONLINE = 'Stream is online.';

--- a/webroot/styles/app.css
+++ b/webroot/styles/app.css
@@ -60,7 +60,7 @@ header {
 #logo-container {
   background-size: 1.35em;
   padding: 1.15rem;
-  background-image: url(/img/logo.svg);
+  background-image: url(../img/logo.svg);
 }
 
 #chat-toggle {


### PR DESCRIPTION
This resolves https://github.com/owncast/owncast/issues/505

I tested this and it works great when running on `/` and also on different path, for example with following Caddy config:
```
my-owncast-instance.xyz

handle_path /my_secret_path/* {
        uri strip_prefix /my_secret_path/
        reverse_proxy 127.0.0.1:8080
}

```

That way you can have your owncast instance run privately for only those who have secret link, e.g. https://my-owncast-instance.xyz/my_secret_path/