### PR TITLE
Add terminations to error repsonses in API.

### DIFF
--- a/controllers/admin/chat.go
+++ b/controllers/admin/chat.go
@@ -97,6 +97,7 @@ func GetIPAddressBans(w http.ResponseWriter, r *http.Request) {
 	bans, err := data.GetIPAddressBans()
 	if err != nil {
 		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
 	}
 
 	controllers.WriteResponse(w, bans)

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -626,6 +626,7 @@ func SetExternalActions(w http.ResponseWriter, r *http.Request) {
 
 	if err := data.SetExternalActions(actions.Value); err != nil {
 		controllers.WriteSimpleResponse(w, false, "unable to update external actions with provided values")
+		return
 	}
 
 	controllers.WriteSimpleResponse(w, true, "external actions update")
@@ -662,6 +663,7 @@ func SetForbiddenUsernameList(w http.ResponseWriter, r *http.Request) {
 
 	if err := data.SetForbiddenUsernameList(request.Value); err != nil {
 		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
 	}
 
 	controllers.WriteSimpleResponse(w, true, "forbidden username list updated")
@@ -683,6 +685,7 @@ func SetSuggestedUsernameList(w http.ResponseWriter, r *http.Request) {
 
 	if err := data.SetSuggestedUsernamesList(request.Value); err != nil {
 		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
 	}
 
 	controllers.WriteSimpleResponse(w, true, "suggested username list updated")

--- a/controllers/admin/federation.go
+++ b/controllers/admin/federation.go
@@ -24,6 +24,7 @@ func SendFederatedMessage(w http.ResponseWriter, r *http.Request) {
 	message, ok := configValue.Value.(string)
 	if !ok {
 		controllers.WriteSimpleResponse(w, false, "unable to send message")
+		return
 	}
 
 	if err := activitypub.SendPublicFederatedMessage(message); err != nil {


### PR DESCRIPTION
# Description

Certain API responses do not fully terminate when it hits an error. This results in a malformed JSON response that includes both the failure JSON string and the success JSON string.

<img width="391" alt="image" src="https://user-images.githubusercontent.com/52957110/164942770-bf3dc7c2-f42a-4fcf-8057-18061c9a081d.png">

## Changes

This change adds termination on error responses from the API. Without the termination, the error will be written to the response, as well as the success (or further error messages).