### PR TITLE
Fix build for Windows (#1377)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/core/chat/concurrentConnections.go
+++ b/core/chat/concurrentConnections.go
@@ -1,5 +1,6 @@
 // nolint:goimports
-// +build !freebsd
+//go:build !freebsd && !windows
+// +build !freebsd,!windows
 
 package chat
 

--- a/core/chat/concurrentConnections_windows.go
+++ b/core/chat/concurrentConnections_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+// +build windows
+
+package chat
+
+func setSystemConcurrentConnectionLimit(limit int64) {}

--- a/core/chat/utils.go
+++ b/core/chat/utils.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package chat
 
 import (

--- a/core/chat/utils_windows.go
+++ b/core/chat/utils_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package chat
+
+func getMaximumConcurrentConnectionLimit() int64 {
+	// The maximum limit I can find for windows is 16,777,216
+	// (essentially unlimited, but add the 0.7 multiplier as well to be
+	// consistent with other systems)
+	// https://docs.microsoft.com/en-gb/archive/blogs/markrussinovich/pushing-the-limits-of-windows-handles
+	return (16777216 * 7) / 10
+}


### PR DESCRIPTION
Fixes #1377. This PR adds specific build constraints for windows, including a no-op setSystemConcurrentConnectionLimit and a getMaximumConcurrentConnectionLimit which simply returns a constant for the closest value I could find for windows. This also adds the new style build constraints (added in go 1.17) but also keeps the original version.