### PR TITLE
Do not send user joined messages for already active users

### DIFF
--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -112,4 +112,5 @@ func (s *Server) userMessageSent(eventData chatClientEvent) {
 	SaveUserMessage(event)
 
 	eventData.client.MessageCount = eventData.client.MessageCount + 1
+	_lastSeenCache[event.User.ID] = time.Now()
 }

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -86,8 +86,9 @@ func (s *Server) Addclient(conn *websocket.Conn, user *user.User, accessToken st
 		ConnectedAt: time.Now(),
 	}
 
+	// Do not send user re-joined broadcast message if they've been active within 5 minutes.
 	shouldSendJoinedMessages := true
-	if previouslyLastSeen, ok := _lastSeenCache[user.ID]; ok && time.Since(previouslyLastSeen) < time.Minute*10 {
+	if previouslyLastSeen, ok := _lastSeenCache[user.ID]; ok && time.Since(previouslyLastSeen) < time.Minute*5 {
 		shouldSendJoinedMessages = false
 	}
 


### PR DESCRIPTION
This aims to stop the scenario where somebody is on a bad network, or is refreshing their browser for whatever reason, forcing User Joined messages to show over and over again in the chat.  It's annoying enough for me to do something about it.

With this change if a user ID has been active within 10 minutes then don't alert everyone that the user has joined, because they've already been told once previously.  If we think 10 minutes is too aggressive we can reduce it.

Closes https://github.com/owncast/owncast/issues/1406