### PR TITLE
Feature/oc 1316 add support for system message to single user

### DIFF
--- a/controllers/admin/chat.go
+++ b/controllers/admin/chat.go
@@ -128,15 +128,16 @@ func SendSystemMessage(integration user.ExternalAPIUser, w http.ResponseWriter, 
 	controllers.WriteSimpleResponse(w, true, "sent")
 }
 
+// SendSystemMessageToConnectedClient will handle incoming requests to send a single message to a single connected client by ID.
 func SendSystemMessageToConnectedClient(integration user.ExternalAPIUser, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	clientIdText, err := utils.ReadRestUrlParameter(r, "clientId")
+	clientIDText, err := utils.ReadRestURLParameter(r, "clientId")
 	if err != nil {
 		controllers.BadRequestHandler(w, err)
 		return
 	}
 
-	clientIdNumeric, err := strconv.ParseUint(clientIdText, 10, 32)
+	clientIDNumeric, err := strconv.ParseUint(clientIDText, 10, 32)
 	if err != nil {
 		controllers.BadRequestHandler(w, err)
 		return
@@ -148,7 +149,7 @@ func SendSystemMessageToConnectedClient(integration user.ExternalAPIUser, w http
 		return
 	}
 
-	chat.SendSystemMessageToClient(uint(clientIdNumeric), message.Body)
+	chat.SendSystemMessageToClient(uint(clientIDNumeric), message.Body)
 	controllers.WriteSimpleResponse(w, true, "sent")
 }
 

--- a/controllers/admin/chat.go
+++ b/controllers/admin/chat.go
@@ -150,7 +150,6 @@ func SendSystemMessageToConnectedClient(integration user.ExternalAPIUser, w http
 
 	chat.SendSystemMessageToClient(uint(clientIdNumeric), message.Body)
 	controllers.WriteSimpleResponse(w, true, "sent")
-
 }
 
 // SendUserMessage will send a message to chat on behalf of a user. *Depreciated*.

--- a/controllers/admin/chat.go
+++ b/controllers/admin/chat.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/owncast/owncast/controllers"
 	"github.com/owncast/owncast/core/chat"
 	"github.com/owncast/owncast/core/chat/events"
 	"github.com/owncast/owncast/core/user"
+	"github.com/owncast/owncast/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -130,8 +130,15 @@ func SendSystemMessage(integration user.ExternalAPIUser, w http.ResponseWriter, 
 
 func SendSystemMessageToConnectedClient(integration user.ExternalAPIUser, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	clientId, err := strconv.ParseUint(r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:], 10, 64)
+	clientIdText, err := utils.ReadRestUrlParameter(r, "clientId")
 	if err != nil {
+		controllers.BadRequestHandler(w, err)
+		return
+	}
+
+	clientIdNumeric, err := strconv.ParseUint(clientIdText, 10, 64)
+	if err != nil {
+		controllers.BadRequestHandler(w, err)
 		return
 	}
 
@@ -141,7 +148,7 @@ func SendSystemMessageToConnectedClient(integration user.ExternalAPIUser, w http
 		return
 	}
 
-	chat.SendSystemMessageToClient(uint(clientId), message.Body)
+	chat.SendSystemMessageToClient(uint(clientIdNumeric), message.Body)
 	controllers.WriteSimpleResponse(w, true, "sent")
 
 }

--- a/controllers/admin/chat.go
+++ b/controllers/admin/chat.go
@@ -136,7 +136,7 @@ func SendSystemMessageToConnectedClient(integration user.ExternalAPIUser, w http
 		return
 	}
 
