### PR TITLE
GitHub GO Lint Action: fix git reference

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: golangci-lint


### PR DESCRIPTION
the lint action didn't specify the correct git reference on pull requests.

simply removing the given reference **should** fix this. the underlying `actions/checkout@v2` should do the right thing for both push and pull request events. try, could not fully test it.