### PR TITLE
Only trigger responsive behavior if zoom does not happen on touch screen devices

### DIFF
--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -104,7 +104,9 @@ export default class App extends Component {
 
   componentDidMount() {
     this.getConfig();
-    window.addEventListener('resize', this.handleWindowResize);
+    if (!this.hasTouchScreen) {
+      window.addEventListener('resize', this.handleWindowResize);
+    }
     window.addEventListener('blur', this.handleWindowBlur);
     window.addEventListener('focus', this.handleWindowFocus);
     if (this.hasTouchScreen) {


### PR DESCRIPTION
This resolves #594 by only reacting responsively to zoom actions if the device does not have a touch screen. Since pinch zooming allows users to focus on content relatively straight forward, there is no need to behave responsively (in my opinion).  