### PR TITLE
Add -transcoderlog flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"fmt"
 )
 
@@ -8,6 +9,9 @@ import (
 
 // DatabaseFilePath is the path to the file ot be used as the global database for this run of the application.
 var DatabaseFilePath = "data/owncast.db"
+
+// LogDirectory is the path to various log files
+var LogDirectory = "."
 
 // EnableDebugFeatures will print additional data to help in debugging.
 var EnableDebugFeatures = false
@@ -37,4 +41,8 @@ func GetReleaseString() string {
 	var gitCommit = GitCommit
 
 	return fmt.Sprintf("Owncast v%s-%s (%s)", versionNumber, buildPlatform, gitCommit)
+}
+
+func GetTranscoderLogFilePath() string {
+	return filepath.Join(LogDirectory, "transcoder.log")
 }

--- a/core/transcoder/transcoder.go
+++ b/core/transcoder/transcoder.go
@@ -101,7 +101,7 @@ func (t *Transcoder) Start() {
 
 	err = _commandExec.Start()
 	if err != nil {
-		log.Errorln("Transcoder error.  See transcoder.log for full output to debug.")
+		log.Errorln("Transcoder error.  See ", config.GetTranscoderLogFilePath(), " for full output to debug.")
 		log.Panicln(err, command)
 	}
 
@@ -119,7 +119,7 @@ func (t *Transcoder) Start() {
 	}
 
 	if err != nil {
-		log.Errorln("transcoding error. look at transcoder.log to help debug. your copy of ffmpeg may not support your selected codec of", t.codec.Name(), "https://owncast.online/docs/troubleshooting/#codecs")
+		log.Errorln("transcoding error. look at ", config.GetTranscoderLogFilePath(), " to help debug. your copy of ffmpeg may not support your selected codec of", t.codec.Name(), "https://owncast.online/docs/troubleshooting/#codecs")
 	}
 }
 
@@ -142,7 +142,7 @@ func (t *Transcoder) getString() string {
 		hlsOptionsString = "-hls_flags " + strings.Join(hlsOptionFlags, "+")
 	}
 	ffmpegFlags := []string{
-		`FFREPORT=file="transcoder.log":level=32`,
+		fmt.Sprintf(`FFREPORT=file="%s":level=32`, config.GetTranscoderLogFilePath()),
 		t.ffmpegPath,
 		"-hide_banner",
 		"-loglevel warning",

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 
 	configFile := flag.String("configFile", "config.yaml", "Config file path to migrate to the new database")
 	dbFile := flag.String("database", "", "Path to the database file.")
+	logDirectory := flag.String("logdir", "", "Directory where logs will be written to")
 	enableDebugOptions := flag.Bool("enableDebugFeatures", false, "Enable additional debugging options.")
 	enableVerboseLogging := flag.Bool("enableVerboseLogging", false, "Enable additional logging.")
 	restoreDatabaseFile := flag.String("restoreDatabase", "", "Restore an Owncast database backup")
@@ -56,6 +57,10 @@ func main() {
 		config.BuildPlatform = BuildPlatform
 	}
 	log.Infoln(config.GetReleaseString())
+
+	if *logDirectory != "" {
+		config.LogDirectory = *logDirectory
+	}
 
 	// Create the data directory if needed
 	if !utils.DoesFileExists("data") {


### PR DESCRIPTION
As discussed, I am adding this flag to be able to specify where to save the transcoder logs.
I have kept the default to be the same as before (eg: `transcoder.log` relative to the pwd). 
This is my first dive into this project so feel free to comment on the approach, etc. I was not too sure if I was supposed to use the config.* as global variables, but that seemed to be how it is done.

EDIT: I left the `transcoder_*` file as is, not sure if you want me to use `config.TranscoderLogFilePath` there as well.