### PR TITLE
Derive chat display-name from upstream HTTP user header

### DIFF
--- a/controllers/chat.go
+++ b/controllers/chat.go
@@ -58,6 +58,10 @@ func RegisterAnonymousChatUser(w http.ResponseWriter, r *http.Request) {
 		// this is fine. register a new user anyway.
 	}
 
+	if request.DisplayName == "" {
+		request.DisplayName = r.Header.Get("X-Forwarded-User")
+	}
+
 	newUser, err := user.CreateAnonymousUser(request.DisplayName)
 	if err != nil {
 		WriteSimpleResponse(w, false, err.Error())

--- a/test/automated/api/chat.test.js
+++ b/test/automated/api/chat.test.js
@@ -38,3 +38,24 @@ test('can fetch chat messages', async (done) => {
 
   done();
 });
+
+test('can derive display name from user header', async (done) => {
+  const res = await request
+    .post('/api/chat/register')
+    .set('X-Forwarded-User', 'test-user')
+    .expect(200);
+
+  expect(res.body.displayName).toBe('test-user');
+  done();
+});
+
+test('can overwrite user header derived display name with body', async (done) => {
+  const res = await request
+    .post('/api/chat/register')
+    .send({displayName: 'TestUserChat'})
+    .set('X-Forwarded-User', 'test-user')
+    .expect(200);
+
+  expect(res.body.displayName).toBe('TestUserChat');
+  done();
+});


### PR DESCRIPTION
This MR introduces a feature to inherit the chat display-name from an incoming HTTP header (via the `/api/chat/register'` endpoint), if not already conveyed as part of the body. This allows the use of authenticating reverse proxies (e.g. nginx, httpd mod-auth, oauth2-proxy) to set a sane default display-name instead of auto-generated ones and even achieve *some* level of account management. The user is still able to change change the username and the fall-back behaviour of using auto-generated names is still in place (if no HTTP header is sent).

Looking at other software, `X-Forwarded-User` seems to be the most used HTTP header to convey the username, being directly supported by reverse-proxies like [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy), simply configurable via nginx or apache/httpd and also used by other tools (e.g. [Jenkins reverse-proxy-auth-plugin](https://plugins.jenkins.io/reverse-proxy-auth-plugin/)). Since the `/api/chat/register` endpoint already ingests direct input from users, no further validation or protection (e.g. *trusted upstream proxies*) have to be added.

I've successfully tested these changes in a docker-compose setup with *oauth2-proxy* as authenticating reverse proxy.

If these changes go into the right direction, I can also provide a follow-up MR and some docs to `owncast/owncast.github.io`.

Fixes #1365
