### PR TITLE
set max 10 retries for videojs playlist

### DIFF
--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -26,6 +26,7 @@ const VIDEO_OPTIONS = {
       // used to select the lowest bitrate playlist initially. This helps to decrease playback start time. This setting is false by default.
       enableLowInitialPlaylist: true,
       experimentalBufferBasedABR: true,
+      maxPlaylistRetries: 10,
     },
   },
   liveTracker: {


### PR DESCRIPTION
for #1335

10 seems like a reasonable number but I chose it pretty arbitrarily. This makes the infinite loop stop after about 10-15 seconds.