### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -4,9 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -223,7 +223,7 @@ func SetLogo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	imgPath := filepath.Join("data", "logo"+extension)
-	if err := ioutil.WriteFile(imgPath, bytes, 0600); err != nil {
+	if err := os.WriteFile(imgPath, bytes, 0600); err != nil {
 		controllers.WriteSimpleResponse(w, false, err.Error())
 		return
 	}

--- a/controllers/emoji.go
+++ b/controllers/emoji.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -31,7 +30,7 @@ func getCustomEmojiList() []models.CustomEmoji {
 	}
 
 	if len(emojiCache) == 0 {
-		files, err := ioutil.ReadDir(fullPath)
+		files, err := os.ReadDir(fullPath)
 		if err != nil {
 			log.Errorln(err)
 			return emojiCache

--- a/controllers/logo.go
+++ b/controllers/logo.go
@@ -1,8 +1,8 @@
 package controllers
 
 import (
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -94,5 +94,5 @@ func writeBytesAsImage(data []byte, contentType string, w http.ResponseWriter, c
 }
 
 func getImage(path string) ([]byte, error) {
-	return ioutil.ReadFile(path) // nolint
+	return os.ReadFile(path) // nolint
 }

--- a/core/data/data_test.go
+++ b/core/data/data_test.go
@@ -2,13 +2,12 @@ package data
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
-	dbFile, err := ioutil.TempFile(os.TempDir(), "owncast-test-db.db")
+	dbFile, err := os.CreateTemp(os.TempDir(), "owncast-test-db.db")
 	if err != nil {
 		panic(err)
 	}

--- a/core/streamState.go
+++ b/core/streamState.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -88,7 +87,7 @@ func SetStreamAsDisconnected() {
 
 	offlineFileData := static.GetOfflineSegment()
 	offlineFilename := "offline.ts"
-	offlineTmpFile, err := ioutil.TempFile(os.TempDir(), offlineFilename)
+	offlineTmpFile, err := os.CreateTemp(os.TempDir(), offlineFilename)
 	if err != nil {
 		log.Errorln("unable to create temp file for offline video segment")
 	}

--- a/core/transcoder/thumbnailGenerator.go
+++ b/core/transcoder/thumbnailGenerator.go
@@ -1,7 +1,6 @@
 package transcoder
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -54,15 +53,20 @@ func fireThumbnailGenerator(segmentPath string, variantIndex int) error {
 	previewGifFile := path.Join(config.WebRoot, "preview.gif")
 
 	framePath := path.Join(segmentPath, strconv.Itoa(variantIndex))
-	files, err := ioutil.ReadDir(framePath)
+	files, err := os.ReadDir(framePath)
 	if err != nil {
 		return err
 	}
 
 	var modTime time.Time
 	var names []string
-	for _, fi := range files {
-		if path.Ext(fi.Name()) != ".ts" {
+	for _, f := range files {
+		if path.Ext(f.Name()) != ".ts" {
+			continue
+		}
+
+		fi, err := f.Info()
+		if err != nil {
 			continue
 		}
 

--- a/utils/backup.go
+++ b/utils/backup.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,7 +19,7 @@ import (
 func Restore(backupFile string, databaseFile string) error {
 	log.Printf("Restoring database backup %s to %s", backupFile, databaseFile)
 
-	data, err := ioutil.ReadFile(backupFile) // nolint
+	data, err := os.ReadFile(backupFile) // nolint
 	if err != nil {
 		return fmt.Errorf("unable to read backup file %s", err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -52,12 +51,12 @@ func GetIndexFromFilePath(path string) string {
 
 // Copy copies the file to destination.
 func Copy(source, destination string) error {
-	input, err := ioutil.ReadFile(source) // nolint
+	input, err := os.ReadFile(source) // nolint
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(destination, input, 0600)
+	return os.WriteFile(destination, input, 0600)
 }
 
 // Move moves the file to destination.

--- a/yp/yp.go
+++ b/yp/yp.go
@@ -2,12 +2,11 @@ package yp
 
 import (
 	"bytes"
-	"io/ioutil"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
-
-	"encoding/json"
 
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/core/data"
@@ -107,7 +106,7 @@ func (yp *YP) ping() {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorln(err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since owncast has been upgraded to Go 1.17 (#1464), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

While the `io/ioutil` package is still usable, it is best for us to move to the new definitions now to ensure code consistency in the future.
