### PR TITLE
Fix exception when using emoji input in chrome

### DIFF
--- a/webroot/js/utils/chat.js
+++ b/webroot/js/utils/chat.js
@@ -6,16 +6,21 @@ import {
 
 // Taken from https://stackoverflow.com/a/46902361
 export function getCaretPosition(node) {
-  var range = window.getSelection().getRangeAt(0),
-    preCaretRange = range.cloneRange(),
-    caretPosition,
-    tmp = document.createElement('div');
+  const selection = window.getSelection();
+
+  if (selection.rangeCount === 0) {
+    return 0;
+  }
+
+  const range = selection.getRangeAt(0);
+  const preCaretRange = range.cloneRange();
+  const tempElement = document.createElement('div');
 
   preCaretRange.selectNodeContents(node);
   preCaretRange.setEnd(range.endContainer, range.endOffset);
-  tmp.appendChild(preCaretRange.cloneContents());
-  caretPosition = tmp.innerHTML.length;
-  return caretPosition;
+  tempElement.appendChild(preCaretRange.cloneContents());
+
+  return tempElement.innerHTML.length;
 }
 
 // Might not need this anymore


### PR DESCRIPTION
If you use the emoji picker in chrome without focusing the input field before, an exception occurs and the emoji gets discarded.

`Uncaught (in promise) DOMException: Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index.`
This change fixes the error. Have refactored the function.

https://user-images.githubusercontent.com/59258980/157997457-340ad21d-7fbc-4389-9bfe-9d5a65e48d61.mp4