### PR TITLE
Add “services” and “metadata” to NodeInfo/2.0

### DIFF
--- a/activitypub/controllers/nodeinfo.go
+++ b/activitypub/controllers/nodeinfo.go
@@ -59,6 +59,9 @@ func NodeInfoController(w http.ResponseWriter, r *http.Request) {
 
 // NodeInfoV2Controller returns the V2 node info response.
 func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
+	type metadata struct {
+		ChatEnabled bool `json:"chat_enabled"`
+	}
 	type services struct {
 		Outbound []string `json:"outbound"`
 		Inbound  []string `json:"inbound"`
@@ -83,6 +86,7 @@ func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
 		Protocols         []string `json:"protocols"`
 		Usage             usage    `json:"usage"`
 		OpenRegistrations bool     `json:"openRegistrations"`
+		Metadata          metadata `json:"metadata"`
 	}
 
 	if !data.GetFederationEnabled() {
@@ -112,6 +116,9 @@ func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
 		},
 		OpenRegistrations: false,
 		Protocols:         []string{"activitypub"},
+		Metadata: metadata{
+			ChatEnabled: !data.GetChatDisabled(),
+		},
 	}
 
 	if err := writeResponse(res, w); err != nil {

--- a/activitypub/controllers/nodeinfo.go
+++ b/activitypub/controllers/nodeinfo.go
@@ -59,6 +59,10 @@ func NodeInfoController(w http.ResponseWriter, r *http.Request) {
 
 // NodeInfoV2Controller returns the V2 node info response.
 func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
+	type services struct {
+		Outbound []string `json:"outbound"`
+		Inbound  []string `json:"inbound"`
+	}
 	type software struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
@@ -74,6 +78,7 @@ func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
 	}
 	type response struct {
 		Version           string   `json:"version"`
+		Services          services `json:"services"`
 		Software          software `json:"software"`
 		Protocols         []string `json:"protocols"`
 		Usage             usage    `json:"usage"`
@@ -89,6 +94,10 @@ func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
 
 	res := response{
 		Version: "2.0",
+		Services: services{
+			Inbound:  []string{""},
+			Outbound: []string{""},
+		},
 		Software: software{
 			Name:    "owncast",
 			Version: config.VersionNumber,


### PR DESCRIPTION
“services” and “metadata” are both required by the [NodeInfo schema version 2.0](http://nodeinfo.diaspora.software/ns/schema/2.0).