### PR TITLE
Prevent CSS class injection and directory traversal via custom emojis

### DIFF
--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -125,8 +125,9 @@ func RenderMarkdown(raw string) string {
 }
 
 var (
-	_sanitizeReSrcMatch      = regexp.MustCompile(`(?i)^/img/emoji`)
+	_sanitizeReSrcMatch      = regexp.MustCompile(`(?i)^/img/emoji/[^\.%]*.[A-Z]*$`)
 	_sanitizeReAltTitleMatch = regexp.MustCompile(`:\S+:`)
+	_sanitizeReClassMatch    = regexp.MustCompile(`(?i)^(emoji)[A-Z_]*?$`)
 )
 
 func sanitize(raw string) string {
@@ -153,7 +154,7 @@ func sanitize(raw string) string {
 	// Allow img tags from the the local emoji directory only
 	p.AllowAttrs("src").Matching(_sanitizeReSrcMatch).OnElements("img")
 	p.AllowAttrs("alt", "title").Matching(_sanitizeReAltTitleMatch).OnElements("img")
-	p.AllowAttrs("class").OnElements("img")
+	p.AllowAttrs("class").Matching(_sanitizeReClassMatch).OnElements("img")
 
 	// Allow bold
 	p.AllowElements("strong")


### PR DESCRIPTION
This change prevents the arbitrary use of `class` attributes when sending custom emojis via `<img>` tags. Furthermore, the emoji path is validated so that only images from `/img/emoji/` can be used. This has already been implemented, but it is incomplete, since it's possible to navigate out of the directory by using `/../../` ([Directory Traversal](https://owasp.org/www-community/attacks/Path_Traversal)).

---

## `<img>` `src` validation
Allowed:
`/img/emoji/cakeparrot.gif`
`/img/emoji/!§$&()ÜÄÖl_-x.gif`
`/img/emoji/other/dir/sticker.png`

Disallowed:
`/thumbnail.jpg`
`/img/emoji/../../thumbnail.jpg`
`/img/emoji/%2E%2E/%2E%2E/thumbnail.jpg` (URL-encoded `..`)

## `<img>` `class` validation
To be able to use your own CSS classes for custom emojis by customizing the frontend, only the collision with existing CSS classes is prevented. It is assumed that the class names always start with `emoji`.

Allowed:
`emoji` (default)
`emojicustom`
`emoji_large`

Disallowed:
All class names that do not start with `emoji` or contain special characters except underscores.

## Why is this important?
Currently, viewers can destroy the frontend by sending manipulated emojis.
Here the classes `custom-thumbnail-image modal__overlay` are used, which scale the image to full screen size.
Other classes can be used in the admin area, which makes it impossible to ban or hide the user.

PoC:

https://user-images.githubusercontent.com/59258980/157307127-52b43d9c-5d4f-4791-a532-2c4760ac5bba.mp4

