### PR TITLE
Change .editorconfig to reflect current state of the code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 2
 tab_width = 2
 end_of_line = lf


### PR DESCRIPTION
The code appears to be using tabs, but the `.editorconfig` file says `spaces`, this causes tools respecting `.editorconfig` to do the wrong thing.