### PR TITLE
link assets under the same protocol for bots

### DIFF
--- a/controllers/index.go
+++ b/controllers/index.go
@@ -74,12 +74,17 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 // to give to Opengraph clients and web scrapers (bots, web crawlers, etc).
 func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	tmpl := template.Must(template.ParseFiles(path.Join("static", "metadata.html")))
+	protocol := "http"
 
-	fullURL, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, r.URL.Path))
+	if r.TLS != nil {
+		protocol = "https"
+	}
+
+	fullURL, err := url.Parse(fmt.Sprintf("%s://%s%s", protocol, r.Host, r.URL.Path))
 	if err != nil {
 		log.Panicln(err)
 	}
-	imageURL, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, "/logo"))
+	imageURL, err := url.Parse(fmt.Sprintf("%s://%s%s", protocol, r.Host, "/logo"))
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -89,7 +94,7 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	// If the thumbnail does not exist or we're offline then just use the logo image
 	var thumbnailURL string
 	if status.Online && utils.DoesFileExists(filepath.Join(config.WebRoot, "thumbnail.jpg")) {
-		thumbnail, err := url.Parse(fmt.Sprintf("http://%s%s", r.Host, "/thumbnail.jpg"))
+		thumbnail, err := url.Parse(fmt.Sprintf("%s://%s%s", protocol, r.Host, "/thumbnail.jpg"))
 		if err != nil {
 			log.Errorln(err)
 			thumbnailURL = imageURL.String()

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -74,17 +74,12 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 // to give to Opengraph clients and web scrapers (bots, web crawlers, etc).
 func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	tmpl := template.Must(template.ParseFiles(path.Join("static", "metadata.html")))
-	protocol := "http"
 
-	if r.TLS != nil {
-		protocol = "https"
-	}
-
-	fullURL, err := url.Parse(fmt.Sprintf("%s://%s%s", protocol, r.Host, r.URL.Path))
+	fullURL, err := url.Parse(fmt.Sprintf("//%s%s", r.Host, r.URL.Path))
 	if err != nil {
 		log.Panicln(err)
 	}
-	imageURL, err := url.Parse(fmt.Sprintf("%s://%s%s", protocol, r.Host, "/logo"))
+	imageURL, err := url.Parse(fmt.Sprintf("//%s%s", r.Host, "/logo"))
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -94,7 +89,7 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	// If the thumbnail does not exist or we're offline then just use the logo image
 	var thumbnailURL string
 	if status.Online && utils.DoesFileExists(filepath.Join(config.WebRoot, "thumbnail.jpg")) {
-		thumbnail, err := url.Parse(fmt.Sprintf("%s://%s%s", protocol, r.Host, "/thumbnail.jpg"))
+		thumbnail, err := url.Parse(fmt.Sprintf("//%s%s", r.Host, "/thumbnail.jpg"))
 		if err != nil {
 			log.Errorln(err)
 			thumbnailURL = imageURL.String()


### PR DESCRIPTION
When serving the page over a secure connection, the links should be also over the https.