### PR TITLE
:rocket: fix: split EXPOSE into multiple statements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Perform a build
 FROM golang:alpine AS build
-EXPOSE 8080 1935
+EXPOSE 8080
+EXPOSE 1935
 RUN mkdir /build
 ADD . /build
 WORKDIR /build


### PR DESCRIPTION
This is a change in the Dockerfile because Plesk seems to be bad with having multiple ports in one `EXPOSE` statement.

Related to #1447.
