### PR TITLE
Prevent remote image injection with /img/emoji/ in url

### DIFF
--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -139,7 +139,7 @@ func sanitize(raw string) string {
 	p.AllowElements("br", "p")
 
 	// Allow img tags from the the local emoji directory only
-	p.AllowAttrs("src").Matching(regexp.MustCompile(`(?i)/img/emoji`)).OnElements("img")
+	p.AllowAttrs("src").Matching(regexp.MustCompile(`(?i)^/img/emoji`)).OnElements("img")
 	p.AllowAttrs("alt", "title").Matching(regexp.MustCompile(`:\S+:`)).OnElements("img")
 	p.AllowAttrs("class").OnElements("img")
 

--- a/core/chat/messageRendering_test.go
+++ b/core/chat/messageRendering_test.go
@@ -33,7 +33,7 @@ blah blah blah
 
 // Test to make sure we block remote images in chat messages.
 func TestBlockRemoteImages(t *testing.T) {
-	messageContent := `<img src="https://via.placeholder.com/350x150"> test ![](https://via.placeholder.com/350x150)`
+	messageContent := `<img src="https://via.placeholder.com/img/emoji/350x150"> test ![](https://via.placeholder.com/img/emoji/350x150)`
 	expected := `<p> test </p>`
 	result := events.RenderAndSanitize(messageContent)
 


### PR DESCRIPTION
Remote images with `/img/emoji/` in their url were not being filtered properly. Added a test [4fc5528] (which failed) and patched it [9785b04].