### PR TITLE
Allow alt and title tags in chat emojis

### DIFF
--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -140,7 +140,8 @@ func sanitize(raw string) string {
 
 	// Allow img tags from the the local emoji directory only
 	p.AllowAttrs("src").Matching(regexp.MustCompile(`(?i)/img/emoji`)).OnElements("img")
-	p.AllowAttrs("class", "alt", "title").OnElements("img")
+	p.AllowAttrs("alt", "title").Matching(regexp.MustCompile(`:\S+:`)).OnElements("img")
+	p.AllowAttrs("class").OnElements("img")
 
 	// Allow bold
 	p.AllowElements("strong")

--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -139,8 +139,8 @@ func sanitize(raw string) string {
 	p.AllowElements("br", "p")
 
 	// Allow img tags from the the local emoji directory only
-	p.AllowAttrs("src", "alt", "class", "title").Matching(regexp.MustCompile(`(?i)/img/emoji`)).OnElements("img")
-	p.AllowAttrs("class").OnElements("img")
+	p.AllowAttrs("src").Matching(regexp.MustCompile(`(?i)/img/emoji`)).OnElements("img")
+	p.AllowAttrs("class", "alt", "title").OnElements("img")
 
 	// Allow bold
 	p.AllowElements("strong")


### PR DESCRIPTION
Users can now copy-paste the posted chat messages with emoji in them.
closes #1202