### PR TITLE
Fix rtmp secret validation to allow `/` (#1069)

### DIFF
--- a/core/rtmp/rtmp.go
+++ b/core/rtmp/rtmp.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"strings"
 	"syscall"
 	"time"
 
@@ -78,9 +77,7 @@ func HandleConn(c *rtmp.Conn, nc net.Conn) {
 		return
 	}
 
-	streamingKeyComponents := strings.Split(c.URL.Path, "/")
-	streamingKey := streamingKeyComponents[len(streamingKeyComponents)-1]
-	if streamingKey != data.GetStreamKey() {
+	if !secretMatch(data.GetStreamKey(), c.URL.Path) {
 		log.Errorln("invalid streaming key; rejecting incoming stream")
 		nc.Close()
 		return

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -78,16 +78,21 @@ func getVideoCodec(codec interface{}) string {
 }
 
 func secretMatch(configStreamKey string, url string) bool {
-  sep := "/live/"
-  givenParts := strings.Split(url, sep)
+	sep := "/live/"
+	givenParts := strings.Split(url, sep)
 
-  if len(givenParts) < 2 { // url part and secret
-    return false
-  }
+	if len(givenParts) < 2 { // url part and secret
+		return false
+	}
 
-  // If the given url has /live/ in the secret, this /live/ was removed with the
-  // `strings.Split/2` above. So, we add it back now.
-  streamingKey := strings.Join(givenParts[1:], sep)
+	host := strings.Split(givenParts[0], "/")
+	if len(host) != 3 { // "rtmp:", "" between the //, "verylong.example.com"
+		return false // There is stuff between the domain and "/live/", thus fail.
+	}
 
-  return streamingKey == configStreamKey
+	// If the given url has /live/ in the secret, this /live/ was removed with the
+	// `strings.Split/2` above. So, we add it back now.
+	streamingKey := strings.Join(givenParts[1:], sep)
+
+	return streamingKey == configStreamKey
 }

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -76,3 +76,18 @@ func getVideoCodec(codec interface{}) string {
 
 	return unknownString
 }
+
+func secretMatch(configStreamKey string, url string) bool {
+  sep := "/live/"
+  givenParts := strings.Split(url, sep)
+
+  if len(givenParts) < 2 { // url part and secret
+    return false
+  }
+
+  // If the given url has /live/ in the secret, this /live/ was removed with the
+  // `strings.Split/2` above. So, we add it back now.
+  streamingKey := strings.Join(givenParts[1:], sep)
+
+  return streamingKey == configStreamKey
+}

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nareix/joy5/format/flv/flvio"
 	"github.com/owncast/owncast/models"
+	log "github.com/sirupsen/logrus"
 )
 
 const unknownString = "Unknown"
@@ -77,22 +78,14 @@ func getVideoCodec(codec interface{}) string {
 	return unknownString
 }
 
-func secretMatch(configStreamKey string, url string) bool {
-	sep := "/live/"
-	givenParts := strings.Split(url, sep)
+func secretMatch(configStreamKey string, path string) bool {
+	prefix := "/live/"
 
-	if len(givenParts) < 2 { // url part and secret
-		return false
+	if !strings.HasPrefix(path, prefix) {
+		log.Debug("RTMP path does not start with " + prefix)
+		return false // We need the path to begin with $prefix
 	}
 
-	host := strings.Split(givenParts[0], "/")
-	if len(host) != 3 { // "rtmp:", "" between the //, "verylong.example.com"
-		return false // There is stuff between the domain and "/live/", thus fail.
-	}
-
-	// If the given url has /live/ in the secret, this /live/ was removed with the
-	// `strings.Split/2` above. So, we add it back now.
-	streamingKey := strings.Join(givenParts[1:], sep)
-
+	streamingKey := path[len(prefix):] // Remove $prefix
 	return streamingKey == configStreamKey
 }

--- a/core/rtmp/utils_test.go
+++ b/core/rtmp/utils_test.go
@@ -20,6 +20,10 @@ func Test_secretMatch(t *testing.T) {
 		{"bad urls", "anything", "nonsense", false},
 		{"missing secret", "abc", "rtmp://example.com/live/", false},
 		{"missing secret and missing last slash", "abc", "rtmp://example.com/live", false},
+		{"streamkey before /live/", "streamkey", "rtmp://example.com/streamkey/live", false},
+		{"missing /live/", "anything", "rtmp://example.com/something/else", false},
+		{"stuff before and after /live/", "after", "rtmp://example.com/before/live/after", false},
+		{"host validation", "abc", "rtmp://very.long.subdomain.example.com/live/abc", true},
 	}
 
 	for _, tt := range tests {

--- a/core/rtmp/utils_test.go
+++ b/core/rtmp/utils_test.go
@@ -6,29 +6,28 @@ func Test_secretMatch(t *testing.T) {
 	tests := []struct {
 		name      string
 		streamKey string
-		url       string
+		path      string
 		want      bool
 	}{
-		{"simple positive", "abc", "rtmp://example.com/live/abc", true},
-		{"simple negative", "abc", "rtmp://example.com/live/def", false},
-		{"simple positive with numbers", "abc123", "rtmp://example.com/live/abc123", true},
-		{"simple negative with numbers", "abc123", "rtmp://example.com/live/def456", false},
-		{"positive with url chars", "one/two/three", "rtmp://example.com/live/one/two/three", true},
-		{"negative with url chars", "one/two/three", "rtmp://example.com/live/four/five/six", false},
-		{"check the entire secret", "three", "rtmp://example.com/live/one/two/three", false},
-		{"with /live/ in secret", "one/live/three", "rtmp://example.com/live/one/live/three", true},
-		{"bad urls", "anything", "nonsense", false},
-		{"missing secret", "abc", "rtmp://example.com/live/", false},
-		{"missing secret and missing last slash", "abc", "rtmp://example.com/live", false},
-		{"streamkey before /live/", "streamkey", "rtmp://example.com/streamkey/live", false},
-		{"missing /live/", "anything", "rtmp://example.com/something/else", false},
-		{"stuff before and after /live/", "after", "rtmp://example.com/before/live/after", false},
-		{"host validation", "abc", "rtmp://very.long.subdomain.example.com/live/abc", true},
+		{"positive", "abc", "/live/abc", true},
+		{"negative", "abc", "/live/def", false},
+		{"positive with numbers", "abc123", "/live/abc123", true},
+		{"negative with numbers", "abc123", "/live/def456", false},
+		{"positive with url chars", "one/two/three", "/live/one/two/three", true},
+		{"negative with url chars", "one/two/three", "/live/four/five/six", false},
+		{"check the entire secret", "three", "/live/one/two/three", false},
+		{"with /live/ in secret", "one/live/three", "/live/one/live/three", true},
+		{"bad path", "anything", "nonsense", false},
+		{"missing secret", "abc", "/live/", false},
+		{"missing secret and missing last slash", "abc", "/live", false},
+		{"streamkey before /live/", "streamkey", "/streamkey/live", false},
+		{"missing /live/", "anything", "/something/else", false},
+		{"stuff before and after /live/", "after", "/before/live/after", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := secretMatch(tt.streamKey, tt.url); got != tt.want {
+			if got := secretMatch(tt.streamKey, tt.path); got != tt.want {
 				t.Errorf("secretMatch() = %v, want %v", got, tt.want)
 			}
 		})

--- a/core/rtmp/utils_test.go
+++ b/core/rtmp/utils_test.go
@@ -1,0 +1,32 @@
+package rtmp
+
+import "testing"
+
+func Test_secretMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		streamKey string
+		url       string
+		want      bool
+	}{
+		{"simple positive", "abc", "rtmp://example.com/live/abc", true},
+		{"simple negative", "abc", "rtmp://example.com/live/def", false},
+		{"simple positive with numbers", "abc123", "rtmp://example.com/live/abc123", true},
+		{"simple negative with numbers", "abc123", "rtmp://example.com/live/def456", false},
+		{"positive with url chars", "one/two/three", "rtmp://example.com/live/one/two/three", true},
+		{"negative with url chars", "one/two/three", "rtmp://example.com/live/four/five/six", false},
+		{"check the entire secret", "three", "rtmp://example.com/live/one/two/three", false},
+		{"with /live/ in secret", "one/live/three", "rtmp://example.com/live/one/live/three", true},
+		{"bad urls", "anything", "nonsense", false},
+		{"missing secret", "abc", "rtmp://example.com/live/", false},
+		{"missing secret and missing last slash", "abc", "rtmp://example.com/live", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := secretMatch(tt.streamKey, tt.url); got != tt.want {
+				t.Errorf("secretMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Now allowing `/` in the stream secret.

This does rely on the middle part being `/live/` which was not enforced before. All of our docs use `/live/` in the examples, but there was nothing that stopped users to set this to other values.

Tangentely related to #1069 which reported that they're unable to use `/` secrets in OBS.