### PR TITLE
ForAllSecure's Mayhem for API testing

### DIFF
--- a/.github/workflows/ForAllSecure-Mayhem-for-API.yaml
+++ b/.github/workflows/ForAllSecure-Mayhem-for-API.yaml
@@ -1,0 +1,29 @@
+name: Mayhem for API
+on:
+  push:
+  workflow_dispatch:
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Start API
+      run: |
+        docker build . -t owncast
+        docker run -p 8080:8080 owncast&
+        sleep 5s
+        curl -vv http://localhost:8080/api/ping
+
+
+    - name: Run Mayhem for API to check for vulnerabilities
+      uses: ForAllSecure/mapi-action@v1
+      with:
+        api-url: http://localhost:8080
+        api-spec: openapi.yaml
+        target: rossimo/owncast
+        duration: 90sec
+        run-args: |
+          --header-auth
+          Authorization: Basic YWRtaW46YWJjMTIz


### PR DESCRIPTION
[Mayhem4API](https://mayhem4api.forallsecure.com/) is an automatic API tester that owncast might find useful.

If you all are interested, this pull request integrates the github action [mapi-action](https://github.com/ForAllSecure/mapi-action) to enable automatic API and server testing.

Running [Mayhem4API](https://mayhem4api.forallsecure.com/) against owncast yielded a number of issues and seemed to DOS the server on occassion.

After merge, all that is needed is for some maintainer to add a `MAPI_TOKEN` secret as detailed [here.](https://github.com/ForAllSecure/mapi-action#usage)