### PR TITLE
update logo POST route

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -144,8 +144,9 @@ func Start() error {
 
 	// Connected clients
 	http.HandleFunc("/api/integrations/clients", middleware.RequireAccessToken(models.ScopeHasAdminAccess, controllers.GetConnectedClients))
+
 	// Logo path
-	http.HandleFunc("/api/admin/config/logo", middleware.RequireAdminAuth(admin.SetLogoPath))
+	http.HandleFunc("/api/admin/config/logo", middleware.RequireAdminAuth(admin.SetLogo))
 
 	// Server tags
 	http.HandleFunc("/api/admin/config/tags", middleware.RequireAdminAuth(admin.SetTags))


### PR DESCRIPTION
The logo POST route now accepts a base64 encoded image instead of a path to an
image in the data folder. The route now saves the posted image to the data
folder, with the correct file type extension, and updates logo path in the
database appropriately.

Closes https://github.com/owncast/owncast/issues/716