### PR TITLE
strip any leading hash symbols from admin tag input using strings.TrimLeft

### DIFF
--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -38,7 +38,7 @@ func SetTags(w http.ResponseWriter, r *http.Request) {
 
 	tagStrings := make([]string, 0)
 	for _, tag := range configValues {
-		tagStrings = append(tagStrings, tag.Value.(string))
+		tagStrings = append(tagStrings, strings.TrimLeft(tag.Value.(string), "#"))
 	}
 
 	if err := data.SetServerMetadataTags(tagStrings); err != nil {


### PR DESCRIPTION
# Description

This is a small change to admin behavior, removing any/all hashtag symbols at the start of a tag before it is saved.

Fixes #1476 

Note I'm fairly new to learning Go, so I apologize if this isn't idiomatic or anything.