### PR TITLE
Specify required Go version to compile from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OBS, Streamlabs, Restream and many others have been used with Owncast. [Read mor
 ## Building from Source
 
 1. Ensure you have the gcc compiler configured.
-1. Install the [Go toolchain](https://golang.org/dl/).
+1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above).
 1. Clone the repo. `git clone https://github.com/owncast/owncast`
 1. `go run main.go` will run from source.
 1. Point your [broadcasting software](https://owncast.online/docs/broadcasting/) at your new server and start streaming.


### PR DESCRIPTION
# Description

A small documentation change I noticed when building from source today; I was running into issues compiling on a slightly older VPS that had Go 1.15 installed, and it wasn't immediately clear to me why (the `io/fs` module in particular was missing).
