### PR TITLE
Fix codeblocks in chat

### DIFF
--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -117,11 +117,13 @@ func (s *server) Listen() {
 			// and standardize this message into something safe we can send everyone else.
 			msg.RenderAndSanitizeMessageBody()
 
-			s.listener.MessageSent(msg)
-			s.sendAll(msg)
+			if !msg.Empty() {
+				s.listener.MessageSent(msg)
+				s.sendAll(msg)
 
-			// Store in the message history
-			addMessage(msg)
+				// Store in the message history
+				addMessage(msg)
+			}
 		case ping := <-s.pingCh:
 			fmt.Println("PING?", ping)
 

--- a/models/chatMessage.go
+++ b/models/chatMessage.go
@@ -111,5 +111,9 @@ func sanitize(raw string) string {
 	// Allow emphasis
 	p.AllowElements("em")
 
+	// Allow code blocks
+	p.AllowElements("code")
+	p.AllowElements("pre")
+
 	return p.Sanitize(raw)
 }

--- a/models/chatMessage.go
+++ b/models/chatMessage.go
@@ -38,6 +38,10 @@ func (m *ChatEvent) RenderAndSanitizeMessageBody() {
 	m.Body = RenderAndSanitize(raw)
 }
 
+func (m *ChatEvent) Empty() bool {
+	return m.Body == ""
+}
+
 // RenderAndSanitize will turn markdown into HTML, sanitize raw user-supplied HTML and standardize
 // the message into something safe and renderable for clients.
 func RenderAndSanitize(raw string) string {


### PR DESCRIPTION
I wrote a quick fix for #675 .

This fix consists of two parts.

Part 1:
When the chat message looks like this `  ```a ` without actual content in the code block (`a` does not count as it will set the language for the block). This will be converted into the following html by goldmark:

```html
<pre><code></code></pre>
```
This will be trimmed into an empty string by bluemonday, as both tags are forbitten. The empty string will than omited, as its empty. Therefore, undefined will be displayed in the chat. I added a quick check if the message is empty. If a message is empty, it will not be sent to the frontend/to the chat.

Part 2:

I added pre and code as allowed tags.