### PR TITLE
Fix #1001 set RTMP port from cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 	restoreDatabaseFile := flag.String("restoreDatabase", "", "Restore an Owncast database backup")
 	newStreamKey := flag.String("streamkey", "", "Set your stream key/admin password")
 	webServerPortOverride := flag.String("webserverport", "", "Force the web server to listen on a specific port")
+	rtmpPortOverride := flag.Int("rtmpport", 0, "Set listen port for the RTMP server")
 
 	flag.Parse()
 
@@ -123,6 +124,12 @@ func main() {
 	}
 
 	config.WebServerPort = data.GetHTTPPortNumber()
+
+	// Set the rtmp server port
+	if *rtmpPortOverride > 0 {
+		log.Println("Saving new RTMP server port number to", *rtmpPortOverride)
+		data.SetRTMPPortNumber(float64(*rtmpPortOverride))
+	}
 
 	// starts the core
 	if err := core.Start(); err != nil {


### PR DESCRIPTION
Using flag.Int instead of manual string conversion, seems cleaner? flag does validate the type and complains.