### PR TITLE
Fix "invalid cross-device link" error when running on a different filesystem

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,8 @@ var DatabaseFilePath = "data/owncast.db"
 // LogDirectory is the path to various log files.
 var LogDirectory = "./data/logs"
 
+var TempDir = "./data/tmp"
+
 // EnableDebugFeatures will print additional data to help in debugging.
 var EnableDebugFeatures = false
 

--- a/core/offlineState.go
+++ b/core/offlineState.go
@@ -20,7 +20,7 @@ func appendOfflineToVariantPlaylist(index int, playlistFilePath string) {
 	}
 
 	tmpFileName := fmt.Sprintf("tmp-stream-%d.m3u8", index)
-	atomicWriteTmpPlaylistFile, err := os.CreateTemp(os.TempDir(), tmpFileName)
+	atomicWriteTmpPlaylistFile, err := os.CreateTemp(config.TempDir, tmpFileName)
 	if err != nil {
 		log.Errorln("error creating tmp playlist file to write to", playlistFilePath, err)
 		return
@@ -94,7 +94,7 @@ func createEmptyOfflinePlaylist(playlistFilePath string, offlineFilename string)
 
 func saveOfflineClipToDisk(offlineFilename string) (string, error) {
 	offlineFileData := static.GetOfflineSegment()
-	offlineTmpFile, err := os.CreateTemp(os.TempDir(), offlineFilename)
+	offlineTmpFile, err := os.CreateTemp(config.TempDir, offlineFilename)
 	if err != nil {
 		log.Errorln("unable to create temp file for offline video segment", err)
 	}

--- a/core/transcoder/thumbnailGenerator.go
+++ b/core/transcoder/thumbnailGenerator.go
@@ -106,7 +106,7 @@ func fireThumbnailGenerator(segmentPath string, variantIndex int) error {
 	}
 
 	// rename temp file
-	if err := os.Rename(outputFileTemp, outputFile); err != nil {
+	if err := utils.Move(outputFileTemp, outputFile); err != nil {
 		log.Errorln(err)
 	}
 
@@ -134,7 +134,7 @@ func makeAnimatedGifPreview(sourceFile string, outputFile string) {
 	if _, err := exec.Command("sh", "-c", ffmpegCmd).Output(); err != nil {
 		log.Errorln(err)
 		// rename temp file
-	} else if err := os.Rename(outputFileTemp, outputFile); err != nil {
+	} else if err := utils.Move(outputFileTemp, outputFile); err != nil {
 		log.Errorln(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -47,6 +47,17 @@ func main() {
 		}
 	}
 
+	// Recreate the temp dir
+	if utils.DoesFileExists(config.TempDir) {
+		err := os.RemoveAll(config.TempDir)
+		if err != nil {
+			log.Fatalln("Unable to remove temp dir!")
+		}
+	}
+	if err := os.Mkdir(config.TempDir, 0700); err != nil {
+		log.Fatalln("Unable to create temp dir!", err)
+	}
+
 	configureLogging(*enableDebugOptions, *enableVerboseLogging)
 	log.Infoln(config.GetReleaseString())
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -61,9 +61,19 @@ func Copy(source, destination string) error {
 	return os.WriteFile(destination, input, 0600)
 }
 
-// Move moves a file using a copy followed by a delete, which works across file systems.
-// source: https://gist.github.com/var23rav/23ae5d0d4d830aff886c3c970b8f6c6b
+// Move moves the file at source to destination.
 func Move(source, destination string) error {
+	err := os.Rename(source, destination)
+	if err != nil {
+		log.Warnln("Moving with os.Rename failed, falling back to copy and delete!", err)
+		return moveFallback(source, destination)
+	}
+	return nil
+}
+
+// moveFallback moves a file using a copy followed by a delete, which works across file systems.
+// source: https://gist.github.com/var23rav/23ae5d0d4d830aff886c3c970b8f6c6b
+func moveFallback(source, destination string) error {
 	inputFile, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("Couldn't open source file: %s", err)


### PR DESCRIPTION
Hi,

this PR fixes #1768 by replacing the call to `os.Rename` in `utils.Move` with a copy followed by a delete. 

I've also used the `utils.Move` function in the thumbnail generator, where `os.Rename` was used directly.