### PR TITLE
Add support for socket activation

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,7 +34,7 @@ var (
 )
 
 // Start starts up the core processing.
-func Start() error {
+func Start(listenersWithNames map[string][]net.Listener) error {
 	resetDirectories()
 
 	data.PopulateDefaults()
@@ -73,7 +74,7 @@ func Start() error {
 	}
 
 	// start the rtmp server
-	go rtmp.Start(setStreamAsConnected, setBroadcaster)
+	go rtmp.Start(listenersWithNames, setStreamAsConnected, setBroadcaster)
 
 	rtmpPort := data.GetRTMPPortNumber()
 	log.Infof("RTMP is accepting inbound streams on port %d.", rtmpPort)

--- a/examples/systemd-with-container/README.md
+++ b/examples/systemd-with-container/README.md
@@ -1,0 +1,41 @@
+## systemd user service containerized owncast
+
+[Podman](https://github.com/containers/podman/) version 3.4.0 (released September 2021)
+supports running OCI containers (i.e. Docker containers) with _socket activation_.
+This opens up the possibility to run an owncast container with _socket activation_ in
+a systemd user service.
+
+### Install
+
+1. Clone this repository
+    ```
+    git clone URL
+    ```
+
+2. Install the systemd files
+    ```
+    mkdir -p ~/.config/systemd/user
+    cp -r owncast/examples/systemd-with-container/owncast-*@* ~/.config/systemd/user
+    ```
+
+3. Optional: If __container-linux__ >= v2.179.0
+   it's possible to remove `--security-opt label=disable`
+
+   ```
+   sed '/--security-opt label=disable/d' ~/.config/systemd/user/owncast@.service
+   ```
+
+4. Reload systemd
+
+   ```
+   systemctl --user daemon-reload
+   ```
+
+### Usage
+
+1. Start the target _owncast@tcpdemo.target_
+    ```
+    systemctl --user start owncast@tcpdemo.target
+    ```
+
+2. Open  _http://localhost:8080_ in a web browser

--- a/examples/systemd-with-container/owncast-rtmp@.socket
+++ b/examples/systemd-with-container/owncast-rtmp@.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=owncast with socket activation for %I
+PartOf=owncast@%i.target
+
+[Socket]
+
+FileDescriptorName=rtmp
+
+Service=owncast@%i.service
+
+[Install]
+WantedBy=default.target

--- a/examples/systemd-with-container/owncast-rtmp@tcpdemo.socket.d/override.conf
+++ b/examples/systemd-with-container/owncast-rtmp@tcpdemo.socket.d/override.conf
@@ -1,0 +1,2 @@
+[Socket]
+ListenStream=127.0.0.1:1935

--- a/examples/systemd-with-container/owncast-rtmp@unixdemo.socket.d/override.conf
+++ b/examples/systemd-with-container/owncast-rtmp@unixdemo.socket.d/override.conf
@@ -1,0 +1,2 @@
+[Socket]
+ListenStream=%h/owncast-rtmp-socket.%i

--- a/examples/systemd-with-container/owncast-webserver@.socket
+++ b/examples/systemd-with-container/owncast-webserver@.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=owncast with socket activation for %I
+PartOf=owncast@%i.target
+
+[Socket]
+
+FileDescriptorName=webserver
+
+Service=owncast@%i.service
+
+[Install]
+WantedBy=default.target

--- a/examples/systemd-with-container/owncast-webserver@tcpdemo.socket.d/override.conf
+++ b/examples/systemd-with-container/owncast-webserver@tcpdemo.socket.d/override.conf
@@ -1,0 +1,3 @@
+[Socket]
+ListenStream=127.0.0.1:8080
+

--- a/examples/systemd-with-container/owncast-webserver@unixdemo.socket.d/override.conf
+++ b/examples/systemd-with-container/owncast-webserver@unixdemo.socket.d/override.conf
@@ -1,0 +1,2 @@
+[Socket]
+ListenStream=%h/owncast-webserver-socket.%i

--- a/examples/systemd-with-container/owncast@.service
+++ b/examples/systemd-with-container/owncast@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=owncast with socket activation for %I
+Wants=network-online.target
+After=network-online.target
+RequiresMountsFor=%t/containers
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n-%i
+Restart=on-failure
+TimeoutStopSec=70
+
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=mkdir -p %h/owncast-data.%i
+ExecStart=/usr/bin/podman run \
+  --cidfile=%t/%n.ctr-id \
+  --cgroups=no-conmon \
+  --rm \
+  --sdnotify=conmon \
+  --replace \
+  --security-opt label=disable \
+  --network none \
+  --volume %h/owncast-data.%i:/app/data:Z \
+  --name owncast-%i \
+    localhost/owncast
+ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+Type=notify
+NotifyAccess=all
+
+Sockets=owncast-rtmp@%i.socket owncast-webserver@%i.socket
+
+[Install]
+WantedBy=default.target

--- a/examples/systemd-with-container/owncast@.target
+++ b/examples/systemd-with-container/owncast@.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=All owncast sockets
+
+Requires=owncast-rtmp@%i.socket
+Requires=owncast-webserver@%i.socket
+
+#[Install]
+#WantedBy=multi-user.target default.target

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/amalfra/etag v0.0.0-20190921100247-cafc8de96bc5
 	github.com/aws/aws-sdk-go v1.43.0
+	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/go-fed/activity v1.0.1-0.20210803212804-d866ba75dd0f
 	github.com/go-fed/httpsig v1.1.0
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aws/aws-sdk-go v1.43.0 h1:y4UrPbxU/mIL08qksVPE/nwH9IXuC1udjOaNyhEe+pI
 github.com/aws/aws-sdk-go v1.43.0/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
+github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -15,6 +17,7 @@ github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/owncast/owncast/logging"
 	log "github.com/sirupsen/logrus"
 
@@ -79,12 +80,16 @@ func main() {
 
 	handleCommandLineFlags()
 
+	listenersWithNames, err := activation.ListenersWithNames()
+	if err != nil {
+		log.Fatalln("failed to run activation.ListenersWithNames()", err)
+	}
 	// starts the core
-	if err := core.Start(); err != nil {
+	if err := core.Start(listenersWithNames); err != nil {
 		log.Fatalln("failed to start the core package", err)
 	}
 
-	if err := router.Start(); err != nil {
+	if err := router.Start(listenersWithNames); err != nil {
 		log.Fatalln("failed to start/run the router", err)
 	}
 }


### PR DESCRIPTION
* To use socket activation give the systemd sockets
  the names FileDescriptorName=webserver
  and FileDescriptorName=rtmp
  Fixes #1750

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>


Please include a summary of the change and which issue number is fixed, including relevant motivation and context. Feel free to mark this as a Draft or WIP and write up some details later.

# Description

Fixes #1750 

---

Some things you might want to mention:

1. Why are you making the change?

Container runtime support for _socket activation_ has improved lately.
[Podman](https://github.com/containers/podman/) version 3.4.0 (released September 2021)
supports running OCI containers (i.e. Docker containers) with _socket activation_.

2. Explain how it works and decisions you made.
3. If you're fixing something, what was wrong? How should we stop from having this issue happen again?
4. If this is a new feature or addition to functionality, why should it be added? What are the use cases? Who was asking for this functionality?

I added the rationale in the feature request
https://github.com/owncast/owncast/issues/1750

Right now the implementation only allows one socket per type, in other words, there can be only one `FileDescriptorName=webserver`  (either a TCP socket or  a UNIX socket) and there can be only one 
`FileDescriptorName=rtmp`  (either a TCP socket or  a UNIX socket).

I would guess that this restriction could be lifted with changes to the code. 
Maybe someone with better Golang knowledge could help out with this (or I could try to learn by experimenting).

Feel free to modify the code....

