### PR TITLE
Fix status code for options requests

### DIFF
--- a/router/middleware/auth.go
+++ b/router/middleware/auth.go
@@ -28,9 +28,9 @@ func RequireAdminAuth(handler http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 
-		// For request needing CORS, send a 200.
+		// For request needing CORS, send a 204.
 		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 
@@ -60,7 +60,7 @@ func RequireExternalAPIAccessToken(scope string, handler ExternalAccessTokenHand
 		if r.Method == "OPTIONS" {
 			// All OPTIONS requests should have a wildcard CORS header.
 			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 

--- a/test/automated/integrations.test.js
+++ b/test/automated/integrations.test.js
@@ -142,7 +142,7 @@ test('test fetch chat history OPTIONS request', async (done) => {
     const res = await request
         .options('/api/integrations/chat')
         .set('Authorization', 'Bearer ' + accessToken)
-        .expect(200);
+        .expect(204);
     done();
 });
 


### PR DESCRIPTION
This PR fixes the HTTP status code sent by owncast upon receiving OPTIONS requests.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS), OPTIONS requests expect the 204 No Content status code instead of 200 OK.

The integration unit test has also been updated to reflect this change.