### PR TITLE
feat: add matrix user agents to bot list (#1581)

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -75,6 +75,9 @@ func IsUserAgentABot(userAgent string) bool {
 		"pleroma",
 		"applebot",
 		"whatsapp",
+		"matrix",
+		"synapse",
+		"element",
 	}
 
 	for _, botString := range botStrings {


### PR DESCRIPTION
Add the matrix user agents to our bot list. Due to the decentralized nature of matrix, it is not always clear which application loads the preview and what's their user agent.

Fixes #1581.