### PR TITLE
Add support for loading the owncast URL in mpv

### DIFF
--- a/controllers/index.go
+++ b/controllers/index.go
@@ -44,6 +44,11 @@ func IndexHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if utils.IsUserAgentAPlayer(r.UserAgent()) && isIndexRequest {
+		http.Redirect(w, r, "/hls/stream.m3u8", http.StatusTemporaryRedirect)
+		return
+	}
+
 	// If the ETags match then return a StatusNotModified
 	if responseCode := middleware.ProcessEtags(w, r); responseCode != 0 {
 		w.WriteHeader(responseCode)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -95,6 +95,7 @@ func IsUserAgentAPlayer(userAgent string) bool {
 	playerStrings := []string{
 		"mpv",
 		"player",
+		"vlc",
 	}
 
 	for _, playerString := range playerStrings {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -86,6 +86,26 @@ func IsUserAgentABot(userAgent string) bool {
 	return ua.Bot()
 }
 
+// IsUserAgentAPlayer returns if a web client user-agent is seen as a media player.
+func IsUserAgentAPlayer(userAgent string) bool {
+	if userAgent == "" {
+		return false
+	}
+
+	playerStrings := []string{
+		"mpv",
+		"player",
+	}
+
+	for _, playerString := range playerStrings {
+		if strings.Contains(strings.ToLower(userAgent), playerString) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func RenderSimpleMarkdown(raw string) string {
 	markdown := goldmark.New(
 		goldmark.WithRendererOptions(


### PR DESCRIPTION
mpv first tries to load the URL with the user-agent set as a typical browser. The returned page gets parsed with the yt-dl. In this phase we cannot detect/intercept it. 

In case of failure in the first step, mpv will load the same URL with the user-agent set as “mpv” and pipes the result directly into ffmpeg. If we redirect it to the bot page here, ffmpeg will not be able to parse the html page and extract the hls link. But instead we can just redirect it to the hls link and ffmpeg should handle the rest.

PS: +Bonus VLC support! 😎