### PR TITLE
Rework how hiding messages works.

### DIFF
--- a/core/chat/events/eventtype.go
+++ b/core/chat/events/eventtype.go
@@ -10,8 +10,8 @@ const (
 	UserJoined EventType = "USER_JOINED"
 	// UserNameChanged is the event sent when a chat username change takes place.
 	UserNameChanged EventType = "NAME_CHANGE"
-	// VisibiltyToggled is the event sent when a chat message's visibility changes.
-	VisibiltyToggled EventType = "VISIBILITY-UPDATE"
+	// VisibiltyUpdate is the event sent when a chat message's visibility changes.
+	VisibiltyUpdate EventType = "VISIBILITY_UPDATE"
 	// PING is a ping message.
 	PING EventType = "PING"
 	// PONG is a pong message.

--- a/core/chat/events/eventtype.go
+++ b/core/chat/events/eventtype.go
@@ -11,7 +11,7 @@ const (
 	// UserNameChanged is the event sent when a chat username change takes place.
 	UserNameChanged EventType = "NAME_CHANGE"
 	// VisibiltyUpdate is the event sent when a chat message's visibility changes.
-	VisibiltyUpdate EventType = "VISIBILITY_UPDATE"
+	VisibiltyUpdate EventType = "VISIBILITY-UPDATE"
 	// PING is a ping message.
 	PING EventType = "PING"
 	// PONG is a pong message.

--- a/core/chat/events/setMessageVisibilityEvent.go
+++ b/core/chat/events/setMessageVisibilityEvent.go
@@ -1,0 +1,21 @@
+package events
+
+// SetMessageVisibilityEvent is the event fired when one or more message
+// visibilities are changed.
+type SetMessageVisibilityEvent struct {
+	Event
+	UserMessageEvent
+	MessageIDs []string
+	Visible    bool
+}
+
+// GetBroadcastPayload will return the object to send to all chat users.
+func (e *SetMessageVisibilityEvent) GetBroadcastPayload() EventPayload {
+	return EventPayload{
+		"type":      VisibiltyUpdate,
+		"id":        e.ID,
+		"timestamp": e.Timestamp,
+		"ids":       e.MessageIDs,
+		"visible":   e.Visible,
+	}
+}

--- a/webroot/js/components/chat/chat.js
+++ b/webroot/js/components/chat/chat.js
@@ -194,7 +194,7 @@ export default class Chat extends Component {
     const updatedMessageList = [...curMessages];
 
     // Change the visibility of messages by ID.
-    if (messageType === 'VISIBILITY_UPDATE') {
+    if (messageType === 'VISIBILITY-UPDATE') {
       const idsToUpdate = message.ids;
       const visible = message.visible;
 

--- a/webroot/js/components/chat/chat.js
+++ b/webroot/js/components/chat/chat.js
@@ -29,6 +29,7 @@ export default class Chat extends Component {
     this.receivedFirstMessages = false;
     this.receivedMessageUpdate = false;
     this.hasFetchedHistory = false;
+    this.forceRender = false;
 
     this.windowBlurred = false;
     this.numMessagesSinceBlur = 0;
@@ -69,6 +70,11 @@ export default class Chat extends Component {
 
     const { webSocketConnected, messages, chatUserNames, newMessagesReceived } =
       this.state;
+
+    if (this.forceRender) {
+      return true;
+    }
+
     const {
       webSocketConnected: nextSocket,
       messages: nextMessages,
@@ -185,42 +191,51 @@ export default class Chat extends Component {
       (item) => item.id === messageId
     );
 
-    // If the message already exists and this is an update event
-    // then update it.
-    if (messageType === 'VISIBILITY-UPDATE') {
-      const updatedMessageList = [...curMessages];
+    const updatedMessageList = [...curMessages];
+
+    // Change the visibility of messages by ID.
+    if (messageType === 'VISIBILITY_UPDATE') {
+      const idsToUpdate = message.ids;
+      const visible = message.visible;
+
+      updatedMessageList.forEach((item) => {
+        if (idsToUpdate.includes(item.id)) {
+          item.visible = visible;
+        }
+
+        this.forceRender = true;
+        this.setState({
+          messages: updatedMessageList,
+        });
+      });
+      return;
+    } else if (existingIndex === -1 && messageVisible) {
       const convertedMessage = {
         ...message,
         type: 'CHAT',
       };
-      // if message exists and should now hide, take it out.
-      if (existingIndex >= 0 && !messageVisible) {
-        this.setState({
-          messages: curMessages.filter((item) => item.id !== messageId),
-        });
-      } else if (existingIndex === -1 && messageVisible) {
-        // insert message at timestamp
-        const insertAtIndex = curMessages.findIndex((item, index) => {
-          const time = item.timestamp || messageTimestamp;
-          const nextMessage =
-            index < curMessages.length - 1 && curMessages[index + 1];
-          const nextTime = nextMessage.timestamp || messageTimestamp;
-          const messageTimestampDate = new Date(messageTimestamp);
-          return (
-            messageTimestampDate > new Date(time) &&
-            messageTimestampDate <= new Date(nextTime)
-          );
-        });
-        updatedMessageList.splice(insertAtIndex + 1, 0, convertedMessage);
-        if (updatedMessageList.length > 300) {
-          updatedMessageList = updatedMessageList.slice(
-            Math.max(updatedMessageList.length - 300, 0)
-          );
-        }
-        this.setState({
-          messages: updatedMessageList,
-        });
+
+      // insert message at timestamp
+      const insertAtIndex = curMessages.findIndex((item, index) => {
+        const time = item.timestamp || messageTimestamp;
+        const nextMessage =
+          index < curMessages.length - 1 && curMessages[index + 1];
+        const nextTime = nextMessage.timestamp || messageTimestamp;
+        const messageTimestampDate = new Date(messageTimestamp);
+        return (
+          messageTimestampDate > new Date(time) &&
+          messageTimestampDate <= new Date(nextTime)
+        );
+      });
+      updatedMessageList.splice(insertAtIndex + 1, 0, convertedMessage);
+      if (updatedMessageList.length > 300) {
+        updatedMessageList = updatedMessageList.slice(
+          Math.max(updatedMessageList.length - 300, 0)
+        );
       }
+      this.setState({
+        messages: updatedMessageList,
+      });
     } else if (existingIndex === -1) {
       // else if message doesn't exist, add it and extra username
       const newState = {
@@ -353,6 +368,8 @@ export default class Chat extends Component {
   render(props, state) {
     const { username, readonly, chatInputEnabled, inputMaxBytes } = props;
     const { messages, chatUserNames, webSocketConnected } = state;
+
+    this.forceRender = false;
 
     const messageList = messages
       .filter((message) => message.visible !== false)


### PR DESCRIPTION
We used to send a copy of the entire message when changing the visibility of a message, now only an array of message IDs get sent.

Fixes #1350
