### PR TITLE
Remove doubled paragraphs around stream title in AP outbox

### DIFF
--- a/activitypub/outbox/outbox.go
+++ b/activitypub/outbox/outbox.go
@@ -60,7 +60,7 @@ func SendLive() error {
 	if title := data.GetStreamTitle(); title != "" {
 		streamTitle = fmt.Sprintf("<p>%s</p>", title)
 	}
-	textContent = fmt.Sprintf("<p>%s</p><p>%s</p><p>%s</p><a href=\"%s\">%s</a>", textContent, streamTitle, tagsString, data.GetServerURL(), data.GetServerURL())
+	textContent = fmt.Sprintf("<p>%s</p>%s<p>%s</p><a href=\"%s\">%s</a>", textContent, streamTitle, tagsString, data.GetServerURL(), data.GetServerURL())
 
 	activity, _, note, noteID := createBaseOutboundMessage(textContent)
 


### PR DESCRIPTION
# Description

While inspecting AP posts of Owncast for a Misskey issue (that in the end didn't end up being related) we found out that Owncast generates invalid HTML for the live messages.

<details>
<summary>Example payload</summary>

```sh
$ curl -sH 'accept: application/activity+json' https://desu.watch/federation/ySL4fBXnR | python3 -m json.tool
{
    "@context": [
        "https://www.w3.org/ns/activitystreams",
        "http://joinmastodon.org/ns"
    ],
    "attachment": {
        "content": "Live stream preview",
        "type": "Image",
        "url": "https://desu.watch/preview.gif"
    },
    "attributedTo": "https://desu.watch/federation/user/pixel",
    "cc": "https://www.w3.org/ns/activitystreams#Public",
    "content": "<p>I've gone live!</p><p><p>Misskey contributions!</p></p><p><a class=\"hashtag\" href=\"https://directory.owncast.online/tags/owncast\">#owncast</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/streaming\">#streaming</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/programming\">#programming</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/javascript\">#javascript</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/typescript\">#typescript</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/gaming\">#gaming</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/roguelikes\">#roguelikes</a> <a class=\"hashtag\" href=\"https://directory.owncast.online/tags/rhythmgames\">#rhythmgames</a></p><a href=\"https://desu.watch\">https://desu.watch</a>",
    "id": "https://desu.watch/federation/ySL4fBXnR",
    "published": "2022-05-20T23:13:19Z",
    "tag": [
        {
            "href": "https://directory.owncast.online/tags/owncast",
            "name": "#owncast",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/streaming",
            "name": "#streaming",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/programming",
            "name": "#programming",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/javascript",
            "name": "#javascript",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/typescript",
            "name": "#typescript",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/gaming",
            "name": "#gaming",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/roguelikes",
            "name": "#roguelikes",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/rhythmgames",
            "name": "#rhythmgames",
            "type": "Hashtag"
        },
        {
            "href": "https://directory.owncast.online/tags/owncast",
            "name": "#owncast",
            "type": "Hashtag"
        }
    ],
    "type": "Note"
}
```

</details>

You can see in the provided payloads `content` right at the start around the stream title there is an additional set of paragraph-tags. (`<p>I've gone live!</p><p><p>Misskey contributions!</p></p><p><a class=\"...`)

By specification, nested paragraph-tags are not allowed. However, this is also not a critical fix, because most parser/display implementations (like browsers) gracefully handle this with just closing an open paragraph-tag before nesting happens.

This however, is not the nicest thing, and might _possibly_ end up looking weird in places. So fixing this is just in the best interest of everyone!
