### PR TITLE
Cache the custom emoji list

### DIFF
--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -22,6 +22,7 @@ const emojiDir = "/img/emoji" // Relative to webroot
 var emojiCache = make([]models.CustomEmoji, 0)
 var emojiCacheTimestamp time.Time
 
+// getCustomEmojiList returns a list of custom emoji either from the cache or from the emoji directory.
 func getCustomEmojiList() []models.CustomEmoji {
 	fullPath := filepath.Join(config.WebRoot, emojiDir)
 	emojiDirInfo, err := os.Stat(fullPath)

--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -17,27 +17,31 @@ import (
 // to need it to be.  The config is getting a bit bloated.
 const emojiDir = "/img/emoji" // Relative to webroot
 
+var emojiCache = make([]models.CustomEmoji, 0)
+
+func getCustomEmojiList() []models.CustomEmoji {
+	if len(emojiCache) == 0 {
+		fullPath := filepath.Join(config.WebRoot, emojiDir)
+		files, err := ioutil.ReadDir(fullPath)
+		if err != nil {
+			log.Errorln(err)
+			return emojiCache
+		}
+
+		for _, f := range files {
+			name := strings.TrimSuffix(f.Name(), path.Ext(f.Name()))
+			emojiPath := filepath.Join(emojiDir, f.Name())
+			singleEmoji := models.CustomEmoji{Name: name, Emoji: emojiPath}
+			emojiCache = append(emojiCache, singleEmoji)
+		}
+	}
+
+	return emojiCache
+}
+
 // GetCustomEmoji returns a list of custom emoji via the API.
 func GetCustomEmoji(w http.ResponseWriter, r *http.Request) {
-	emojiList := make([]models.CustomEmoji, 0)
-
-	fullPath := filepath.Join(config.WebRoot, emojiDir)
-	files, err := ioutil.ReadDir(fullPath)
-	if err != nil {
-		log.Errorln(err)
-		// Throw HTTP 500
-		return
-	}
-
-	// Memoize this result somewhere?  Right now it iterates through the
-	// filesystem every time the API is hit.  Should you need to restart
-	// the server to add emoji?
-	for _, f := range files {
-		name := strings.TrimSuffix(f.Name(), path.Ext(f.Name()))
-		emojiPath := filepath.Join(emojiDir, f.Name())
-		singleEmoji := models.CustomEmoji{Name: name, Emoji: emojiPath}
-		emojiList = append(emojiList, singleEmoji)
-	}
+	emojiList := getCustomEmojiList()
 
 	if err := json.NewEncoder(w).Encode(emojiList); err != nil {
 		InternalErrorHandler(w, err)

--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -30,7 +30,7 @@ func getCustomEmojiList() []models.CustomEmoji {
 		log.Errorln(err)
 	}
 	if emojiDirInfo.ModTime() != emojiCacheTimestamp {
-		log.Traceln("Emoji cache invalidated!")
+		log.Traceln("Emoji cache invalid")
 		emojiCache = make([]models.CustomEmoji, 0)
 	}
 

--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/models"
@@ -18,22 +20,33 @@ import (
 const emojiDir = "/img/emoji" // Relative to webroot
 
 var emojiCache = make([]models.CustomEmoji, 0)
+var emojiCacheTimestamp time.Time
 
 func getCustomEmojiList() []models.CustomEmoji {
+	fullPath := filepath.Join(config.WebRoot, emojiDir)
+	emojiDirInfo, err := os.Stat(fullPath)
+	if err != nil {
+		log.Errorln(err)
+	}
+	if emojiDirInfo.ModTime() != emojiCacheTimestamp {
+		log.Traceln("Emoji cache invalidated!")
+		emojiCache = make([]models.CustomEmoji, 0)
+	}
+
 	if len(emojiCache) == 0 {
-		fullPath := filepath.Join(config.WebRoot, emojiDir)
 		files, err := ioutil.ReadDir(fullPath)
 		if err != nil {
 			log.Errorln(err)
 			return emojiCache
 		}
-
 		for _, f := range files {
 			name := strings.TrimSuffix(f.Name(), path.Ext(f.Name()))
 			emojiPath := filepath.Join(emojiDir, f.Name())
 			singleEmoji := models.CustomEmoji{Name: name, Emoji: emojiPath}
 			emojiCache = append(emojiCache, singleEmoji)
 		}
+
+		emojiCacheTimestamp = emojiDirInfo.ModTime()
 	}
 
 	return emojiCache


### PR DESCRIPTION
We cache the emoji list and return it for the API calls. If the emoji directory’s modification time is not the same as the cache’s timestamp, we renew the cache.

PS: and the answer to [this comment](https://github.com/owncast/owncast/pull/108/commits/53b7bd77ad1ec5a3547cdc9e09893bfd6647f4c3#diff-db61f30213576cd7f03ff9fa695ce59656366854fa9b9dfa5e96e4c496857aadR31-R32) is: no! there is no need to restart the server after adding emojis :)