### PR TITLE
Fix Windows tests

### DIFF
--- a/core/transcoder/transcoder_nvenc_test.go
+++ b/core/transcoder/transcoder_nvenc_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
+	"strings"
+	"runtime"
 )
 
 func TestFFmpegNvencCommand(t *testing.T) {
@@ -41,6 +43,10 @@ func TestFFmpegNvencCommand(t *testing.T) {
 	cmd := transcoder.getString()
 
 	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning -hwaccel cuda -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_nvenc -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30 -tune:v:0 ll -map a:0? -c:a:0 copy -preset p3 -map v:0 -c:v:1 h264_nvenc -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24 -tune:v:1 ll -map a:0? -c:a:1 copy -preset p5 -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset p1  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1  -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdoieGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
+
+	if runtime.GOOS == "windows" {
+		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
+	}
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_nvenc_test.go
+++ b/core/transcoder/transcoder_nvenc_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
-	"strings"
-	"runtime"
+	"path/filepath"
 )
 
 func TestFFmpegNvencCommand(t *testing.T) {
@@ -13,7 +12,7 @@ func TestFFmpegNvencCommand(t *testing.T) {
 	codec := NvencCodec{}
 
 	transcoder := new(Transcoder)
-	transcoder.ffmpegPath = "/fake/path/ffmpeg"
+	transcoder.ffmpegPath = filepath.Join("fake", "path", "ffmpeg")
 	transcoder.SetInput("fakecontent.flv")
 	transcoder.SetOutputPath("fakeOutput")
 	transcoder.SetIdentifier("jdoieGg")
@@ -42,11 +41,8 @@ func TestFFmpegNvencCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning -hwaccel cuda -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_nvenc -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30 -tune:v:0 ll -map a:0? -c:a:0 copy -preset p3 -map v:0 -c:v:1 h264_nvenc -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24 -tune:v:1 ll -map a:0? -c:a:1 copy -preset p5 -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset p1  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1  -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdoieGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
-
-	if runtime.GOOS == "windows" {
-		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
-	}
+	expectedLogPath := filepath.Join("data", "logs", "transcoder.log")
+	expected := `FFREPORT=file="`+expectedLogPath+`":level=32 `+transcoder.ffmpegPath+` -hide_banner -loglevel warning -hwaccel cuda -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_nvenc -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30 -tune:v:0 ll -map a:0? -c:a:0 copy -preset p3 -map v:0 -c:v:1 h264_nvenc -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24 -tune:v:1 ll -map a:0? -c:a:1 copy -preset p5 -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset p1  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1  -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdoieGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_omx_test.go
+++ b/core/transcoder/transcoder_omx_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
-	"strings"
-	"runtime"
+	"path/filepath"
 )
 
 func TestFFmpegOmxCommand(t *testing.T) {
@@ -13,7 +12,7 @@ func TestFFmpegOmxCommand(t *testing.T) {
 	codec := OmxCodec{}
 
 	transcoder := new(Transcoder)
-	transcoder.ffmpegPath = "/fake/path/ffmpeg"
+	transcoder.ffmpegPath = filepath.Join("fake", "path", "ffmpeg")
 	transcoder.SetInput("fakecontent.flv")
 	transcoder.SetOutputPath("fakeOutput")
 	transcoder.SetIdentifier("jdFsdfzGg")
@@ -42,11 +41,8 @@ func TestFFmpegOmxCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning  -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_omx -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30  -map a:0? -c:a:0 copy -preset veryfast -map v:0 -c:v:1 h264_omx -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24  -map a:0? -c:a:1 copy -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1 -tune zerolatency -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdFsdfzGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
-
-	if runtime.GOOS == "windows" {
-		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
-	}
+	expectedLogPath := filepath.Join("data", "logs", "transcoder.log")
+	expected := `FFREPORT=file="`+expectedLogPath+`":level=32 `+transcoder.ffmpegPath+` -hide_banner -loglevel warning  -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_omx -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30  -map a:0? -c:a:0 copy -preset veryfast -map v:0 -c:v:1 h264_omx -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24  -map a:0? -c:a:1 copy -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1 -tune zerolatency -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdFsdfzGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_omx_test.go
+++ b/core/transcoder/transcoder_omx_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
+	"strings"
+	"runtime"
 )
 
 func TestFFmpegOmxCommand(t *testing.T) {
@@ -41,6 +43,10 @@ func TestFFmpegOmxCommand(t *testing.T) {
 	cmd := transcoder.getString()
 
 	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning  -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_omx -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30  -map a:0? -c:a:0 copy -preset veryfast -map v:0 -c:v:1 h264_omx -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24  -map a:0? -c:a:1 copy -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1 -tune zerolatency -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdFsdfzGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
+
+	if runtime.GOOS == "windows" {
+		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
+	}
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_vaapi_test.go
+++ b/core/transcoder/transcoder_vaapi_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
+	"strings"
+	"runtime"
 )
 
 func TestFFmpegVaapiCommand(t *testing.T) {
@@ -41,6 +43,10 @@ func TestFFmpegVaapiCommand(t *testing.T) {
 	cmd := transcoder.getString()
 
 	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning -vaapi_device /dev/dri/renderD128 -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_vaapi -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30  -map a:0? -c:a:0 copy -filter:v:0 "format=nv12,hwupload" -preset veryfast -map v:0 -c:v:1 h264_vaapi -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24  -map a:0? -c:a:1 copy -filter:v:1 "format=nv12,hwupload" -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1  -pix_fmt vaapi_vld -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdofFGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
+
+	if runtime.GOOS == "windows" {
+		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
+	}
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_vaapi_test.go
+++ b/core/transcoder/transcoder_vaapi_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
-	"strings"
-	"runtime"
+	"path/filepath"
 )
 
 func TestFFmpegVaapiCommand(t *testing.T) {
@@ -13,7 +12,7 @@ func TestFFmpegVaapiCommand(t *testing.T) {
 	codec := VaapiCodec{}
 
 	transcoder := new(Transcoder)
-	transcoder.ffmpegPath = "/fake/path/ffmpeg"
+	transcoder.ffmpegPath = filepath.Join("fake", "path", "ffmpeg")
 	transcoder.SetInput("fakecontent.flv")
 	transcoder.SetOutputPath("fakeOutput")
 	transcoder.SetIdentifier("jdofFGg")
@@ -42,11 +41,8 @@ func TestFFmpegVaapiCommand(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning -vaapi_device /dev/dri/renderD128 -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_vaapi -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30  -map a:0? -c:a:0 copy -filter:v:0 "format=nv12,hwupload" -preset veryfast -map v:0 -c:v:1 h264_vaapi -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24  -map a:0? -c:a:1 copy -filter:v:1 "format=nv12,hwupload" -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1  -pix_fmt vaapi_vld -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdofFGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
-
-	if runtime.GOOS == "windows" {
-		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
-	}
+	expectedLogPath := filepath.Join("data", "logs", "transcoder.log")
+	expected := `FFREPORT=file="`+expectedLogPath+`":level=32 `+transcoder.ffmpegPath+` -hide_banner -loglevel warning -vaapi_device /dev/dri/renderD128 -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 h264_vaapi -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30  -map a:0? -c:a:0 copy -filter:v:0 "format=nv12,hwupload" -preset veryfast -map v:0 -c:v:1 h264_vaapi -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24  -map a:0? -c:a:1 copy -filter:v:1 "format=nv12,hwupload" -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1  -pix_fmt vaapi_vld -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdofFGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_x264_test.go
+++ b/core/transcoder/transcoder_x264_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
+	"strings"
+	"runtime"
 )
 
 func TestFFmpegx264Command(t *testing.T) {
@@ -41,6 +43,10 @@ func TestFFmpegx264Command(t *testing.T) {
 	cmd := transcoder.getString()
 
 	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning  -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30 -x264-params:v:0 "scenecut=0:open_gop=0" -bufsize:v:0 1440k -profile:v:0 high -map a:0? -c:a:0 copy -preset veryfast -map v:0 -c:v:1 libx264 -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24 -x264-params:v:1 "scenecut=0:open_gop=0" -bufsize:v:1 4200k -profile:v:1 high -map a:0? -c:a:1 copy -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1 -tune zerolatency -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdofFGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
+
+	if runtime.GOOS == "windows" {
+		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
+	}
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)

--- a/core/transcoder/transcoder_x264_test.go
+++ b/core/transcoder/transcoder_x264_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/owncast/owncast/models"
-	"strings"
-	"runtime"
+	"path/filepath"
 )
 
 func TestFFmpegx264Command(t *testing.T) {
@@ -13,7 +12,7 @@ func TestFFmpegx264Command(t *testing.T) {
 	codec := Libx264Codec{}
 
 	transcoder := new(Transcoder)
-	transcoder.ffmpegPath = "/fake/path/ffmpeg"
+	transcoder.ffmpegPath = filepath.Join("fake", "path", "ffmpeg")
 	transcoder.SetInput("fakecontent.flv")
 	transcoder.SetOutputPath("fakeOutput")
 	transcoder.SetIdentifier("jdofFGg")
@@ -42,11 +41,8 @@ func TestFFmpegx264Command(t *testing.T) {
 
 	cmd := transcoder.getString()
 
-	expected := `FFREPORT=file="data/logs/transcoder.log":level=32 /fake/path/ffmpeg -hide_banner -loglevel warning  -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30 -x264-params:v:0 "scenecut=0:open_gop=0" -bufsize:v:0 1440k -profile:v:0 high -map a:0? -c:a:0 copy -preset veryfast -map v:0 -c:v:1 libx264 -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24 -x264-params:v:1 "scenecut=0:open_gop=0" -bufsize:v:1 4200k -profile:v:1 high -map a:0? -c:a:1 copy -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1 -tune zerolatency -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdofFGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
-
-	if runtime.GOOS == "windows" {
-		expected = strings.Replace(expected, "data/logs/transcoder.log", "data\\logs\\transcoder.log", 1)
-	}
+	expectedLogPath := filepath.Join("data", "logs", "transcoder.log")
+	expected := `FFREPORT=file="`+expectedLogPath+`":level=32 `+transcoder.ffmpegPath+` -hide_banner -loglevel warning  -fflags +genpts -i  fakecontent.flv  -map v:0 -c:v:0 libx264 -b:v:0 1200k -maxrate:v:0 1272k -g:v:0 90 -keyint_min:v:0 90 -r:v:0 30 -x264-params:v:0 "scenecut=0:open_gop=0" -bufsize:v:0 1440k -profile:v:0 high -map a:0? -c:a:0 copy -preset veryfast -map v:0 -c:v:1 libx264 -b:v:1 3500k -maxrate:v:1 3710k -g:v:1 72 -keyint_min:v:1 72 -r:v:1 24 -x264-params:v:1 "scenecut=0:open_gop=0" -bufsize:v:1 4200k -profile:v:1 high -map a:0? -c:a:1 copy -preset fast -map v:0 -c:v:2 copy -map a:0? -c:a:2 copy -preset ultrafast  -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 " -f hls -hls_time 3 -hls_list_size 3  -segment_format_options mpegts_flags=+initial_discontinuity:mpegts_copyts=1 -tune zerolatency -pix_fmt yuv420p -sc_threshold 0 -master_pl_name stream.m3u8 -strftime 1 -hls_segment_filename http://127.0.0.1:8123/%v/stream-jdofFGg%s.ts -max_muxing_queue_size 400 -method PUT -http_persistent 0 http://127.0.0.1:8123/%v/stream.m3u8`
 
 	if cmd != expected {
 		t.Errorf("ffmpeg command does not match expected.\nGot %s\n, want: %s", cmd, expected)


### PR DESCRIPTION
Fixes #1353.

This adds a really simple check to see if the tests are running on Windows and uses backslashes for the FFREPORT file path in that case.

This is my first contribution to this project, and as such might not necessarily meet some coding guideline that I'm not aware of. Please let me know of any necessary adjustments.

Note: The Windows *build* still fails since the chat project calls various rlimit-related functions which do not exist on Windows, so I didn't re-add it to the test matrix.