### PR TITLE
improve emoji cache timestamping

### DIFF
--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -40,14 +40,15 @@ func getCustomEmojiList() []models.CustomEmoji {
 			log.Errorln(err)
 			return emojiCache
 		}
+
+		emojiCacheTimestamp = emojiDirInfo.ModTime()
+
 		for _, f := range files {
 			name := strings.TrimSuffix(f.Name(), path.Ext(f.Name()))
 			emojiPath := filepath.Join(emojiDir, f.Name())
 			singleEmoji := models.CustomEmoji{Name: name, Emoji: emojiPath}
 			emojiCache = append(emojiCache, singleEmoji)
 		}
-
-		emojiCacheTimestamp = emojiDirInfo.ModTime()
 	}
 
 	return emojiCache


### PR DESCRIPTION
In the old version, if the content of the emoji directory was modified during the caching process, it was possible for the cache to get a wrong timestamp.