### PR TITLE
:zap: execute webhooks in parallel (and :bug: update webhooks.last_used correctly)

### DIFF
--- a/core/webhooks/webhooks.go
+++ b/core/webhooks/webhooks.go
@@ -36,10 +36,12 @@ func SendEventToWebhooks(payload WebhookEvent) {
 	webhooks := data.GetWebhooksForEvent(payload.Type)
 
 	for _, webhook := range webhooks {
-		log.Debugf("Event %s sent to Webhook %s", payload.Type, webhook.URL)
-		if err := sendWebhook(webhook.URL, payload); err != nil {
-			log.Errorf("Event: %s failed to send to webhook: %s  Error: %s", payload.Type, webhook.URL, err)
-		}
+		go func(payload WebhookEvent, webhook models.Webhook) {
+			log.Debugf("Event %s sent to Webhook %s", payload.Type, webhook.URL)
+			if err := sendWebhook(webhook.URL, payload); err != nil {
+				log.Errorf("Event: %s failed to send to webhook: %s  Error: %s", payload.Type, webhook.URL, err)
+			}
+		}(payload, webhook)
 	}
 }
 


### PR DESCRIPTION
Change how webhook requests are send out.

Previously, this was done sequentially, as described in #1504.

With the change, each call of `SendEventToWebhooks(payload WebhookEvent)` creates `n` go routines for the `n` webhook URLs which are then run in parallel / non-blocking. After the HTTP request went through and the last-used cell is updated, the go routine is destructed.

PS: While looking into it, I found that the `SetWebhookAsUsed` call does not work as expected. I have attempted to fix it, in the second commit (0b4705ca). Since the field is not used anywhere (from what I can see), I didn't want to create new PR.