### PR TITLE
Support text input of :emoji: in chat

### DIFF
--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -181,7 +181,7 @@ export default class ChatInput extends Component {
 
     if (textValue != convertToText(processedHTML)) {
       this.setState({
-        inputHTML: processedHTML
+        inputHTML: processedHTML,
       });
       return true;
     }
@@ -251,6 +251,7 @@ export default class ChatInput extends Component {
       }
     }
     this.setState({
+      inputText: textValue,
       inputCharsLeft: CHAT_MAX_MESSAGE_LENGTH - textValue.length,
     });
   }

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -193,8 +193,7 @@ export default class ChatInput extends Component {
       });
 
       if (emojiIndex != -1) {
-        const url = location.protocol + '//' + location.host + '/' + emojiList[emojiIndex].emoji;
-        const emojiImgElement = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" title="' + emojiList[emojiIndex].name + '" src="' + url + '"/>';
+        const emojiImgElement = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" title="' + emojiList[emojiIndex].name + '" src="' + emojiList[emojiIndex].emoji + '"/>';
 
         processedHTML = processedHTML.replace(":" + typedEmoji + ":", emojiImgElement)
         foundEmoji = true;

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -182,12 +182,12 @@ export default class ChatInput extends Component {
       return false;
     }
 
-    let typedEmoji = inputHTML.substring(at + 1, position).trim();
-    const emojiIndex = emojiList.findIndex(function (emojiItem) { return emojiItem.name === typedEmoji; });
+    const typedEmoji = textValue.substring(at + 1, position).trim();
+    const emojiIndex = emojiList.findIndex(function (emojiItem) { return emojiItem.name.toLowerCase() === typedEmoji.toLowerCase(); });
 
     if (emojiIndex != -1) {
       const url = location.protocol + '//' + location.host + '/' + emojiList[emojiIndex].emoji;
-      const emojiItem = '<img class="emoji" alt="' + typedEmoji + '" src="' + url + '"/>';
+      const emojiItem = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" src="' + url + '"/>';
 
       this.setState({
         inputHTML: inputHTML.replace(":" + typedEmoji, emojiItem)

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -180,12 +180,12 @@ export default class ChatInput extends Component {
     let processedHTML = inputHTML;
     for (var lastPos = textValue.length; lastPos >= 0; lastPos--) {
       const endPos = textValue.lastIndexOf(':', lastPos);
-      if (endPos === -1) {
+      if (endPos <= 0) {
         break;
       }
       const startPos = textValue.lastIndexOf(':', endPos - 1);
-      if (startPos === endPos) {
-        continue;
+      if (startPos === -1) {
+        break;
       }
       const typedEmoji = textValue.substring(startPos + 1, endPos).trim();
       const emojiIndex = emojiList.findIndex(function (emojiItem) {

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -8,6 +8,7 @@ import ContentEditable, { replaceCaret } from './content-editable.js';
 import {
   generatePlaceholderText,
   getCaretPosition,
+  getCaretCharacterOffsetWithin,
   convertToText,
   convertOnPaste,
   createEmojiMarkup,
@@ -176,7 +177,7 @@ export default class ChatInput extends Component {
   injectEmoji() {
     const { inputHTML, emojiList } = this.state;
     let textValue = this.formMessageInput.current.textContent;
-    const position = getCaretPosition(this.formMessageInput.current);
+    const position = getCaretCharacterOffsetWithin(this.formMessageInput.current);
     const at = textValue.lastIndexOf(':', position - 1);
     if (at === -1) {
       return false;

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -234,7 +234,7 @@ export default class ChatInput extends Component {
 
   handleMessageInputKeyup(event) {
     const formField = this.formMessageInput.current;
-    let textValue = formField.textContent; // get this only to count chars
+    const textValue = formField.textContent; // get this only to count chars
 
     const { key } = event;
 
@@ -245,13 +245,9 @@ export default class ChatInput extends Component {
       this.modifierKeyPressed = false;
     }
     if (key === ':' || key === ';') {
-      if (this.injectEmoji()) {
-        // value could have been changed, update char count
-        textValue = formField.textContent;
-      }
+      this.injectEmoji();
     }
     this.setState({
-      inputText: textValue,
       inputCharsLeft: CHAT_MAX_MESSAGE_LENGTH - textValue.length,
     });
   }

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -266,7 +266,7 @@ export default class ChatInput extends Component {
       event.preventDefault();
       return;
     }
-    convertOnPaste(event);
+    convertOnPaste(event, this.state.emojiList);
     this.handleMessageInputKeydown(event);
   }
 

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -11,6 +11,7 @@ import {
   convertToText,
   convertOnPaste,
   createEmojiMarkup,
+  emojify,
 } from '../../utils/chat.js';
 import {
   getLocalStorage,
@@ -175,35 +176,16 @@ export default class ChatInput extends Component {
   // replace :emoji: with the emoji <img>
   injectEmoji() {
     const { inputHTML, emojiList } = this.state;
-    let foundEmoji = false;
-    let textValue = this.formMessageInput.current.textContent;
-    let processedHTML = inputHTML;
-    for (var lastPos = textValue.length; lastPos >= 0; lastPos--) {
-      const endPos = textValue.lastIndexOf(':', lastPos);
-      if (endPos <= 0) {
-        break;
-      }
-      const startPos = textValue.lastIndexOf(':', endPos - 1);
-      if (startPos === -1) {
-        break;
-      }
-      const typedEmoji = textValue.substring(startPos + 1, endPos).trim();
-      const emojiIndex = emojiList.findIndex(function (emojiItem) {
-        return emojiItem.name.toLowerCase() === typedEmoji.toLowerCase();
+    const textValue = convertToText(inputHTML);
+    const processedHTML = emojify(inputHTML, emojiList);
+
+    if (textValue != convertToText(processedHTML)) {
+      this.setState({
+        inputHTML: processedHTML
       });
-
-      if (emojiIndex != -1) {
-        const emojiImgElement = createEmojiMarkup(emojiList[emojiIndex], true)
-
-        processedHTML = processedHTML.replace(":" + typedEmoji + ":", emojiImgElement)
-        foundEmoji = true;
-        textValue = this.formMessageInput.current.textContent;
-      }
+      return true;
     }
-    this.setState({
-      inputHTML: processedHTML
-    });
-    return foundEmoji;
+    return false;
   }
 
   handleMessageInputKeydown(event) {

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -175,8 +175,9 @@ export default class ChatInput extends Component {
   // replace :emoji: with the emoji <img>
   injectEmoji() {
     const { inputHTML, emojiList } = this.state;
+    let textValue = this.formMessageInput.current.textContent;
     const position = getCaretPosition(this.formMessageInput.current);
-    const at = inputHTML.lastIndexOf(':', position - 1);
+    const at = textValue.lastIndexOf(':', position - 1);
     if (at === -1) {
       return false;
     }
@@ -189,8 +190,7 @@ export default class ChatInput extends Component {
       const emojiItem = '<img class="emoji" alt="' + typedEmoji + '" src="' + url + '"/>';
 
       this.setState({
-        inputHTML:
-          inputHTML.substring(0, at) + emojiItem + inputHTML.substring(position),
+        inputHTML: inputHTML.replace(":" + typedEmoji, emojiItem)
       });
       return true;
     }

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -177,13 +177,13 @@ export default class ChatInput extends Component {
   injectEmoji() {
     const { inputHTML, emojiList } = this.state;
     const textValue = this.formMessageInput.current.textContent;
-    const position = getCaretCharacterOffsetWithin(this.formMessageInput.current);
-    const at = textValue.lastIndexOf(':', position - 1);
-    if (at === -1) {
+    const currentPos = getCaretCharacterOffsetWithin(this.formMessageInput.current);
+    const startPos = textValue.lastIndexOf(':', currentPos - 2);
+    if (startPos === -1) {
       return false;
     }
 
-    const typedEmoji = textValue.substring(at + 1, position).trim();
+    const typedEmoji = textValue.substring(startPos + 1, currentPos - 1).trim();
     const emojiIndex = emojiList.findIndex(function (emojiItem) {
       return emojiItem.name.toLowerCase() === typedEmoji.toLowerCase();
     });
@@ -193,7 +193,7 @@ export default class ChatInput extends Component {
       const emojiImgElement = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" title="' + emojiList[emojiIndex].name + '" src="' + url + '"/>';
 
       this.setState({
-        inputHTML: inputHTML.replace(":" + typedEmoji, emojiImgElement)
+        inputHTML: inputHTML.replace(":" + typedEmoji + ":", emojiImgElement)
       });
       return true;
     }
@@ -232,15 +232,6 @@ export default class ChatInput extends Component {
       }
     }
 
-    if (key === ':') {
-      if (this.injectEmoji()) {
-        event.preventDefault();
-        // value could have been changed, update char count
-        textValue = formField.textContent;
-        numCharsLeft = CHAT_MAX_MESSAGE_LENGTH - textValue.length;
-      }
-    }
-
     if (numCharsLeft <= 0 && !CHAT_OK_KEYCODES.includes(key)) {
       newStates.inputText = textValue;
       this.setState(newStates);
@@ -255,7 +246,7 @@ export default class ChatInput extends Component {
 
   handleMessageInputKeyup(event) {
     const formField = this.formMessageInput.current;
-    const textValue = formField.textContent; // get this only to count chars
+    let textValue = formField.textContent; // get this only to count chars
 
     const { key } = event;
 
@@ -264,6 +255,12 @@ export default class ChatInput extends Component {
     }
     if (CHAT_KEY_MODIFIERS.includes(key)) {
       this.modifierKeyPressed = false;
+    }
+    if (key === ':') {
+      if (this.injectEmoji()) {
+        // value could have been changed, update char count
+        textValue = formField.textContent;
+      }
     }
     this.setState({
       inputCharsLeft: CHAT_MAX_MESSAGE_LENGTH - textValue.length,

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -176,7 +176,7 @@ export default class ChatInput extends Component {
   // replace :emoji: with the emoji <img>
   injectEmoji() {
     const { inputHTML, emojiList } = this.state;
-    let textValue = this.formMessageInput.current.textContent;
+    const textValue = this.formMessageInput.current.textContent;
     const position = getCaretCharacterOffsetWithin(this.formMessageInput.current);
     const at = textValue.lastIndexOf(':', position - 1);
     if (at === -1) {
@@ -184,14 +184,16 @@ export default class ChatInput extends Component {
     }
 
     const typedEmoji = textValue.substring(at + 1, position).trim();
-    const emojiIndex = emojiList.findIndex(function (emojiItem) { return emojiItem.name.toLowerCase() === typedEmoji.toLowerCase(); });
+    const emojiIndex = emojiList.findIndex(function (emojiItem) {
+      return emojiItem.name.toLowerCase() === typedEmoji.toLowerCase();
+    });
 
     if (emojiIndex != -1) {
       const url = location.protocol + '//' + location.host + '/' + emojiList[emojiIndex].emoji;
-      const emojiItem = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" src="' + url + '"/>';
+      const emojiImgElement = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" title="' + emojiList[emojiIndex].name + '" src="' + url + '"/>';
 
       this.setState({
-        inputHTML: inputHTML.replace(":" + typedEmoji, emojiItem)
+        inputHTML: inputHTML.replace(":" + typedEmoji, emojiImgElement)
       });
       return true;
     }

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -263,7 +263,7 @@ export default class ChatInput extends Component {
     if (CHAT_KEY_MODIFIERS.includes(key)) {
       this.modifierKeyPressed = false;
     }
-    if (key === ':') {
+    if (key === ':' || key === ';') {
       if (this.injectEmoji()) {
         // value could have been changed, update char count
         textValue = formField.textContent;

--- a/webroot/js/components/chat/chat-input.js
+++ b/webroot/js/components/chat/chat-input.js
@@ -193,7 +193,7 @@ export default class ChatInput extends Component {
       });
 
       if (emojiIndex != -1) {
-        const emojiImgElement = '<img class="emoji" alt="' + emojiList[emojiIndex].name + '" title="' + emojiList[emojiIndex].name + '" src="' + emojiList[emojiIndex].emoji + '"/>';
+        const emojiImgElement = createEmojiMarkup(emojiList[emojiIndex], true)
 
         processedHTML = processedHTML.replace(":" + typedEmoji + ":", emojiImgElement)
         foundEmoji = true;

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -145,5 +145,5 @@ export function convertOnPaste( event = { preventDefault() {} }) {
 export function createEmojiMarkup(data, isCustom) {
   const emojiUrl = isCustom ? data.emoji : data.url;
   const emojiName = (isCustom ? data.name : data.url.split('\\').pop().split('/').pop().split('.').shift()).toLowerCase();
-  return '<img class="emoji" alt=":' + emojiName + ':" title=":' + emojiName + ':" src="' + emojiUrl + '"/>';
+  return '<img class="emoji" alt="' + emojiName + '" title="' + emojiName + '" src="' + emojiUrl + '"/>';
 }

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -31,31 +31,6 @@ export function getCaretPosition(editableDiv) {
 	return caretPos;
 }
 
-// from https://stackoverflow.com/questions/4811822/get-a-ranges-start-and-end-offsets-relative-to-its-parent-container/4812022#4812022
-export function getCaretCharacterOffsetWithin(element) {
-  var caretOffset = 0;
-  var doc = element.ownerDocument || element.document;
-  var win = doc.defaultView || doc.parentWindow;
-  var sel;
-  if (typeof win.getSelection != "undefined") {
-      sel = win.getSelection();
-      if (sel.rangeCount > 0) {
-          var range = win.getSelection().getRangeAt(0);
-          var preCaretRange = range.cloneRange();
-          preCaretRange.selectNodeContents(element);
-          preCaretRange.setEnd(range.endContainer, range.endOffset);
-          caretOffset = preCaretRange.toString().length;
-      }
-  } else if ( (sel = doc.selection) && sel.type != "Control") {
-      var textRange = sel.createRange();
-      var preCaretTextRange = doc.body.createTextRange();
-      preCaretTextRange.moveToElementText(element);
-      preCaretTextRange.setEndPoint("EndToEnd", textRange);
-      caretOffset = preCaretTextRange.text.length;
-    }
-    return caretOffset;
-}
-
 // Might not need this anymore
 // Pieced together from parts of https://stackoverflow.com/questions/6249095/how-to-set-caretcursor-position-in-contenteditable-element-div
 export function setCaretPosition(editableDiv, position) {

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -86,6 +86,9 @@ export function convertToText(str = '') {
   // Replace `<p>` (from IE).
   value = value.replace(/<p>/gi, '\n');
 
+  // Cleanup the emoji titles.
+  value = value.replace(/\u200C/gi, '');
+
   // Trim each line.
   value = value
     .split('\n')
@@ -147,7 +150,7 @@ export function convertOnPaste(event = { preventDefault() { } }, emojiList) {
 export function createEmojiMarkup(data, isCustom) {
   const emojiUrl = isCustom ? data.emoji : data.url;
   const emojiName = (isCustom ? data.name : data.url.split('\\').pop().split('/').pop().split('.').shift()).toLowerCase();
-  return '<img class="emoji" alt="' + emojiName + '" title="' + emojiName + '" src="' + emojiUrl + '"/>';
+  return '<img class="emoji" alt=":‌' + emojiName + '‌:" title=":‌' + emojiName + '‌:" src="' + emojiUrl + '"/>';
 }
 
 export function emojify(HTML, emojiList) {

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -87,7 +87,7 @@ export function convertToText(str = '') {
   value = value.replace(/<p>/gi, '\n');
 
   // Cleanup the emoji titles.
-  value = value.replace(/\u200C/gi, '');
+  value = value.replace(/\u200C{2}/gi, '');
 
   // Trim each line.
   value = value
@@ -150,7 +150,7 @@ export function convertOnPaste(event = { preventDefault() { } }, emojiList) {
 export function createEmojiMarkup(data, isCustom) {
   const emojiUrl = isCustom ? data.emoji : data.url;
   const emojiName = (isCustom ? data.name : data.url.split('\\').pop().split('/').pop().split('.').shift()).toLowerCase();
-  return '<img class="emoji" alt=":‌' + emojiName + '‌:" title=":‌' + emojiName + '‌:" src="' + emojiUrl + '"/>';
+  return '<img class="emoji" alt=":‌‌' + emojiName + '‌‌:" title=":‌‌' + emojiName + '‌‌:" src="' + emojiUrl + '"/>';
 }
 
 export function emojify(HTML, emojiList) {

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -7,41 +7,41 @@ import {
 
 // Taken from https://stackoverflow.com/questions/3972014/get-contenteditable-caret-index-position
 export function getCaretPosition(editableDiv) {
-	var caretPos = 0,
-		sel, range;
-	if (window.getSelection) {
-		sel = window.getSelection();
-		if (sel.rangeCount) {
-			range = sel.getRangeAt(0);
-			if (range.commonAncestorContainer.parentNode == editableDiv) {
-				caretPos = range.endOffset;
-			}
-		}
-	} else if (document.selection && document.selection.createRange) {
-		range = document.selection.createRange();
-		if (range.parentElement() == editableDiv) {
-			var tempEl = document.createElement("span");
-			editableDiv.insertBefore(tempEl, editableDiv.firstChild);
-			var tempRange = range.duplicate();
-			tempRange.moveToElementText(tempEl);
-			tempRange.setEndPoint("EndToEnd", range);
-			caretPos = tempRange.text.length;
-		}
-	}
-	return caretPos;
+  var caretPos = 0,
+    sel, range;
+  if (window.getSelection) {
+    sel = window.getSelection();
+    if (sel.rangeCount) {
+      range = sel.getRangeAt(0);
+      if (range.commonAncestorContainer.parentNode == editableDiv) {
+        caretPos = range.endOffset;
+      }
+    }
+  } else if (document.selection && document.selection.createRange) {
+    range = document.selection.createRange();
+    if (range.parentElement() == editableDiv) {
+      var tempEl = document.createElement("span");
+      editableDiv.insertBefore(tempEl, editableDiv.firstChild);
+      var tempRange = range.duplicate();
+      tempRange.moveToElementText(tempEl);
+      tempRange.setEndPoint("EndToEnd", range);
+      caretPos = tempRange.text.length;
+    }
+  }
+  return caretPos;
 }
 
 // Might not need this anymore
 // Pieced together from parts of https://stackoverflow.com/questions/6249095/how-to-set-caretcursor-position-in-contenteditable-element-div
 export function setCaretPosition(editableDiv, position) {
-	var range = document.createRange();
-	var sel = window.getSelection();
-	range.selectNode(editableDiv);
-	range.setStart(editableDiv.childNodes[0], position);
-	range.collapse(true);
+  var range = document.createRange();
+  var sel = window.getSelection();
+  range.selectNode(editableDiv);
+  range.setStart(editableDiv.childNodes[0], position);
+  range.collapse(true);
 
-	sel.removeAllRanges();
-	sel.addRange(range);
+  sel.removeAllRanges();
+  sel.addRange(range);
 }
 
 
@@ -55,7 +55,7 @@ export function generatePlaceholderText(isEnabled, hasSentFirstChatMessage) {
 export function extraUserNamesFromMessageHistory(messages) {
   const list = [];
   if (messages) {
-    messages.forEach(function(message) {
+    messages.forEach(function (message) {
       if (!list.includes(message.user.displayName)) {
         list.push(message.user.displayName);
       }
@@ -109,7 +109,7 @@ export function convertToText(str = '') {
   You would call this when a user pastes from
   the clipboard into a `contenteditable` area.
 */
-export function convertOnPaste( event = { preventDefault() {} }) {
+export function convertOnPaste(event = { preventDefault() { } }) {
   // Prevent paste.
   event.preventDefault();
 
@@ -146,4 +146,30 @@ export function createEmojiMarkup(data, isCustom) {
   const emojiUrl = isCustom ? data.emoji : data.url;
   const emojiName = (isCustom ? data.name : data.url.split('\\').pop().split('/').pop().split('.').shift()).toLowerCase();
   return '<img class="emoji" alt="' + emojiName + '" title="' + emojiName + '" src="' + emojiUrl + '"/>';
+}
+
+export function emojify(HTML, emojiList) {
+  const textValue = convertToText(HTML)
+
+  for (var lastPos = textValue.length; lastPos >= 0; lastPos--) {
+    const endPos = textValue.lastIndexOf(':', lastPos);
+    if (endPos <= 0) {
+      break;
+    }
+    const startPos = textValue.lastIndexOf(':', endPos - 1);
+    if (startPos === -1) {
+      break;
+    }
+    const typedEmoji = textValue.substring(startPos + 1, endPos).trim();
+    const emojiIndex = emojiList.findIndex(function (emojiItem) {
+      return emojiItem.name.toLowerCase() === typedEmoji.toLowerCase();
+    });
+
+    if (emojiIndex != -1) {
+      const emojiImgElement = createEmojiMarkup(emojiList[emojiIndex], true)
+      HTML = HTML.replace(":" + typedEmoji + ":", emojiImgElement)
+    }
+  }
+  return HTML;
+
 }

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -31,6 +31,31 @@ export function getCaretPosition(editableDiv) {
 	return caretPos;
 }
 
+// from https://stackoverflow.com/questions/4811822/get-a-ranges-start-and-end-offsets-relative-to-its-parent-container/4812022#4812022
+export function getCaretCharacterOffsetWithin(element) {
+  var caretOffset = 0;
+  var doc = element.ownerDocument || element.document;
+  var win = doc.defaultView || doc.parentWindow;
+  var sel;
+  if (typeof win.getSelection != "undefined") {
+      sel = win.getSelection();
+      if (sel.rangeCount > 0) {
+          var range = win.getSelection().getRangeAt(0);
+          var preCaretRange = range.cloneRange();
+          preCaretRange.selectNodeContents(element);
+          preCaretRange.setEnd(range.endContainer, range.endOffset);
+          caretOffset = preCaretRange.toString().length;
+      }
+  } else if ( (sel = doc.selection) && sel.type != "Control") {
+      var textRange = sel.createRange();
+      var preCaretTextRange = doc.body.createTextRange();
+      preCaretTextRange.moveToElementText(element);
+      preCaretTextRange.setEndPoint("EndToEnd", textRange);
+      caretOffset = preCaretTextRange.text.length;
+    }
+    return caretOffset;
+}
+
 // Might not need this anymore
 // Pieced together from parts of https://stackoverflow.com/questions/6249095/how-to-set-caretcursor-position-in-contenteditable-element-div
 export function setCaretPosition(editableDiv, position) {

--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -109,7 +109,7 @@ export function convertToText(str = '') {
   You would call this when a user pastes from
   the clipboard into a `contenteditable` area.
 */
-export function convertOnPaste(event = { preventDefault() { } }) {
+export function convertOnPaste(event = { preventDefault() { } }, emojiList) {
   // Prevent paste.
   event.preventDefault();
 
@@ -136,9 +136,11 @@ export function convertOnPaste(event = { preventDefault() { } }) {
   // Clean up text.
   value = convertToText(value);
 
+  const HTML = emojify(value, emojiList);
+
   // Insert text.
   if (typeof document.execCommand === 'function') {
-    document.execCommand('insertText', false, value);
+    document.execCommand('insertHTML', false, HTML);
   }
 }
 


### PR DESCRIPTION
Replaces the typed `:emoji:` in the chat on client-side with the emoji `<img>`. Only the valid emoji names get replaced [+bonus point!]. Emoji name lookup is case-insensitive. Supports pasting text with `:emoji:` in it (you can paste `This is a :portalparrot:!` and it will be rendered). Copy-pasting of the rendered emoji is also supported! [+extra bonus point! 😉]

closes #480

