### PR TITLE
Replaces redirect of /embed URLs to return content directly.

### DIFF
--- a/controllers/embed.go
+++ b/controllers/embed.go
@@ -6,15 +6,15 @@ import (
 
 // GetChatEmbedreadwrite gets the embed for readwrite chat.
 func GetChatEmbedreadwrite(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/index-standalone-chat-readwrite.html", http.StatusTemporaryRedirect)
+	http.ServeFile(w, r, "webroot/index-standalone-chat-readwrite.html")
 }
 
 // GetChatEmbedreadonly gets the embed for readonly chat.
 func GetChatEmbedreadonly(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/index-standalone-chat-readonly.html", http.StatusTemporaryRedirect)
+	http.ServeFile(w, r, "webroot/index-standalone-chat-readonly.html")
 }
 
 // GetVideoEmbed gets the embed for video.
 func GetVideoEmbed(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/index-video-only.html", http.StatusTemporaryRedirect)
+	http.ServeFile(w, r, "webroot/index-video-only.html")
 }

--- a/webroot/index-standalone-chat-readonly.html
+++ b/webroot/index-standalone-chat-readonly.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
     <link href="/js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
-    <link href="./styles/chat.css" rel="stylesheet" />
-    <link href="./styles/standalone-chat-readonly.css" rel="stylesheet" />
+    <link href="/styles/chat.css" rel="stylesheet" />
+    <link href="/styles/standalone-chat-readonly.css" rel="stylesheet" />
   </head>
 
   <body>
@@ -17,7 +17,7 @@
       import htm from '/js/web_modules/htm.js';
       const html = htm.bind(h);
 
-      import StandaloneChat from './js/app-standalone-chat.js';
+      import StandaloneChat from '/js/app-standalone-chat.js';
       render(
         html`<${StandaloneChat} readonly />`, document.getElementById("messages-only")
       );

--- a/webroot/index-standalone-chat-readwrite.html
+++ b/webroot/index-standalone-chat-readwrite.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
     <link href="/js/web_modules/tailwindcss/dist/tailwind.min.css" rel="stylesheet" />
-    <link href="./styles/chat.css" rel="stylesheet" />
-    <link href="./styles/standalone-chat-readwrite.css" rel="stylesheet" />
+    <link href="/styles/chat.css" rel="stylesheet" />
+    <link href="/styles/standalone-chat-readwrite.css" rel="stylesheet" />
   </head>
 
   <body>
@@ -17,7 +17,7 @@
       import htm from '/js/web_modules/htm.js';
       const html = htm.bind(h);
 
-      import StandaloneChat from './js/app-standalone-chat.js';
+      import StandaloneChat from '/js/app-standalone-chat.js';
       render(
         html`<${StandaloneChat} />`, document.getElementById("messages-only")
       );

--- a/webroot/index-video-only.html
+++ b/webroot/index-video-only.html
@@ -8,8 +8,8 @@
     <link href="/js/web_modules/videojs/video-js.min.css" rel="stylesheet"/>
     <link href="/js/web_modules/@videojs/themes/fantasy/index.css" rel="stylesheet" />
 
-    <link href="./styles/video.css" rel="stylesheet" />
-    <link href="./styles/video-only.css" rel="stylesheet" />
+    <link href="/styles/video.css" rel="stylesheet" />
+    <link href="/styles/video-only.css" rel="stylesheet" />
   </head>
 
   <body>
@@ -21,7 +21,7 @@
       import htm from '/js/web_modules/htm.js';
       const html = htm.bind(h);
 
-      import VideoOnly from './js/app-video-only.js';
+      import VideoOnly from '/js/app-video-only.js';
       render(html`<${VideoOnly} />`, document.getElementById("video-only"));
     </script>
   </body>


### PR DESCRIPTION
# Description

- Removes relative imports from embedded player, chat.
- Replaces `Redirect` calls with `ServeFile` in `embed.go`.

This PR replaces the temporary redirect of owncast's `/embed` URLs with calls to `http.ServeFile` to directly supply the embeds. This will reduce confusion when embedding owncast streams. In the process of making this change, relative imports in `index-standalone-chat-.*` and `index-video-only.html` were replaced with absolute imports. This way, the proper resources are loaded by the pages regardless their path.

Fixes #1281.