### PR TITLE
Put play button behind the header bar when scrolling

### DIFF
--- a/webroot/styles/video.css
+++ b/webroot/styles/video.css
@@ -19,11 +19,11 @@ video.video-js {
 }
 
 .vjs-big-play-button {
-  z-index: 100;
+  z-index: 48;
 }
 
 .vjs-loading-spinner {
-  z-index: 200;
+  z-index: 49;
 }
 
 /*


### PR DESCRIPTION
Lower the z-index of the play button to push it behind the header. Fix for issue #951.