### PR TITLE
Override default protocol if one is set in settings

### DIFF
--- a/controllers/index.go
+++ b/controllers/index.go
@@ -97,7 +97,7 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	// If the thumbnail does not exist or we're offline then just use the logo image
 	var thumbnailURL string
 	if status.Online && utils.DoesFileExists(filepath.Join(config.WebRoot, "thumbnail.jpg")) {
-		thumbnail, err := url.Parse(fmt.Sprintf("//%s%s", r.Host, "/thumbnail.jpg"))
+		thumbnail, err := url.Parse(fmt.Sprintf("%s//%s%s", scheme, r.Host, "/thumbnail.jpg"))
 		if err != nil {
 			log.Errorln(err)
 			thumbnailURL = imageURL.String()

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -75,11 +75,19 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 	tmpl := template.Must(template.ParseFiles(path.Join("static", "metadata.html")))
 
-	fullURL, err := url.Parse(fmt.Sprintf("//%s%s", r.Host, r.URL.Path))
+	scheme := "http"
+
+	if siteUrl := data.GetServerURL(); siteUrl != "" {
+		if parsed, err := url.Parse(siteUrl); err == nil && parsed.Scheme != "" {
+			scheme = parsed.Scheme
+		}
+	}
+
+	fullURL, err := url.Parse(fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL.Path))
 	if err != nil {
 		log.Panicln(err)
 	}
-	imageURL, err := url.Parse(fmt.Sprintf("//%s%s", r.Host, "/logo"))
+	imageURL, err := url.Parse(fmt.Sprintf("%s://%s%s", scheme, r.Host, "/logo"))
 	if err != nil {
 		log.Panicln(err)
 	}


### PR DESCRIPTION
This continues the discussion from https://github.com/owncast/owncast/pull/1187.

It restores the default protocol to `http` but overrides it if one is set in the server settings.  This is probably a good middle ground.

Closes #1225 

@jeyemwey @MFTabriz 