### PR TITLE
proper cleanup and permission check for the hls directory

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -114,28 +114,13 @@ func resetDirectories() {
 	log.Trace("Resetting file directories to a clean slate.")
 
 	// Wipe the public, web-accessible hls data directory
-	err := os.RemoveAll(config.PublicHLSStoragePath)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	err = os.RemoveAll(config.PrivateHLSStoragePath)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	err = os.MkdirAll(config.PublicHLSStoragePath, 0777)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	err = os.MkdirAll(config.PrivateHLSStoragePath, 0777)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	utils.CleanupDirectory(config.PublicHLSStoragePath)
+	utils.CleanupDirectory(config.PrivateHLSStoragePath)
 
 	// Remove the previous thumbnail
 	logo := data.GetLogoPath()
 	if utils.DoesFileExists(logo) {
-		err = utils.Copy(path.Join("data", logo), filepath.Join(config.WebRoot, "thumbnail.jpg"))
+		err := utils.Copy(path.Join("data", logo), filepath.Join(config.WebRoot, "thumbnail.jpg"))
 		if err != nil {
 			log.Warnln(err)
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -114,9 +114,15 @@ func resetDirectories() {
 	log.Trace("Resetting file directories to a clean slate.")
 
 	// Wipe the public, web-accessible hls data directory
-	os.RemoveAll(config.PublicHLSStoragePath)
-	os.RemoveAll(config.PrivateHLSStoragePath)
-	err := os.MkdirAll(config.PublicHLSStoragePath, 0777)
+	err := os.RemoveAll(config.PublicHLSStoragePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	err = os.RemoveAll(config.PrivateHLSStoragePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	err = os.MkdirAll(config.PublicHLSStoragePath, 0777)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/core/transcoder/utils.go
+++ b/core/transcoder/utils.go
@@ -91,6 +91,16 @@ func handleTranscoderMessage(message string) {
 
 func createVariantDirectories() {
 	// Create private hls data dirs
+
+	err := os.RemoveAll(config.PublicHLSStoragePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	err = os.RemoveAll(config.PrivateHLSStoragePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	
 	if len(data.GetStreamOutputVariants()) != 0 {
 		for index := range data.GetStreamOutputVariants() {
 			err := os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(index)), 0777)

--- a/core/transcoder/utils.go
+++ b/core/transcoder/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/core/data"
+	"github.com/owncast/owncast/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -91,19 +92,12 @@ func handleTranscoderMessage(message string) {
 
 func createVariantDirectories() {
 	// Create private hls data dirs
-
-	err := os.RemoveAll(config.PublicHLSStoragePath)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	err = os.RemoveAll(config.PrivateHLSStoragePath)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	utils.CleanupDirectory(config.PublicHLSStoragePath)
+	utils.CleanupDirectory(config.PrivateHLSStoragePath)
 	
 	if len(data.GetStreamOutputVariants()) != 0 {
 		for index := range data.GetStreamOutputVariants() {
-			err = os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(index)), 0777)
+			err := os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(index)), 0777)
 			if err != nil {
 				log.Fatalln(err)
 			}
@@ -117,7 +111,7 @@ func createVariantDirectories() {
 	} else {
 		dir := path.Join(config.PrivateHLSStoragePath, strconv.Itoa(0))
 		log.Traceln("Creating", dir)
-		err = os.MkdirAll(dir, 0777)
+		err := os.MkdirAll(dir, 0777)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/core/transcoder/utils.go
+++ b/core/transcoder/utils.go
@@ -103,7 +103,7 @@ func createVariantDirectories() {
 	
 	if len(data.GetStreamOutputVariants()) != 0 {
 		for index := range data.GetStreamOutputVariants() {
-			err := os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(index)), 0777)
+			err = os.MkdirAll(path.Join(config.PrivateHLSStoragePath, strconv.Itoa(index)), 0777)
 			if err != nil {
 				log.Fatalln(err)
 			}
@@ -117,7 +117,7 @@ func createVariantDirectories() {
 	} else {
 		dir := path.Join(config.PrivateHLSStoragePath, strconv.Itoa(0))
 		log.Traceln("Creating", dir)
-		err := os.MkdirAll(dir, 0777)
+		err = os.MkdirAll(dir, 0777)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -226,3 +226,14 @@ func VerifyFFMpegPath(path string) error {
 
 	return nil
 }
+
+// Removes the directory and makes it again. Throws fatal error on fail.
+func CleanupDirectory(path string) {
+	log.Traceln("Cleaning", path)
+	if err := os.RemoveAll(path); err != nil {
+		log.Fatalln(err)
+	}
+	if err := os.MkdirAll(path, 0777); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -227,13 +227,13 @@ func VerifyFFMpegPath(path string) error {
 	return nil
 }
 
-// Removes the directory and makes it again. Throws fatal error on fail.
+// Removes the directory and makes it again. Throws fatal error on failure.
 func CleanupDirectory(path string) {
 	log.Traceln("Cleaning", path)
 	if err := os.RemoveAll(path); err != nil {
-		log.Fatalln(err)
+		log.Fatalln("Unable to remove directory. Please check the ownership and permissions", err)
 	}
 	if err := os.MkdirAll(path, 0777); err != nil {
-		log.Fatalln(err)
+		log.Fatalln("Unable to create directory. Please check the ownership and permissions", err)
 	}
 }


### PR DESCRIPTION
If the process doesn't have the right (write) permission for the hls directory:

```
INFO[2021-07-07T18:11:12Z] Owncast v0.0.8-dev (20210707)                
TRAC[2021-07-07T18:11:12Z] Creating webhooks table...                   
TRAC[2021-07-07T18:11:12Z] Creating access_tokens table...              
TRAC[2021-07-07T18:11:12Z] http_listen_address sql: no rows in result set 
TRAC[2021-07-07T18:11:12Z] Resetting file directories to a clean slate. 
FATA[2021-07-07T18:11:12Z] unlinkat ./hls/0/stream-offline***********.ts: permission denied 
exit status 1
```

closes #1166
