### PR TITLE
🐛 use currentBroadcast for playlist overwrites

### DIFF
--- a/core/streamState.go
+++ b/core/streamState.go
@@ -88,7 +88,7 @@ func SetStreamAsDisconnected() {
 		_yp.Stop()
 	}
 
-	for index := range data.GetStreamOutputVariants() {
+	for index := range _currentBroadcast.OutputSettings {
 		playlistFilePath := fmt.Sprintf(filepath.Join(config.PrivateHLSStoragePath, "%d/stream.m3u8"), index)
 		segmentFilePath := fmt.Sprintf(filepath.Join(config.PrivateHLSStoragePath, "%d/%s"), index, offlineFilename)
 


### PR DESCRIPTION
Fixes #1147 since it looks into currentBroadcast and does not use the configuration of the next stream.