### PR TITLE
Check multiple Accept headers for content-type

### DIFF
--- a/router/middleware/activityPub.go
+++ b/router/middleware/activityPub.go
@@ -22,8 +22,10 @@ func RequireActivityPubOrRedirect(handler http.HandlerFunc) http.HandlerFunc {
 		}
 
 		acceptedContentTypes := []string{"application/json", "application/json+ld", "application/activity+json", `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`}
-		acceptString := r.Header.Get("Accept")
-		accept := strings.Split(acceptString, ",")
+		var accept []string
+		for _, a := range r.Header.Values("Accept") {
+			accept = append(accept, strings.Split(a, ",")...)
+		}
 
 		for _, singleType := range accept {
 			if _, accepted := utils.FindInSlice(acceptedContentTypes, strings.TrimSpace(singleType)); accepted {


### PR DESCRIPTION
Please include a summary of the change and which issue number is fixed, including relevant motivation and context. Feel free to mark this as a Draft or WIP and write up some details later.

# Description

This PR update the ActivityPub middleware to check through multiple Accept headers (rather than just the 1st one) when negotiating content-type. This fixes an issue we were seeing with GoToSocial where setting the header, then appending to it, was causing issues with redirects when trying to dereference an Owncast account.

This shouldn't have any negative consequences, it's just a more thorough implementation of content negotiation.

Fixes # (issue)

---

Some things you might want to mention:

1. Why are you making the change?
2. Explain how it works and decisions you made.
3. If you're fixing something, what was wrong? How should we stop from having this issue happen again?
4. If this is a new feature or addition to functionality, why should it be added? What are the use cases? Who was asking for this functionality?

If this is an unsolicited change or have no issue associated please do your best to detail the motivations behind this PR.
