### PR TITLE
Fix Dockerfile to be read in Plesk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Perform a build
 FROM golang:alpine AS build
-EXPOSE 8080 1935
 RUN mkdir /build
 ADD . /build
 WORKDIR /build
@@ -26,3 +25,4 @@ COPY --from=build /build/webroot /app/webroot
 COPY --from=build /build/static /app/static
 RUN mkdir /app/data
 CMD ["/app/owncast"]
+EXPOSE 8080 1935


### PR DESCRIPTION
Plesk Docker Extension reads `EXPOSE` as part of the build process


Plesk reads the EXPOSE var too soon and assumes its part of the build process.  Moving it to the bottom solves this.

Closes https://github.com/owncast/owncast/issues/1447


