### PR TITLE
Remove empty action buttons container with extra space

### DIFF
--- a/webroot/js/app.js
+++ b/webroot/js/app.js
@@ -550,21 +550,22 @@ export default class App extends Component {
       : html` <${VideoPoster} offlineImage=${logo} active=${streamOnline} /> `;
 
     const externalActionButtons =
-      externalActions &&
-      html`<div
-        id="external-actions-container"
-        class="flex flex-row align-center"
-      >
-        ${externalActions.map(
-          function (action, index) {
-            return html`<${ExternalActionButton}
-              onClick=${this.displayExternalAction}
-              action=${action}
-              index=${index}
-            />`;
-          }.bind(this)
-        )}
-      </div>`;
+      externalActions && externalActions.length > 0
+      ? html`<div
+          id="external-actions-container"
+          class="flex flex-row align-center"
+        >
+          ${externalActions.map(
+            function (action, index) {
+              return html`<${ExternalActionButton}
+                onClick=${this.displayExternalAction}
+                action=${action}
+                index=${index}
+              />`;
+            }.bind(this)
+          )}
+        </div>`
+      : null;
 
     const externalActionModal = externalAction
       ? html`<${ExternalActionModal}
@@ -667,7 +668,7 @@ export default class App extends Component {
               <h2 class="font-semibold text-5xl">
                 <span class="streamer-name text-indigo-600">${name}</span>
               </h2>
-              <div>${externalActionButtons}</div>
+              ${externalActionButtons && html`<div>${externalActionButtons}</div>`}
               <h3 class="font-semibold text-3xl">
                 ${streamOnline && streamTitle}
               </h3>


### PR DESCRIPTION
### Description
Removed the unnecessary action buttons container that creates extra spacing when actions is empty. 

### Test
You need to go to the main page and see if the large space between the heading and the section with social networks has disappeared