### PR TITLE
Fixed Firefox positioning caret on the right in chat input

### DIFF
--- a/webroot/styles/chat.css
+++ b/webroot/styles/chat.css
@@ -64,6 +64,7 @@
 #message-input:empty:before {
   content: attr(placeholderText);
   pointer-events: none;
+  position: absolute; /* Fixes firefox positioning caret on the right */
   display: block; /* For Firefox */
   color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
# Description

Fixes #1561 

---

Firefox places caret on the right in contenteditable elements. 
[Bug 904846] (https://bugzilla.mozilla.org/show_bug.cgi?id=904846)

Simply changing position to absolute on the ::before pseudo-element fixes it.

Tested on Chromium and Firefox.
