### PR TITLE
Change CMD to ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ WORKDIR /app
 COPY --from=build /build/owncast /app/owncast
 COPY --from=build /build/webroot /app/webroot
 RUN mkdir /app/data
-CMD ["/app/owncast"]
+ENTRYPOINT ["/app/owncast"]
 EXPOSE 8080 1935


### PR DESCRIPTION
Hello,

This should be easier to allow docker (and docker-compose) users to optionally use the verbose, debug or other command line arguments without breaking the container start up. From my understanding, using ENTRYPOINT in the Dockerfile is more suitable since the `/app/owncast` start command within the container should not be overridden but can be appended to if desired.

I was trying to get `--enableVerboseLogging` and `--enableDebugOptions` to work with docker-compose `command:` but it would not work until I modified the Dockerfile since it was overriding the original command.