### PR TITLE
Don't specify the linter version, as it's not required any longer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.31
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=0
           # Optional: working directory, useful for monorepos


### PR DESCRIPTION
This will always use the latest release of golangci-lint.