### PR TITLE
Sanitize display names. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
+require golang.org/x/text v0.3.6
+
 replace github.com/go-fed/activity => github.com/owncast/activity v1.0.1-0.20211229051252-7821289d4026

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/oschwald/geoip2-golang v1.5.0 h1:igg2yQIrrcRccB1ytFXqBfOHCjXWIoMv85lV
 github.com/oschwald/geoip2-golang v1.5.0/go.mod h1:xdvYt5xQzB8ORWFqPnqMwZpCpgNagttWdoZLlJQzg7s=
 github.com/oschwald/maxminddb-golang v1.8.0 h1:Uh/DSnGoxsyp/KYbY1AuP0tYEwfs0sCph9p/UMXK/Hk=
 github.com/oschwald/maxminddb-golang v1.8.0/go.mod h1:RXZtst0N6+FY/3qCNmZMBApR19cdQj43/NM9VkrNAis=
-github.com/owncast/activity v1.0.1-0.20210908225327-e46ee45ec09c h1:lk78BK8sLYn8nwy4ZZdQqcRdkagxQI//wF/DXuxsg1Y=
-github.com/owncast/activity v1.0.1-0.20210908225327-e46ee45ec09c/go.mod h1:v4QoPaAzjWZ8zN2VFVGL5ep9C02mst0hQYHUpQwso4Q=
 github.com/owncast/activity v1.0.1-0.20211229051252-7821289d4026 h1:E1nxiX44BcMQTSSs8MHLm2rXnqXNedYZkFI31gXMsJc=
 github.com/owncast/activity v1.0.1-0.20211229051252-7821289d4026/go.mod h1:v4QoPaAzjWZ8zN2VFVGL5ep9C02mst0hQYHUpQwso4Q=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,6 +17,8 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 	"mvdan.cc/xurls"
 )
 
@@ -321,10 +323,21 @@ func GetHostnameFromURL(u url.URL) string {
 // GetHostnameFromURLString will return the hostname component from a URL object.
 func GetHostnameFromURLString(s string) string {
 	u, err := url.Parse(s)
-
 	if err != nil {
 		return ""
 	}
 
 	return u.Host
+}
+
+// SanitizeString will strip control characters and extended unicode from a
+// string. See https://go.dev/blog/normalization.
+func SanitizeString(str string) string {
+	isOk := func(r rune) bool {
+		return r < 32 || r >= 127
+	}
+
+	t := transform.Chain(norm.NFKD, transform.RemoveFunc(isOk))
+	str, _, _ = transform.String(t, str)
+	return str
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -30,14 +30,29 @@ func TestSanitizeString(t *testing.T) {
 	for _, s := range testStrings {
 		r := SanitizeString(s)
 		if r != targetString {
-			t.Error("Incorrect sanitization of string", s, "got", r)
+      t.Errorf("Incorrect sanitization of string. Expected '%s', got '%s'.", targetString, r)
 		}
 	}
 
+	// zwspStr has a zero-width space.
 	zwspStr := "str1​str2"
 	zwspStrExpected := "str1str2"
 	r := SanitizeString(zwspStr)
 	if r != zwspStrExpected {
-		t.Error("Incorrect sanitization of string", zwspStr, "got", r)
+    t.Errorf("Incorrect sanitization of string. Expected '%s', got '%s'.", zwspStr, r)
 	}
+
+	legitStrings := []string{
+	  "Thomas Müller",
+	  "Łukasz",
+	  "Gießkanne",
+	  "Tromsø",
+	  "ру́сский алфави́т", // 'Russian Alphabet' according to Wikipedia
+	  "日本語の文字", // 'Japanese characters' according to Google Translate
+  }
+  for _, s := range legitStrings {
+    if clean:=SanitizeString(s); clean != s {
+      t.Errorf("Incorrect sanitization of string. Expected '%s', got '%s'.", s, clean)
+    }
+  }
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -16,3 +16,28 @@ func TestUserAgent(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeString(t *testing.T) {
+	targetString := "this is annoying"
+	testStrings := []string{
+		"𝓉𝒽𝒾𝓈 𝒾𝓈 𝒶𝓃𝓃𝑜𝓎𝒾𝓃𝑔",
+		"𝒕𝒉𝒊𝒔 𝒊𝒔 𝒂𝒏𝒏𝒐𝒚𝒊𝒏𝒈",
+		"𝖙𝖍𝖎𝖘 𝖎𝖘 𝖆𝖓𝖓𝖔𝖞𝖎𝖓𝖌",
+		"t̸̰̰̪̤̲͕̯̳̰͆̐h̶̙͉̝̲͈̘̜̯̖̺͌͘i̷̢̦͓̪̱͝͠ș̴̢́̓ ̴̡͕̺͎̹̽͊i̵̡̳̟̙͔͗́̔̎̾͜s̸̞͍̭̞̙̥͑̑͊͜͜ ̴̮̝̔̐́͑̀̐̒́á̶̪̣̝̝͝ṋ̸̨̱̖̖̥̝̈́͗̓͑̓̏͘̚͝͠n̶̠̓̅͂́̽͛͘ő̶͇̮̹͇̭͕͋͆̋̓̔̓́̈́͘͜ỳ̷̛͉̺̪̯͚͛̋͝ì̴̞̹̑̂̐͂͝n̵̳̞͇̘͔̣͌̈́̀͝g̸̢̢̡̢̛̜̬̤͋͆̈̎̓̀̌̚",
+		"t҉h҉i҉s҉ ҉i҉s҉ ҉a҉n҉n҉o҉y҉i҉n҉g҉",
+	}
+
+	for _, s := range testStrings {
+		r := SanitizeString(s)
+		if r != targetString {
+			t.Error("Incorrect sanitization of string", s, "got", r)
+		}
+	}
+
+	zwspStr := "str1​str2"
+	zwspStrExpected := "str1str2"
+	r := SanitizeString(zwspStr)
+	if r != zwspStrExpected {
+		t.Error("Incorrect sanitization of string", zwspStr, "got", r)
+	}
+}


### PR DESCRIPTION
This sanitizes/normalizes characters from display names from extended character sets.  It still allows for pretty liberal usage of characters, but the really annoying stuff that trolls would use to junk up chat messages is covered here.

Closes #1541