-	clientIdNumeric, err := strconv.ParseUint(clientIdText, 10, 64)
+	clientIdNumeric, err := strconv.ParseUint(clientIdText, 10, 32)
 	if err != nil {
 		controllers.BadRequestHandler(w, err)
 		return

--- a/core/chat/chat.go
+++ b/core/chat/chat.go
@@ -41,6 +41,12 @@ func GetClientsForUser(userID string) ([]*Client, error) {
 	return clients[userID], nil
 }
 
+// FindClientByID will return a single connected client by ID.
+func FindClientByID(clientID uint) (*Client, bool) {
+	client, found := _server.clients[clientID]
+	return client, found
+}
+
 // GetClients will return all the current chat clients connected.
 func GetClients() []*Client {
 	clients := []*Client{}

--- a/core/chat/chat.go
+++ b/core/chat/chat.go
@@ -111,6 +111,13 @@ func SendAllWelcomeMessage() {
 	_server.sendAllWelcomeMessage()
 }
 
+// SendSystemMessageToClient will send a single message to a single connected chat client.
+func SendSystemMessageToClient(clientID uint, text string) {
+	if client, foundClient := FindClientByID(clientID); foundClient {
+		_server.sendSystemMessageToClient(client, text)
+	}
+}
+
 // Broadcast will send all connected clients the outbound object provided.
 func Broadcast(event events.OutboundEvent) error {
 	return _server.Broadcast(event.GetBroadcastPayload())

--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -66,7 +66,7 @@ func (s *Server) userNameChanged(eventData chatClientEvent) {
 
 	// Send chat user name changed webhook
 	receivedEvent.User = savedUser
-	receivedEvent.ClientId = eventData.client.id
+	receivedEvent.ClientID = eventData.client.id
 	webhooks.SendChatEventUsernameChanged(receivedEvent)
 }
 
@@ -78,7 +78,7 @@ func (s *Server) userMessageSent(eventData chatClientEvent) {
 	}
 
 	event.SetDefaults()
-	event.ClientId = eventData.client.id
+	event.ClientID = eventData.client.id
 
 	// Ignore empty messages
 	if event.Empty() {

--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -66,6 +66,7 @@ func (s *Server) userNameChanged(eventData chatClientEvent) {
 
 	// Send chat user name changed webhook
 	receivedEvent.User = savedUser
+	receivedEvent.ClientId = eventData.client.id
 	webhooks.SendChatEventUsernameChanged(receivedEvent)
 }
 
@@ -77,6 +78,7 @@ func (s *Server) userMessageSent(eventData chatClientEvent) {
 	}
 
 	event.SetDefaults()
+	event.ClientId = eventData.client.id
 
 	// Ignore empty messages
 	if event.Empty() {

--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -36,7 +36,7 @@ type Event struct {
 // UserEvent is an event with an associated user.
 type UserEvent struct {
 	User     *user.User `json:"user"`
-	ClientId uint       `json:"clientId"`
+	ClientID uint       `json:"clientId"`
 	HiddenAt *time.Time `json:"hiddenAt,omitempty"`
 }
 

--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -36,6 +36,7 @@ type Event struct {
 // UserEvent is an event with an associated user.
 type UserEvent struct {
 	User     *user.User `json:"user"`
+	ClientId uint       `json:"clientId"`
 	HiddenAt *time.Time `json:"hiddenAt,omitempty"`
 }
 

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -319,6 +319,7 @@ func (s *Server) sendSystemMessageToClient(c *Client, message string) {
 		},
 	}
 	clientMessage.SetDefaults()
+	clientMessage.RenderBody()
 	s.Send(clientMessage.GetBroadcastPayload(), c)
 }
 

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -246,7 +246,6 @@ func (s *Server) DisconnectUser(userID string) {
 		go func(client *Client) {
 			event := events.UserDisabledEvent{}
 			event.SetDefaults()
-			event.ClientId = client.id
 
 			// Send this disabled event specifically to this single connected client
 			// to let them know they've been banned.

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -115,6 +115,7 @@ func (s *Server) sendUserJoinedMessage(c *Client) {
 	userJoinedEvent := events.UserJoinedEvent{}
 	userJoinedEvent.SetDefaults()
 	userJoinedEvent.User = c.User
+	userJoinedEvent.ClientId = c.id
 
 	if err := s.Broadcast(userJoinedEvent.GetBroadcastPayload()); err != nil {
 		log.Errorln("error adding client to chat server", err)
@@ -245,6 +246,7 @@ func (s *Server) DisconnectUser(userID string) {
 		go func(client *Client) {
 			event := events.UserDisabledEvent{}
 			event.SetDefaults()
+			event.ClientId = client.id
 
 			// Send this disabled event specifically to this single connected client
 			// to let them know they've been banned.

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -115,7 +115,7 @@ func (s *Server) sendUserJoinedMessage(c *Client) {
 	userJoinedEvent := events.UserJoinedEvent{}
 	userJoinedEvent.SetDefaults()
 	userJoinedEvent.User = c.User
-	userJoinedEvent.ClientId = c.id
+	userJoinedEvent.ClientID = c.id
 
 	if err := s.Broadcast(userJoinedEvent.GetBroadcastPayload()); err != nil {
 		log.Errorln("error adding client to chat server", err)

--- a/core/webhooks/chat.go
+++ b/core/webhooks/chat.go
@@ -12,7 +12,7 @@ func SendChatEvent(chatEvent *events.UserMessageEvent) {
 		EventData: &WebhookChatMessage{
 			User:      chatEvent.User,
 			Body:      chatEvent.Body,
-			ClientId:  chatEvent.ClientID,
+			ClientID:  chatEvent.ClientID,
 			RawBody:   chatEvent.RawBody,
 			ID:        chatEvent.ID,
 			Visible:   chatEvent.HiddenAt == nil,

--- a/core/webhooks/chat.go
+++ b/core/webhooks/chat.go
@@ -12,6 +12,7 @@ func SendChatEvent(chatEvent *events.UserMessageEvent) {
 		EventData: &WebhookChatMessage{
 			User:      chatEvent.User,
 			Body:      chatEvent.Body,
+			ClientId:  chatEvent.ClientId,
 			RawBody:   chatEvent.RawBody,
 			ID:        chatEvent.ID,
 			Visible:   chatEvent.HiddenAt == nil,

--- a/core/webhooks/chat.go
+++ b/core/webhooks/chat.go
@@ -12,7 +12,7 @@ func SendChatEvent(chatEvent *events.UserMessageEvent) {
 		EventData: &WebhookChatMessage{
 			User:      chatEvent.User,
 			Body:      chatEvent.Body,
-			ClientId:  chatEvent.ClientId,
+			ClientId:  chatEvent.ClientID,
 			RawBody:   chatEvent.RawBody,
 			ID:        chatEvent.ID,
 			Visible:   chatEvent.HiddenAt == nil,

--- a/core/webhooks/webhooks.go
+++ b/core/webhooks/webhooks.go
@@ -23,7 +23,7 @@ type WebhookEvent struct {
 // WebhookChatMessage represents a single chat message sent as a webhook payload.
 type WebhookChatMessage struct {
 	User      *user.User `json:"user,omitempty"`
-	ClientId  uint       `json:"clientId,omitempty"`
+	ClientID  uint       `json:"clientId,omitempty"`
 	Body      string     `json:"body,omitempty"`
 	RawBody   string     `json:"rawBody,omitempty"`
 	ID        string     `json:"id,omitempty"`

--- a/core/webhooks/webhooks.go
+++ b/core/webhooks/webhooks.go
@@ -23,6 +23,7 @@ type WebhookEvent struct {
 // WebhookChatMessage represents a single chat message sent as a webhook payload.
 type WebhookChatMessage struct {
 	User      *user.User `json:"user,omitempty"`
+	ClientId  uint       `json:"clientId,omitempty"`
 	Body      string     `json:"body,omitempty"`
 	RawBody   string     `json:"rawBody,omitempty"`
 	ID        string     `json:"id,omitempty"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1398,6 +1398,58 @@ paths:
                     type: string
                     example: sent
 
+  /api/integrations/chat/system/client/{clientId}:
+    post:
+      summary: Send system chat message to a client, identified by its ClientId
+      description: Send a chat message on behalf of the system/server to a single client.
+      tags: ["Integrations"]
+      security:
+        - AccessToken: []
+      parameters:
+        - name: clientId
+          in: path
+          description: Client ID (a unique numeric Id, identifying the client connection)
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - "body"
+              properties:
+                body:
+                  type: string
+                  description: The message text that will be sent to the client.
+                  example: "What a beautiful day. I love it"
+      responses:
+        "200":
+          description: Message was sent.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  messages:
+                    type: string
+                    example: sent
+        "500":
+          description: Message was not sent to the client
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: 
+                    type: string
+                    description: message explaining what went wrong sending the message to the client
 
   /api/admin/accesstokens/create:
     post:

--- a/router/router.go
+++ b/router/router.go
@@ -22,7 +22,6 @@ func Start() error {
 	// static files
 	http.HandleFunc("/", controllers.IndexHandler)
 
-	http.HandleFunc()
 	// admin static files
 	http.HandleFunc("/admin/", middleware.RequireAdminAuth(admin.ServeAdmin))
 

--- a/router/router.go
+++ b/router/router.go
@@ -160,6 +160,9 @@ func Start() error {
 	// Send a system message to chat
 	http.HandleFunc("/api/integrations/chat/system", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendSystemMessages, admin.SendSystemMessage))
 
+	// Send a system message to a single client
+	http.HandleFunc("/api/integrations/chat/system/client/", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendSystemMessages, admin.SendSystemMessageToConnectedClient))
+
 	// Send a user message to chat *NO LONGER SUPPORTED
 	http.HandleFunc("/api/integrations/chat/user", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendChatMessages, admin.SendUserMessage))
 

--- a/router/router.go
+++ b/router/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/owncast/owncast/core/chat"
 	"github.com/owncast/owncast/core/user"
 	"github.com/owncast/owncast/router/middleware"
+	"github.com/owncast/owncast/utils"
 	"github.com/owncast/owncast/yp"
 )
 
@@ -21,6 +22,7 @@ func Start() error {
 	// static files
 	http.HandleFunc("/", controllers.IndexHandler)
 
+	http.HandleFunc()
 	// admin static files
 	http.HandleFunc("/admin/", middleware.RequireAdminAuth(admin.ServeAdmin))
 
@@ -161,7 +163,7 @@ func Start() error {
 	http.HandleFunc("/api/integrations/chat/system", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendSystemMessages, admin.SendSystemMessage))
 
 	// Send a system message to a single client
-	http.HandleFunc("/api/integrations/chat/system/client/", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendSystemMessages, admin.SendSystemMessageToConnectedClient))
+	http.HandleFunc(utils.RestEndpoint("/api/integrations/chat/system/client/{clientId}", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendSystemMessages, admin.SendSystemMessageToConnectedClient)))
 
 	// Send a user message to chat *NO LONGER SUPPORTED
 	http.HandleFunc("/api/integrations/chat/user", middleware.RequireExternalAPIAccessToken(user.ScopeCanSendChatMessages, admin.SendUserMessage))

--- a/utils/restendpointhelper.go
+++ b/utils/restendpointhelper.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const restUrlPatternHeaderKey string = "Owncast-Resturl-Pattern"
+const restUrlPatternHeaderKey = "Owncast-Resturl-Pattern"
 
 // takes the segment pattern of an Url string and returns the segment before the first dynamic REST parameter.
 func getPatternForRestEndpoint(pattern string) string {

--- a/utils/restendpointhelper.go
+++ b/utils/restendpointhelper.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 )
@@ -50,7 +49,6 @@ func readParameter(pattern string, requestUrl string, paramName string) (string,
 
 func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error) {
 	pattern, found := r.Header["OWNCAST-RESTURL-PATTERN"]
-	log.Print(r.Header)
 	if !found {
 		return "", errors.New(fmt.Sprintf("This HandlerFunc is not marked as REST-Endpoint. Cannot read Parameter '%s' from Request", parameterName))
 	}
@@ -62,7 +60,6 @@ func RestEndpoint(pattern string, handler http.HandlerFunc) (string, http.Handle
 	baseUrl := getPatternForRestEndpoint(pattern)
 	return baseUrl, func(w http.ResponseWriter, r *http.Request) {
 		r.Header["OWNCAST-RESTURL-PATTERN"] = []string{pattern}
-		log.Print(r.Header)
 		handler(w, r)
 	}
 }

--- a/utils/restendpointhelper.go
+++ b/utils/restendpointhelper.go
@@ -45,7 +45,7 @@ func readParameter(pattern string, requestUrl string, paramName string) (string,
 	if value, exists := all[fmt.Sprintf("{%s}", paramName)]; exists {
 		return value, nil
 	}
-	return "", errors.New(fmt.Sprintf("Paramater with name %s not found", paramName))
+	return "", errors.New(fmt.Sprintf("Parameter with name %s not found", paramName))
 }
 
 func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error) {

--- a/utils/restendpointhelper.go
+++ b/utils/restendpointhelper.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const restUrlPatternHeaderKey = "Owncast-Resturl-Pattern"
+const restURLPatternHeaderKey = "Owncast-Resturl-Pattern"
 
 // takes the segment pattern of an Url string and returns the segment before the first dynamic REST parameter.
 func getPatternForRestEndpoint(pattern string) string {
@@ -27,18 +27,18 @@ func zip2D(iterable1 *[]string, iterable2 *[]string) map[string]string {
 	return dict
 }
 
-func mapPatternWithRequestUrl(pattern string, requestUrl string) (map[string]string, error) {
+func mapPatternWithRequestURL(pattern string, requestURL string) (map[string]string, error) {
 	patternSplit := strings.Split(pattern, "/")
-	requestUrlSplit := strings.Split(requestUrl, "/")
+	requestURLSplit := strings.Split(requestURL, "/")
 
-	if len(patternSplit) == len(requestUrlSplit) {
-		return zip2D(&patternSplit, &requestUrlSplit), nil
+	if len(patternSplit) == len(requestURLSplit) {
+		return zip2D(&patternSplit, &requestURLSplit), nil
 	}
 	return nil, errors.New("The length of pattern and request Url does not match")
 }
 
-func readParameter(pattern string, requestUrl string, paramName string) (string, error) {
-	all, err := mapPatternWithRequestUrl(pattern, requestUrl)
+func readParameter(pattern string, requestURL string, paramName string) (string, error) {
+	all, err := mapPatternWithRequestURL(pattern, requestURL)
 	if err != nil {
 		return "", err
 	}
@@ -49,8 +49,9 @@ func readParameter(pattern string, requestUrl string, paramName string) (string,
 	return "", fmt.Errorf("Parameter with name %s not found", paramName)
 }
 
-func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error) {
-	pattern, found := r.Header[restUrlPatternHeaderKey]
+// ReadRestURLParameter will return the parameter from the request of the requested name.
+func ReadRestURLParameter(r *http.Request, parameterName string) (string, error) {
+	pattern, found := r.Header[restURLPatternHeaderKey]
 	if !found {
 		return "", fmt.Errorf("This HandlerFunc is not marked as REST-Endpoint. Cannot read Parameter '%s' from Request", parameterName)
 	}
@@ -58,10 +59,11 @@ func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error)
 	return readParameter(pattern[0], r.URL.Path, parameterName)
 }
 
+// RestEndpoint wraps a handler to use the rest endpoint helper.
 func RestEndpoint(pattern string, handler http.HandlerFunc) (string, http.HandlerFunc) {
-	baseUrl := getPatternForRestEndpoint(pattern)
-	return baseUrl, func(w http.ResponseWriter, r *http.Request) {
-		r.Header[restUrlPatternHeaderKey] = []string{pattern}
+	baseURL := getPatternForRestEndpoint(pattern)
+	return baseURL, func(w http.ResponseWriter, r *http.Request) {
+		r.Header[restURLPatternHeaderKey] = []string{pattern}
 		handler(w, r)
 	}
 }

--- a/utils/restendpointhelper.go
+++ b/utils/restendpointhelper.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -48,9 +49,10 @@ func readParameter(pattern string, requestUrl string, paramName string) (string,
 }
 
 func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error) {
-	pattern, has_header := r.Header["OWNCAST_RESTURL_PATTERN"]
-	if !has_header {
-		return "", errors.New(fmt.Sprintf("This HandlerFunc is not marked as REST-Endpoint. Cannot read Paramet %s from Request", parameterName))
+	pattern, found := r.Header["OWNCAST-RESTURL-PATTERN"]
+	log.Print(r.Header)
+	if !found {
+		return "", errors.New(fmt.Sprintf("This HandlerFunc is not marked as REST-Endpoint. Cannot read Parameter '%s' from Request", parameterName))
 	}
 
 	return readParameter(pattern[0], r.URL.Path, parameterName)
@@ -59,7 +61,8 @@ func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error)
 func RestEndpoint(pattern string, handler http.HandlerFunc) (string, http.HandlerFunc) {
 	baseUrl := getPatternForRestEndpoint(pattern)
 	return baseUrl, func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Add("OWNCAST_RESTURL_PATTERN", pattern)
+		r.Header["OWNCAST-RESTURL-PATTERN"] = []string{pattern}
+		log.Print(r.Header)
 		handler(w, r)
 	}
 }

--- a/utils/restendpointhelper.go
+++ b/utils/restendpointhelper.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// takes the segment pattern of an Url string and returns the segment before the first dynamic REST parameter
+func getPatternForRestEndpoint(pattern string) string {
+	firstIndex := strings.Index(pattern, "/{")
+	if firstIndex == -1 {
+		return pattern
+	}
+
+	return strings.TrimRight(pattern[:firstIndex], "/") + "/"
+}
+
+func zip2D(iterable1 *[]string, iterable2 *[]string) map[string]string {
+	var dict = make(map[string]string)
+	for index, key := range *iterable1 {
+		dict[key] = (*iterable2)[index]
+	}
+	return dict
+}
+
+func mapPatternWithRequestUrl(pattern string, requestUrl string) (map[string]string, error) {
+	patternSplit := strings.Split(pattern, "/")
+	requestUrlSplit := strings.Split(requestUrl, "/")
+
+	if len(patternSplit) == len(requestUrlSplit) {
+		return zip2D(&patternSplit, &requestUrlSplit), nil
+	}
+	return nil, errors.New("The lenght of pattern and request Url does not match")
+}
+
+func readParameter(pattern string, requestUrl string, paramName string) (string, error) {
+	all, err := mapPatternWithRequestUrl(pattern, requestUrl)
+	if err != nil {
+		return "", err
+	}
+
+	if value, exists := all[fmt.Sprintf("{%s}", paramName)]; exists {
+		return value, nil
+	}
+	return "", errors.New(fmt.Sprintf("Paramater with name %s not found", paramName))
+}
+
+func ReadRestUrlParameter(r *http.Request, parameterName string) (string, error) {
+	pattern, has_header := r.Header["OWNCAST_RESTURL_PATTERN"]
+	if !has_header {
+		return "", errors.New(fmt.Sprintf("This HandlerFunc is not marked as REST-Endpoint. Cannot read Paramet %s from Request", parameterName))
+	}
+
+	return readParameter(pattern[0], r.URL.Path, parameterName)
+}
+
+func RestEndpoint(pattern string, handler http.HandlerFunc) (string, http.HandlerFunc) {
+	baseUrl := getPatternForRestEndpoint(pattern)
+	return baseUrl, func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Add("OWNCAST_RESTURL_PATTERN", pattern)
+		handler(w, r)
+	}
+}

--- a/utils/restendpointhelper_test.go
+++ b/utils/restendpointhelper_test.go
@@ -29,7 +29,10 @@ func TestReadParameter(t *testing.T) {
 
 	for _, ep := range endpoints {
 		v, err := readParameter(ep, strings.Replace(ep, "{p1}", expected, -1), "p1")
-		if err != nil || v != expected {
+		if err != nil {
+			t.Errorf("Unexpected error when reading parameter: %s", err.Error())
+		}
+		if v != expected {
 			t.Errorf("'%s' should have returned %s", ep, expected)
 		}
 	}

--- a/utils/restendpointhelper_test.go
+++ b/utils/restendpointhelper_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetPatternForRestEndpoint(t *testing.T) {
+	expected := "/hello/"
+	endpoints := [...]string{"/hello/{param1}", "/hello/{param1}/{param2}", "/hello/{param1}/world/{param2}"}
+	for _, endpoint := range endpoints {
+		if ep := getPatternForRestEndpoint(endpoint); ep != expected {
+			t.Errorf("%s p does not match expected %s", ep, expected)
+		}
+	}
+}
+
+func TestReadParameter(t *testing.T) {
+	expected := "world"
+	endpoints := [...]string{
+		"/hello/{p1}",
+		"/hello/cruel/{p1}",
+		"/hello/{p1}/my/friend",
+		"/hello/{p1}/{p2}/friend",
+		"/hello/{p2}/{p3}/{p1}",
+		"/{p1}/is/nice",
+		"/{p1}/{p1}/{p1}",
+	}
+
+	for _, ep := range endpoints {
+		v, err := readParameter(ep, strings.Replace(ep, "{p1}", expected, -1), "p1")
+		if err != nil || v != expected {
+			t.Errorf("'%s' should have returned %s", ep, expected)
+		}
+	}
+}


### PR DESCRIPTION
Hello,

I've implemented an additional HTTP endpoint `/api/integrations/chat/system/client/{clientId}` and some very simple `gorilla/mux`-like REST-Helpers that make it easier to parse REST-Like params from an URL in the future.

This http-endpoint calls into core/chat.go, which will find the ChatClient in the connected clients by its Id. 
If the Id is found, I have used the already existing sendMessageToClient function (with the addition that contents are now markdown rendered, hope that's allright?)

Every webhook firing an Event of Type "UserEvent" will now have a ClientId included, which can be utilized by thirdparty integrations to use this endpoint.

2 further Merge Requests incoming (Demo-Bot, which I uesd for testing of everything, and a short update to the Docs).

BR, Ruffy

