### PR TITLE
Prevent sending empty messages

### DIFF
--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -73,7 +73,7 @@ func (m *MessageEvent) RenderAndSanitizeMessageBody() {
 
 // Empty will return if this message's contents is empty.
 func (m *MessageEvent) Empty() bool {
-	return m.Body == ""
+	return m.Body == "" || m.Body == "<p></p>"
 }
 
 // RenderBody will render markdown to html without any sanitization.


### PR DESCRIPTION
The patch can be tested by sending a markdown image with external source.
closes #1263

