### PR TITLE
Optimise regexp usage

### DIFF
--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -124,6 +124,11 @@ func RenderMarkdown(raw string) string {
 	return buf.String()
 }
 
+var (
+	_sanitizeReSrcMatch      = regexp.MustCompile(`(?i)^/img/emoji`)
+	_sanitizeReAltTitleMatch = regexp.MustCompile(`:\S+:`)
+)
+
 func sanitize(raw string) string {
 	p := bluemonday.StrictPolicy()
 
@@ -146,8 +151,8 @@ func sanitize(raw string) string {
 	p.AllowElementsContent("p")
 
 	// Allow img tags from the the local emoji directory only
-	p.AllowAttrs("src").Matching(regexp.MustCompile(`(?i)^/img/emoji`)).OnElements("img")
-	p.AllowAttrs("alt", "title").Matching(regexp.MustCompile(`:\S+:`)).OnElements("img")
+	p.AllowAttrs("src").Matching(_sanitizeReSrcMatch).OnElements("img")
+	p.AllowAttrs("alt", "title").Matching(_sanitizeReAltTitleMatch).OnElements("img")
 	p.AllowAttrs("class").OnElements("img")
 
 	// Allow bold

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -14,13 +14,15 @@ import (
 
 const unknownString = "Unknown"
 
+var _getInboundDetailsFromMetadataRE = regexp.MustCompile(`\{(.*?)\}`)
+
 func getInboundDetailsFromMetadata(metadata []interface{}) (models.RTMPStreamMetadata, error) {
 	metadataComponentsString := fmt.Sprintf("%+v", metadata)
 	if !strings.Contains(metadataComponentsString, "onMetaData") {
 		return models.RTMPStreamMetadata{}, errors.New("Not a onMetaData message")
 	}
-	re := regexp.MustCompile(`\{(.*?)\}`)
-	submatchall := re.FindAllString(metadataComponentsString, 1)
+
+	submatchall := _getInboundDetailsFromMetadataRE.FindAllString(metadataComponentsString, 1)
 
 	if len(submatchall) == 0 {
 		return models.RTMPStreamMetadata{}, errors.New("unable to parse inbound metadata")

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/nareix/joy5/format/flv/flvio"
@@ -14,19 +13,39 @@ import (
 
 const unknownString = "Unknown"
 
+func getMetadataComponents(metadata string) (string, bool) {
+	start := -1
+	ptr := 0
+
+	for ; ptr < len(metadata); ptr++ {
+		switch metadata[ptr] {
+		case '{':
+			if start == -1 {
+				start = ptr
+			}
+
+		case '}':
+			// Make sure there's actually been an opening '{' first
+			if start != -1 {
+				return metadata[start : ptr+1], true
+			}
+		}
+	}
+
+	return "", false
+}
+
 func getInboundDetailsFromMetadata(metadata []interface{}) (models.RTMPStreamMetadata, error) {
 	metadataComponentsString := fmt.Sprintf("%+v", metadata)
 	if !strings.Contains(metadataComponentsString, "onMetaData") {
 		return models.RTMPStreamMetadata{}, errors.New("Not a onMetaData message")
 	}
-	re := regexp.MustCompile(`\{(.*?)\}`)
-	submatchall := re.FindAllString(metadataComponentsString, 1)
+	metadataJSONString, ok := getMetadataComponents(metadataComponentsString)
 
-	if len(submatchall) == 0 {
+	if !ok {
 		return models.RTMPStreamMetadata{}, errors.New("unable to parse inbound metadata")
 	}
 
-	metadataJSONString := submatchall[0]
 	var details models.RTMPStreamMetadata
 	err := json.Unmarshal([]byte(metadataJSONString), &details)
 	return details, err


### PR DESCRIPTION
This PR optimises a couple of uses of RegExps throughout the go backend. In two cases it moves the compilation of the RegExp to the global scope and outside of the function definition so they only need to get compiled once at program startup as opposed to everytime the function gets called. The third RegExp I've taken out and instead replaced with a simple function to parse it manually, in the benchmarks I ran (essentially using various JSON strings, valid and malformed) it generally runs atleast hundreds of times faster and has no additional allocations - I'll attach one set of results below (for one data input), but their relative results were pretty consistent. I also considered simply moving this regex compilation to the global scope as well, but the introduction of the new function instead still offered much better performance.

[No issue attached - I saw this and liked the project, so I wanted to become a little familiar with the codebase, and saw these contributions I could make which would have a positive effect]


```
BenchmarkRegExpRecompile        176647              6544 ns/op            1929 B/op         23 allocs/op
BenchmarkRegExpCompileOnce      471300              2516 ns/op             192 B/op          2 allocs/op
BenchmarkNewParser            16669629                67.69 ns/op            0 B/op          0 allocs/op
```
(first row is original, second row is moving compilation to global scope, third row is using the new function)