### PR TITLE
Auto-select old username text when changing name.

### DIFF
--- a/webroot/js/components/chat/username.js
+++ b/webroot/js/components/chat/username.js
@@ -79,6 +79,12 @@ export default class UsernameForm extends Component {
     }
   }
 
+  componentDidUpdate({ }, { displayForm }) {
+    if (this.state.displayForm && !displayForm ) {
+      document.getElementById('username-change-input').select();
+    }
+  }
+
   render(props, state) {
     const { username, isModerator } = props;
     const { displayForm } = state;


### PR DESCRIPTION
# Description

When a user want to change their username, they have to manually click the input field to edit it. This change makes it so that the old username in the input field is selected automatically and the user can just start typing their new chosen name.
I saw that the username features are planned to be changed, but I believe in the meantime this is a welcome addition.

This is my first PR on here, and the code seems to work. However I don't know anything about preact (I just found enough on Google to understand what I was doing).

I marked this as draft as I am not sure I'm not doing something terrible :)
