### PR TITLE
Add ability to keep the whole stream

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -33,6 +33,8 @@ type Defaults struct {
 	FederationGoLiveMessage string
 
 	ChatEstablishedUserModeTimeDuration time.Duration
+
+	KeepWholeStream bool
 }
 
 // GetDefaults will return default configuration values.
@@ -73,5 +75,7 @@ func GetDefaults() Defaults {
 
 		FederationUsername:      "streamer",
 		FederationGoLiveMessage: "I've gone live!",
+
+		KeepWholeStream: false,
 	}
 }

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -703,23 +703,23 @@ func SetChatJoinMessagesEnabled(w http.ResponseWriter, r *http.Request) {
 	controllers.WriteSimpleResponse(w, true, "chat join message status updated")
 }
 
-// SetKeepWholeStream sets keep whole stream enabled
+// SetKeepWholeStream sets keep whole stream enabled.
 func SetKeepWholeStream(w http.ResponseWriter, r *http.Request) {
-  if !requirePOST(w, r) {
-    return
-  }
+	if !requirePOST(w, r) {
+		return
+	}
 
-  configValue, success := getValueFromRequest(w, r)
-  if !success {
-    return
-  }
+	configValue, success := getValueFromRequest(w, r)
+	if !success {
+		return
+	}
 
-  if err := data.SetKeepWholeStream(configValue.Value.(bool)); err != nil {
-    controllers.WriteSimpleResponse(w, false, err.Error())
-    return
-  }
+	if err := data.SetKeepWholeStream(configValue.Value.(bool)); err != nil {
+		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
+	}
 
-  controllers.WriteSimpleResponse(w, true, "keep whole stream enabled set")
+	controllers.WriteSimpleResponse(w, true, "keep whole stream enabled set")
 }
 
 func requirePOST(w http.ResponseWriter, r *http.Request) bool {

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -703,6 +703,25 @@ func SetChatJoinMessagesEnabled(w http.ResponseWriter, r *http.Request) {
 	controllers.WriteSimpleResponse(w, true, "chat join message status updated")
 }
 
+// SetKeepWholeStream sets keep whole stream enabled
+func SetKeepWholeStream(w http.ResponseWriter, r *http.Request) {
+  if !requirePOST(w, r) {
+    return
+  }
+
+  configValue, success := getValueFromRequest(w, r)
+  if !success {
+    return
+  }
+
+  if err := data.SetKeepWholeStream(configValue.Value.(bool)); err != nil {
+    controllers.WriteSimpleResponse(w, false, err.Error())
+    return
+  }
+
+  controllers.WriteSimpleResponse(w, true, "keep whole stream enabled set")
+}
+
 func requirePOST(w http.ResponseWriter, r *http.Request) bool {
 	if r.Method != controllers.POST {
 		controllers.WriteSimpleResponse(w, false, r.Method+" not supported")

--- a/controllers/admin/serverConfig.go
+++ b/controllers/admin/serverConfig.go
@@ -77,6 +77,7 @@ func GetServerConfig(w http.ResponseWriter, r *http.Request) {
 			ShowEngagement: data.GetFederationShowEngagement(),
 			BlockedDomains: data.GetBlockedFederatedDomains(),
 		},
+		KeepWholeStream: data.GetKeepWholeStream(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -107,6 +108,7 @@ type serverConfigAdminResponse struct {
 	Federation              federationConfigResponse `json:"federation"`
 	SuggestedUsernames      []string                 `json:"suggestedUsernames"`
 	SocketHostOverride      string                   `json:"socketHostOverride,omitempty"`
+	KeepWholeStream         bool                     `json:"keepWholeStream"`
 }
 
 type videoSettings struct {

--- a/controllers/video.go
+++ b/controllers/video.go
@@ -57,3 +57,8 @@ func GetVideoStreamOutputVariants(w http.ResponseWriter, r *http.Request) {
 
 	WriteResponse(w, response)
 }
+
+// GetKeepWholeStream will return the current value of the keep whole stream setting.
+func GetKeepWholeStream(w http.ResponseWriter, r *http.Request) {
+	WriteResponse(w, data.GetKeepWholeStream())
+}

--- a/core/data/config.go
+++ b/core/data/config.go
@@ -56,6 +56,7 @@ const (
 	suggestedUsernamesKey           = "suggested_usernames"
 	chatJoinMessagesEnabledKey      = "chat_join_messages_enabled"
 	chatEstablishedUsersOnlyModeKey = "chat_established_users_only_mode"
+  keepWholeStreamKey              = "keep_whole_stream"
 )
 
 // GetExtraPageBodyContent will return the user-supplied body content.
@@ -443,6 +444,22 @@ func GetS3StorageEnabled() bool {
 // SetS3StorageEnabled will enable or disable external storage.
 func SetS3StorageEnabled(enabled bool) error {
 	return _datastore.SetBool(s3StorageEnabledKey, enabled)
+}
+
+// GetKeepWholeStream will return if the whole stream should be saved.
+func GetKeepWholeStream() bool {
+	enabled, err := _datastore.GetBool(keepWholeStreamKey)
+	if err != nil {
+		log.Traceln(err)
+		return false
+	}
+
+	return enabled
+}
+
+// SetKeepWholeStream will toggle if the whole stream should be kept.
+func SetKeepWholeStream(enabled bool) error {
+	return _datastore.SetBool(keepWholeStreamKey, enabled)
 }
 
 // GetStreamLatencyLevel will return the stream latency level.

--- a/core/data/config.go
+++ b/core/data/config.go
@@ -56,7 +56,7 @@ const (
 	suggestedUsernamesKey           = "suggested_usernames"
 	chatJoinMessagesEnabledKey      = "chat_join_messages_enabled"
 	chatEstablishedUsersOnlyModeKey = "chat_established_users_only_mode"
-  keepWholeStreamKey              = "keep_whole_stream"
+	keepWholeStreamKey              = "keep_whole_stream"
 )
 
 // GetExtraPageBodyContent will return the user-supplied body content.

--- a/core/transcoder/hlsFilesystemCleanup.go
+++ b/core/transcoder/hlsFilesystemCleanup.go
@@ -23,6 +23,11 @@ func CleanupOldContent(baseDirectory string) {
 		return
 	}
 
+	if data.GetKeepWholeStream() {
+		log.Debugln("Skipping data removal because KeepWholeStream is active.")
+		return
+	}
+
 	// Delete old private HLS files on disk
 	for directory := range files {
 		files := files[directory]

--- a/core/transcoder/transcoder.go
+++ b/core/transcoder/transcoder.go
@@ -193,6 +193,12 @@ func (t *Transcoder) getString() string {
 	if len(hlsOptionFlags) > 0 {
 		hlsOptionsString = "-hls_flags " + strings.Join(hlsOptionFlags, "+")
 	}
+
+	hlsListSize := 0
+	if !data.GetKeepWholeStream() {
+		hlsListSize = t.currentLatencyLevel.SegmentCount
+	}
+
 	ffmpegFlags := []string{
 		fmt.Sprintf(`FFREPORT=file="%s":level=32`, logging.GetTranscoderLogFilePath()),
 		t.ffmpegPath,
@@ -208,7 +214,7 @@ func (t *Transcoder) getString() string {
 		"-f", "hls",
 
 		"-hls_time", strconv.Itoa(t.currentLatencyLevel.SecondsPerSegment), // Length of each segment
-		"-hls_list_size", strconv.Itoa(t.currentLatencyLevel.SegmentCount), // Max # in variant playlist
+		"-hls_list_size", strconv.Itoa(hlsListSize), // Max # in variant playlist
 		hlsOptionsString,
 		hlsEventString,
 		"-segment_format_options", "mpegts_flags=mpegts_copyts=1",

--- a/router/router.go
+++ b/router/router.go
@@ -189,6 +189,9 @@ func Start() error {
 	// Set video codec
 	http.HandleFunc("/api/admin/config/video/codec", middleware.RequireAdminAuth(admin.SetVideoCodec))
 
+	// Enable keeping the whole stream
+	http.HandleFunc("/api/admin/config/video/keepwholestream", middleware.RequireAdminAuth(admin.SetKeepWholeStream))
+
 	// Return all webhooks
 	http.HandleFunc("/api/admin/webhooks", middleware.RequireAdminAuth(admin.GetWebhooks))
 

--- a/router/router.go
+++ b/router/router.go
@@ -192,6 +192,9 @@ func Start() error {
 	// Enable keeping the whole stream
 	http.HandleFunc("/api/admin/config/video/keepwholestream", middleware.RequireAdminAuth(admin.SetKeepWholeStream))
 
+	// return if the whole stream is being kept
+	http.HandleFunc("/api/video/keepwholestream", controllers.GetKeepWholeStream)
+
 	// Return all webhooks
 	http.HandleFunc("/api/admin/webhooks", middleware.RequireAdminAuth(admin.GetWebhooks))
 

--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -17,7 +17,7 @@ const VIDEO_OPTIONS = {
   preload: 'auto',
   controlBar: {
     progressControl: {
-      seekBar: false,
+      seekBar: true,
     },
   },
   html5: {

--- a/webroot/js/components/player.js
+++ b/webroot/js/components/player.js
@@ -59,9 +59,9 @@ class OwncastPlayer {
     this.qualitySelectionMenu = null;
   }
 
-  init() {
+  async init() {
     this.addAirplay();
-    this.addQualitySelector();
+    await this.addQualitySelector();
 
     videojs.Vhs.xhr.beforeRequest = (options) => {
       if (options.uri.match('m3u8')) {
@@ -70,6 +70,14 @@ class OwncastPlayer {
       }
       return options;
     };
+
+    try {
+      const response = await fetch('/api/video/keepwholestream');
+      let seekBarEnabled = await response.json();
+      VIDEO_OPTIONS.controlBar.progressControl.seekBar = seekBarEnabled === true;
+    } catch (e) {
+      console.error(e);
+    }
 
     this.vjsPlayer = videojs(VIDEO_ID, VIDEO_OPTIONS);
 


### PR DESCRIPTION
Hi,

I've played around with the videojs player settings and tried enabling the seek bar to allow viewers to (re)view stuff they missed or found interesting. 
This seemed to work (the timer in the seek bar progressed as expected) but when I scrolled back some larger amount of time the player seemed to skip back to a point in time that advanced as the stream progressed, and when reloading the player would show a shorter amount of time than what was available before reloading.

I noticed in the code that owncacst currently limits the number of HLS segments in a stream via the latency setting using a recurring job that deletes old hls segments and the `hls_list_size` option in ffmpeg.

After reading #102 and thinking about the easiest way to solve this, I decided to add a new boolean setting that just disables the deletion job and sets the `hls_list_size` to `0` in the ffmpeg command to keep all the segments in the playlist.

This of course has the obvious caveat that once a new stream is started, the old data will just lie around and never be referenced again (unless you manually delete or copy them from the server). 
I thought about solving this by creating timestamped playlist files once a stream ends but have not implemented anything for that yet because it was stated in #102 that having some kind of archive is not the target of owncast, I still think this might be useful. For example there could be a list in the admin interface where admins can download a stream to export it somewhere else but that's kind of out of scope for this PR.

From a viewer perspective, the only thing changing is the availability of the seek bar. It will be visible if the option is enabled in the admin interface, but the stream will still start at the "Now" time and will only load older segments when the viewer decides to scroll back.