### PR TITLE
added emoji focus check to prevent triggering shortcuts

### DIFF
--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -430,6 +430,7 @@ export default class App extends Component {
     } else if (
       e.target !== document.getElementById('message-input') &&
       e.target !== document.getElementById('username-change-input') &&
+      e.target !== document.getElementsByClassName('emoji-picker__search')[0] &&
       this.state.streamOnline
     ) {
       switch (e.code) {


### PR DESCRIPTION
This should fix #1025. Just if you are curious, the shortcut method checks each element by its id, since not all inputs share the input tag. Maybe we could shorten this statement and prevent issues with shortcuts by using the input tag for every input in the frontend. This should also help improving accessibility.