### PR TITLE
<script type="module" ...> tags to reduce round trips under HTTP/2

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -33,6 +33,44 @@
     <link href="./styles/chat.css" rel="stylesheet" />
     <link href="./styles/user-content.css" rel="stylesheet" />
     <link href="./styles/app.css" rel="stylesheet" />
+
+    <!-- The following script tags are not required for the app to run, 
+         however they will make it load a lot faster (fewer round trips) when HTTP/2 is used. 
+        
+         If you wish to re-generate this list, run the following shell command 
+         (assuming a linux or unix-ish system):
+         find webroot | grep -E '\.js$' | sed -E 's|webroot(.*)|<script type="module" src="\1"></script>|'
+    -->
+
+    <script type="module" src="/js/app.js"></script>
+    <script type="module" src="/js/app-standalone-chat.js"></script>
+    <script type="module" src="/js/app-video-only.js"></script>
+    <script type="module" src="/js/components/chat/chat-input.js"></script>
+    <script type="module" src="/js/components/chat/chat.js"></script>
+    <script type="module" src="/js/components/chat/chat-message-view.js"></script>
+    <script type="module" src="/js/components/chat/content-editable.js"></script>
+    <script type="module" src="/js/components/chat/message.js"></script>
+    <script type="module" src="/js/components/chat/username.js"></script>
+    <script type="module" src="/js/components/platform-logos-list.js"></script>
+    <script type="module" src="/js/components/player.js"></script>
+    <script type="module" src="/js/components/video-poster.js"></script>
+    <script type="module" src="/js/utils/chat.js"></script>
+    <script type="module" src="/js/utils/constants.js"></script>
+    <script type="module" src="/js/utils/helpers.js"></script>
+    <script type="module" src="/js/utils/platforms.js"></script>
+    <script type="module" src="/js/utils/user-colors.js"></script>
+    <script type="module" src="/js/utils/websocket.js"></script>
+    <script type="module" src="/js/web_modules/common/_commonjsHelpers-37fa8da4.js"></script>
+    <script type="module" src="/js/web_modules/common/core-d14f1e1c.js"></script>
+    <script type="module" src="/js/web_modules/common/core-fed3ccd8.js"></script>
+    <script type="module" src="/js/web_modules/htm.js"></script>
+    <script type="module" src="/js/web_modules/@joeattardi/emoji-button.js"></script>
+    <script type="module" src="/js/web_modules/@justinribeiro/lite-youtube.js"></script>
+    <script type="module" src="/js/web_modules/markjs/dist/mark.es6.min.js"></script>
+    <script type="module" src="/js/web_modules/preact.js"></script>
+    <script type="module" src="/js/web_modules/@videojs/http-streaming/dist/videojs-http-streaming.min.js"></script>
+    <script type="module" src="/js/web_modules/videojs/core.js"></script>
+
   </head>
 
   <body class="scrollbar-hidden bg-gray-300 text-gray-800">


### PR DESCRIPTION
I did some 1st impression load time tests with owncast frontend app, testing  pre-loading the JS modules via <script type="module" src="..."> tags. The 1st test with HTTP/1.1 took about 10 seconds regardless of whether the script tags were there or not:

https://picopublish.sequentialread.com/files/owncast-first-impression-http-1.1.mkv

But watch what happens when you turn on HTTP/2:

https://picopublish.sequentialread.com/files/owncast-first-impression-http-2.mkv

Under terrible latency conditions (1 second latency) these script tags will reduce load time by ~75%.

according to caniuse this browser feature is on 92% of all clients today: https://caniuse.com/es6-module