### PR TITLE
Eliminate client close deadlocks.

### DIFF
--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -231,8 +231,8 @@ func (s *Server) Broadcast(payload events.EventPayload) error {
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	for _, client := range s.clients {
 		if client == nil {
@@ -242,8 +242,7 @@ func (s *Server) Broadcast(payload events.EventPayload) error {
 		select {
 		case client.send <- data:
 		default:
-			client.close()
-			delete(s.clients, client.id)
+			go client.close()
 		}
 	}
 


### PR DESCRIPTION
# Description

Currently, a deadlock exists when the chat server tries to broadcast a message to a blocked client `send` channel. The existing behaviour calls the client's `close()` method, which also writes to the server's `unregister` channel. At this point, the receiver to the `unregister` channel also tries to acquire the server's mutex, which it cannot because the broadcast method is still holding it. The broadcast won't continue since the `unregister` channel is unbuffered, causing a deadlock.

## Reproducing

I've encountered the deadlock issue (which kills chat until we restart the Owncast instance) a couple times during my community's streams. This issue is reproducible with a modified `test/fakeChat.js` script that constantly creates and disconnects hundreds of chat clients.

## Changes

This change moves the client close into a goroutine so that client management can be reconciliated after the broadcast is complete.

I've also cleaned up the client ID set management by removing it from the broadcast method. This means that a client will only be truly unregistered when its ID is passed and handled in the `unregister` channel.

Finally, since the close is also asynchronous now, I've added a mutex to the client in order to prevent multiple closes (ie. the Go scheduler runs two broadcasts back to back; this will trigger two calls to a given client's `close()` method) or writing to a nil channel.
