### PR TITLE
Implement RTMP TLS

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -19,8 +19,13 @@ type Defaults struct {
 	DatabaseFilePath string
 	WebServerPort    int
 	WebServerIP      string
-	RTMPServerPort   int
-	StreamKey        string
+
+	RTMPServerPort int
+	StreamKey      string
+
+	RTMPTLSEnabled            bool
+	RTMPTLSCertificatePath    string
+	RTMPTLSCertificateKeyPath string
 
 	YPEnabled bool
 	YPServer  string
@@ -55,12 +60,17 @@ func GetDefaults() Defaults {
 		YPEnabled: false,
 		YPServer:  "https://directory.owncast.online",
 
-		WebServerPort:  8080,
-		WebServerIP:    "0.0.0.0",
+		WebServerPort: 8080,
+		WebServerIP:   "0.0.0.0",
+
 		RTMPServerPort: 1935,
 		StreamKey:      "abc123",
 
 		ChatEstablishedUserModeTimeDuration: time.Minute * 15,
+
+		RTMPTLSEnabled:            false,
+		RTMPTLSCertificatePath:    "ssl/fullchain.pem",
+		RTMPTLSCertificateKeyPath: "ssl/privkey.pem",
 
 		StreamVariants: []models.StreamOutputVariant{
 			{

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -380,6 +380,81 @@ func SetRTMPServerPort(w http.ResponseWriter, r *http.Request) {
 	controllers.WriteSimpleResponse(w, true, "rtmp port set")
 }
 
+// SetRTMPTLSEnabled sets rtmp tls enabled
+func SetRTMPTLSEnabled(w http.ResponseWriter, r *http.Request) {
+	if !requirePOST(w, r) {
+		return
+	}
+
+	configValue, success := getValueFromRequest(w, r)
+	if !success {
+		return
+	}
+
+	if err := data.SetRTMPTLSEnabled(configValue.Value.(bool)); err != nil {
+		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
+	}
+
+	controllers.WriteSimpleResponse(w, true, "rtmp tls enabled set")
+}
+
+// SetRTMPTLSCertificatePath sets rtmp tls certificate path
+func SetRTMPTLSCertificatePath(w http.ResponseWriter, r *http.Request) {
+	if !requirePOST(w, r) {
+		return
+	}
+
+	configValue, success := getValueFromRequest(w, r)
+	if !success {
+		return
+	}
+
+	rawValue, ok := configValue.Value.(string)
+	if !ok {
+		controllers.WriteSimpleResponse(w, false, "rtmp tls certificate path value invalid")
+		return
+	}
+
+	// Trim any trailing slash
+	certPath := strings.TrimRight(rawValue, "/")
+
+	if err := data.SetRTMPTLSCertificatePath(certPath); err != nil {
+		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
+	}
+
+	controllers.WriteSimpleResponse(w, true, "rtmp tls certificate path set")
+}
+
+// SetRTMPTLSCertificateKeyPath sets rtmp tls certificate key path
+func SetRTMPTLSCertificateKeyPath(w http.ResponseWriter, r *http.Request) {
+	if !requirePOST(w, r) {
+		return
+	}
+
+	configValue, success := getValueFromRequest(w, r)
+	if !success {
+		return
+	}
+
+	rawValue, ok := configValue.Value.(string)
+	if !ok {
+		controllers.WriteSimpleResponse(w, false, "rtmp tls certificate key path value invalid")
+		return
+	}
+
+	// Trim any trailing slash
+	certKeyPath := strings.TrimRight(rawValue, "/")
+
+	if err := data.SetRTMPTLSCertificateKeyPath(certKeyPath); err != nil {
+		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
+	}
+
+	controllers.WriteSimpleResponse(w, true, "rtmp tls certificate key path set")
+}
+
 // SetServerURL will handle the web config request to set the full server URL.
 func SetServerURL(w http.ResponseWriter, r *http.Request) {
 	if !requirePOST(w, r) {

--- a/controllers/admin/serverConfig.go
+++ b/controllers/admin/serverConfig.go
@@ -51,6 +51,9 @@ func GetServerConfig(w http.ResponseWriter, r *http.Request) {
 		WebServerPort:           config.WebServerPort,
 		WebServerIP:             config.WebServerIP,
 		RTMPServerPort:          data.GetRTMPPortNumber(),
+		RTMPTLSEnabled:          data.GetRTMPTLSEnabled(),
+		RTMPTLSCertPath:         data.GetRTMPTLSCertificatePath(),
+		RTMPTLSCertKeyPath:      data.GetRTMPTLSCertificateKeyPath(),
 		ChatDisabled:            data.GetChatDisabled(),
 		ChatJoinMessagesEnabled: data.GetChatJoinMessagesEnabled(),
 		SocketHostOverride:      data.GetWebsocketOverrideHost(),
@@ -94,6 +97,9 @@ type serverConfigAdminResponse struct {
 	WebServerPort           int                      `json:"webServerPort"`
 	WebServerIP             string                   `json:"webServerIP"`
 	RTMPServerPort          int                      `json:"rtmpServerPort"`
+	RTMPTLSEnabled          bool                     `json:"rtmpTlsEnabled"`
+	RTMPTLSCertPath         string                   `json:"rtmpTlsCertPath"`
+	RTMPTLSCertKeyPath      string                   `json:"rtmpTlsCertKeyPath"`
 	S3                      models.S3                `json:"s3"`
 	VideoSettings           videoSettings            `json:"videoSettings"`
 	YP                      yp                       `json:"yp"`

--- a/core/core.go
+++ b/core/core.go
@@ -74,13 +74,21 @@ func Start() error {
 
 	// start the rtmp server
 	go rtmp.Start(setStreamAsConnected, setBroadcaster)
-
-	rtmpPort := data.GetRTMPPortNumber()
-	log.Infof("RTMP is accepting inbound streams on port %d.", rtmpPort)
+	logRtmpStart()
 
 	webhooks.InitWorkerPool()
 
 	return nil
+}
+
+func logRtmpStart() {
+	rtmpPort := data.GetRTMPPortNumber()
+	tlsEnabled := data.GetRTMPTLSEnabled()
+	tlsString := ""
+	if tlsEnabled {
+		tlsString = " tls"
+	}
+	log.Infof("RTMP is accepting inbound"+tlsString+" streams on port %d.", rtmpPort)
 }
 
 func createInitialOfflineState() error {

--- a/core/data/config.go
+++ b/core/data/config.go
@@ -26,6 +26,9 @@ const (
 	httpListenAddressKey            = "http_listen_address"
 	websocketHostOverrideKey        = "websocket_host_override"
 	rtmpPortNumberKey               = "rtmp_port_number"
+	rtmpTLSEnabled                  = "rtmp_tls_enabled"
+	rtmpTLSCertificatePath          = "rtmp_tls_certificate_path"
+	rtmpTLSCertificateKeyPath       = "rtmp_tls_certificate_key_path"
 	serverMetadataTagsKey           = "server_metadata_tags"
 	directoryEnabledKey             = "directory_enabled"
 	directoryRegistrationKeyKey     = "directory_registration_key"
@@ -252,6 +255,51 @@ func GetRTMPPortNumber() int {
 // SetRTMPPortNumber will set the server RTMP port.
 func SetRTMPPortNumber(port float64) error {
 	return _datastore.SetNumber(rtmpPortNumberKey, port)
+}
+
+// GetRTMPTLSEnabled will return if RTMP TLS is enabled.
+func GetRTMPTLSEnabled() bool {
+	enabled, err := _datastore.GetBool(rtmpTLSEnabled)
+	if err != nil {
+		log.Traceln(rtmpTLSEnabled, err)
+		return config.GetDefaults().RTMPTLSEnabled
+	}
+	return enabled
+}
+
+// SetRTMPTLSEnabled will set if RTMP TLS is enabled.
+func SetRTMPTLSEnabled(enabled bool) error {
+	return _datastore.SetBool(rtmpTLSEnabled, enabled)
+}
+
+// GetRTMPTLSCertificatePath will return the RTMP TLS certificate path.
+func GetRTMPTLSCertificatePath() string {
+	path, err := _datastore.GetString(rtmpTLSCertificatePath)
+	if err != nil {
+		log.Traceln(rtmpTLSCertificatePath, err)
+		return config.GetDefaults().RTMPTLSCertificatePath
+	}
+	return path
+}
+
+// SetRTMPTLSCertificatePath will set the RTMP TLS certificate path.
+func SetRTMPTLSCertificatePath(path string) error {
+	return _datastore.SetString(rtmpTLSCertificatePath, path)
+}
+
+// GetRTMPTLSCertificateKeyPath will return the RTMP TLS certificate key path.
+func GetRTMPTLSCertificateKeyPath() string {
+	path, err := _datastore.GetString(rtmpTLSCertificateKeyPath)
+	if err != nil {
+		log.Traceln(rtmpTLSCertificateKeyPath, err)
+		return config.GetDefaults().RTMPTLSCertificateKeyPath
+	}
+	return path
+}
+
+// SetRTMPTLSCertificateKeyPath will set the RTMP TLS certificate key path.
+func SetRTMPTLSCertificateKeyPath(path string) error {
+	return _datastore.SetString(rtmpTLSCertificateKeyPath, path)
 }
 
 // GetServerMetadataTags will return the metadata tags.

--- a/router/router.go
+++ b/router/router.go
@@ -264,6 +264,15 @@ func Start() error {
 	// Websocket host override
 	http.HandleFunc("/api/admin/config/sockethostoverride", middleware.RequireAdminAuth(admin.SetSocketHostOverride))
 
+	// RTMP TLS enabled
+	http.HandleFunc("/api/admin/config/rtmptlsenabled", middleware.RequireAdminAuth(admin.SetRTMPTLSEnabled))
+
+	// RTMP TLS certificate path
+	http.HandleFunc("/api/admin/config/rtmptlscertpath", middleware.RequireAdminAuth(admin.SetRTMPTLSCertificatePath))
+
+	// RTMP TLS certificate key path
+	http.HandleFunc("/api/admin/config/rtmptlscertkeypath", middleware.RequireAdminAuth(admin.SetRTMPTLSCertificateKeyPath))
+
 	// Is server marked as NSFW
 	http.HandleFunc("/api/admin/config/nsfw", middleware.RequireAdminAuth(admin.SetNSFW))
 


### PR DESCRIPTION
Hi,

this PR adds TLS support for incoming RTMP streams. 
I have tested it with OBS (It's required to replace `rtmp://` with `rtmps://` when connecting)

This PR does not fix an issue I could find. 

I have added this feature to the fork I use and thought maybe someone else could find it useful.
The obvious advantage is that the stream key and data are not sent in cleartext.

### Usage

**Important:** It's necessary to generate the certificates on the server before turning the feature on. 
When using letsencrypt and running owncast as a different user than root, it is required to use a [certbot deploy hook](https://eff-certbot.readthedocs.io/en/stable/using.html?highlight=/etc/letsencrypt/renewal-hooks/deploy#renewing-certificates) to place the certificate and key somewhere where owncast can read it (`/etc/letsencrypt` is usually only accessible for root).

1. Run/build [a version of the admin interface that includes the settings](https://github.com/owncast/owncast-admin/pull/457)
2. Generate the certificates
3. Start the application
4. Go to "Configuration > Server Settings > RTMP TLS Settings"
    1. Enable TLS
    2. Put the path to the certificate into the upper text field and click "update"
        - Path is relative to owncast working dir (I'd use full paths)
    4. Put the path to the certificate key into the lower text field and click "update"
        - Path is relative to owncast working dir (I'd use full paths)
5. Restart the application
6. (Optional/If it doesn't start) check the logs for errors
    - If the path has a typo you either need to connect to the sqlite db (`data/owncast.db`) and fix it manually or just rename (or create a link to) the file to match the typo. The second option is probably the easiest.