### PR TITLE
Fix crash that occurs with an invalid inbound stream

### DIFF
--- a/core/streamState.go
+++ b/core/streamState.go
@@ -106,6 +106,15 @@ func SetStreamAsDisconnected() {
 		_yp.Stop()
 	}
 
+	// If there is no current broadcast available the previous stream
+	// likely failed for some reason. Don't try to append to it.
+	// Just transition to offline.
+	if _currentBroadcast == nil {
+		stopOnlineCleanupTimer()
+		transitionToOfflineVideoStreamContent()
+		return
+	}
+
 	for index := range _currentBroadcast.OutputSettings {
 		playlistFilePath := fmt.Sprintf(filepath.Join(config.HLSStoragePath, "%d/stream.m3u8"), index)
 		segmentFilePath := fmt.Sprintf(filepath.Join(config.HLSStoragePath, "%d/%s"), index, offlineFilename)

--- a/core/transcoder/utils.go
+++ b/core/transcoder/utils.go
@@ -34,6 +34,7 @@ var errorMap = map[string]string{
 	`Unknown encoder 'h264_x264'`:      "your copy of ffmpeg does not have support for the default x264 codec (h264_x264). download a version of ffmpeg that supports this.",
 	`Unrecognized option 'x264-params`: "your copy of ffmpeg does not have support for the default libx264 codec (h264_x264). download a version of ffmpeg that supports this.",
 	`Failed to set value '/dev/dri/renderD128' for option 'vaapi_device': Invalid argument`: "failed to set va-api device to /dev/dri/renderD128. your system is likely not properly configured for va-api",
+	`Stream map 'v:0' matches no streams`:                                                   "the stream provided looks to have no video included, it may be audio-only. owncast requires a video stream.",
 
 	// Generic error for a codec
 	"Unrecognized option": "error with codec. if your copy of ffmpeg or your hardware does not support your selected codec you may need to select another",
@@ -55,6 +56,7 @@ var ignoredErrors = []string{
 	"maybe the hls segment duration will not precise",
 	"Non-monotonous DTS in output",
 	"frames duplicated",
+	"To ignore this",
 }
 
 func handleTranscoderMessage(message string) {


### PR DESCRIPTION
Fixes a crash that takes place when referencing a broadcast that was invalid. Also adds an error message to alert people of a possible audio-only stream.

Fixes #1439

