### PR TITLE
Link the Docker Pull badge to Dockerhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Owncast is an open source, self-hosted, decentralized, single user live video st
 
 <div>
     <img alt="GitHub all releases" src="https://img.shields.io/github/downloads/owncast/owncast/total?style=for-the-badge">
-    <img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/gabekangas/owncast?style=for-the-badge">
+	  <a href="https://hub.docker.com/r/gabekangas/owncast">
+      <img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/gabekangas/owncast?style=for-the-badge">
+	  </a>
     <a href="https://github.com/owncast/owncast/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
       <img alt="GitHub issues by-label" src="https://img.shields.io/github/issues-raw/owncast/owncast/good%20first%20issue?style=for-the-badge">
     </a>


### PR DESCRIPTION
I find it intuitive to click the Docker Pull Badge to view the Dockerhub page for the Docker image.