### PR TITLE
Use multi-stage-builds for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM golang:alpine
-EXPOSE 8080 1935
+FROM golang:alpine AS build
+RUN apk add --no-cache gcc build-base linux-headers
+
+WORKDIR /build
+COPY . /build
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owncast .
+
+
+FROM alpine
+RUN apk add --no-cache ffmpeg ffmpeg-libs
+
 WORKDIR /app
-ADD . .
-RUN set -ex && \
-    apk add --no-cache ffmpeg ffmpeg-libs && \
-    apk add --no-cache gcc build-base linux-headers && \ 
-    CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o owncast .
+COPY webroot /app/webroot
+COPY static /app/static
+COPY --from=build /build/owncast /app/owncast
+
+EXPOSE 8080 1935
 CMD ["/app/owncast"]


### PR DESCRIPTION
This PR changes the Dockerfile to utilize [multi-stage-builds](https://docs.docker.com/develop/develop-images/multistage-build/).

This dramatically reduces the size of the final image, as the actual building happens in a different environment than the runtime environment.

Some numbers:
```
$ docker image ls owncast
REPOSITORY   TAG           IMAGE ID       CREATED          SIZE
owncast      singlestage   5c9fc314c60a   26 seconds ago   1.07GB
owncast      multistage    dd0ac3ac80e3   10 minutes ago   112MB
```
- `owncast:singlestage` was built with the `develop` branch
- `owncast:multistage` was built with this PR