### PR TITLE
[bugfix] Fix http signatures trying to derive actor

### DIFF
--- a/activitypub/inbox/worker.go
+++ b/activitypub/inbox/worker.go
@@ -119,11 +119,11 @@ func Verify(request *http.Request) (bool, error) {
 	triedAlgos := make(map[httpsig.Algorithm]error)
 	for _, algorithm := range algos {
 		if _, tried := triedAlgos[algorithm]; !tried {
-			if err := verifier.Verify(parsedKey, algorithm); err == nil {
+			err := verifier.Verify(parsedKey, algorithm)
+			if err == nil {
 				return true, nil
-			} else {
-				triedAlgos[algorithm] = err
 			}
+			triedAlgos[algorithm] = err
 		}
 	}
 

--- a/activitypub/inbox/worker.go
+++ b/activitypub/inbox/worker.go
@@ -115,9 +115,14 @@ func Verify(request *http.Request) (bool, error) {
 	}
 
 	// The verifier will verify the Digest in addition to the HTTP signature
+	triedAlgos := make(map[httpsig.Algorithm]error)
 	for _, algorithm := range algos {
-		if err := verifier.Verify(parsedKey, algorithm); err == nil {
-			return true, nil
+		if _, tried := triedAlgos[algorithm]; !tried {
+			if err := verifier.Verify(parsedKey, algorithm); err == nil {
+				return true, nil
+			} else {
+				triedAlgos[algorithm] = err
+			}
 		}
 	}
 

--- a/activitypub/inbox/worker.go
+++ b/activitypub/inbox/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -126,7 +127,7 @@ func Verify(request *http.Request) (bool, error) {
 		}
 	}
 
-	return false, errors.Wrap(err, algorithmString+" http signature verification error for: "+pubKeyID.String())
+	return false, fmt.Errorf("http signature verification error(s) for: %s: %+v", pubKeyID.String(), triedAlgos)
 }
 
 func isBlockedDomain(domain string) bool {

--- a/activitypub/inbox/worker.go
+++ b/activitypub/inbox/worker.go
@@ -109,10 +109,9 @@ func Verify(request *http.Request) (bool, error) {
 	}
 
 	algos := []httpsig.Algorithm{
-		httpsig.RSA_SHA256, // most common algorithm first
+		httpsig.Algorithm(algorithmString), // try stated algorithm first then other common algorithms
+		httpsig.RSA_SHA256,                 // <- used by almost all fedi software
 		httpsig.RSA_SHA512,
-		httpsig.ED25519,
-		httpsig.Algorithm(algorithmString),
 	}
 
 	// The verifier will verify the Digest in addition to the HTTP signature


### PR DESCRIPTION
This PR updates Owncast to dereference just the public key when doing key verification, rather than dereferencing the key and assuming it's an actor (it doesn't have to be).

It also updates the logic of key verification algorithms to try the most common algorithms first, and then fall back to whatever algorithm it can derive from the key signature.

With these changes, an Owncast account can now be successfully followed by a GoToSocial account.

Fixes https://github.com/owncast/owncast/issues/1955
