### PR TITLE
Hufman/earthly builds

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,79 @@
+VERSION 0.6
+
+FROM bdwyertech/go-crosscompile
+
+ARG version=dev
+WORKDIR /build
+
+code:
+  # COPY . /build
+  GIT CLONE --branch=develop git@github.com:owncast/owncast.git /build
+
+build:
+  FROM +code
+  RUN echo $EARTHLY_GIT_HASH
+  ARG NAME
+  ARG GOOS
+  ARG GOARCH
+  ARG CC=$CC
+  ARG CXX=$CXX
+  ENV CGO_ENABLED=1
+  ENV GOOS=$GOOS
+  ENV GOARCH=$GOARCH
+  RUN go build -a -installsuffix cgo -ldflags "-linkmode external -extldflags -static -s -w -X github.com/owncast/owncast/config.GitCommit=$EARTHLY_GIT_HASH -X github.com/owncast/owncast/config.VersionNumber=$version -X github.com/owncast/owncast/config.BuildPlatform=$NAME" -o owncast main.go
+  SAVE ARTIFACT owncast owncast
+  SAVE ARTIFACT webroot webroot
+  SAVE ARTIFACT README.md README.md
+
+tailwind:
+  FROM +code
+  WORKDIR /build/build/javascript
+  RUN apk add --update --no-cache npm >> /dev/null
+  ENV NODE_ENV=production
+  RUN cd /build/build/javascript && npm install --quiet --no-progress >> /dev/null && npm install -g cssnano postcss postcss-cli --quiet --no-progress --save-dev >> /dev/null && ./node_modules/.bin/tailwind build > /build/tailwind.min.css
+  RUN npx postcss /build/tailwind.min.css > /build/prod-tailwind.min.css
+  SAVE ARTIFACT /build/prod-tailwind.min.css
+
+package:
+  RUN apk add --update --no-cache zip >> /dev/null
+
+  ARG NAME
+  COPY +build/webroot /build/dist/webroot
+  COPY +build/owncast /build/dist/owncast
+  COPY +tailwind/prod-tailwind.min.css /build/dist/webroot/js/web_modules/tailwindcss/dist/tailwind.min.css
+  COPY +build/README.md /build/dist/README.md
+  ENV ZIPNAME owncast-$version-$NAME.zip
+  RUN cd /build/dist && zip -r -q -8 /build/dist/owncast.zip .
+  SAVE ARTIFACT /build/dist/owncast.zip dist/$ZIPNAME AS LOCAL dist/$ZIPNAME
+
+build-all:
+  BUILD +linux-arm64
+  BUILD +linux-arm7
+  BUILD +linux-amd64
+  BUILD +linux-i386
+  BUILD +darwin-amd64
+
+linux-arm64:
+  ARG NAME=linux-arm64
+  FROM +build --platform=linux/arm64 --CC=o64-clang --CXX=o64-clang++ --GOOS=linux --GOARCH=arm64
+  FROM +package --NAME=$NAME
+
+linux-arm7:
+  ARG NAME=linux-arm7
+  FROM +build --platform=linux/arm/v7--CC=o64-clang --CXX=o64-clang++ --GOOS=linux --GOARCH=arm/v7
+  FROM +package --NAME=$NAME
+
+linux-amd64:
+  ARG NAME=linux-64bit
+  FROM +build --GOOS=linux --GOARCH=amd64
+  FROM +package --NAME=$NAME
+
+linux-i386:
+  ARG NAME=linux-32bit
+  FROM +build --GOOS=linux --GOARCH=i386
+  FROM +package --NAME=$NAME
+
+darwin-amd64:
+  ARG NAME=macOS-64bit
+  FROM +build --platform=darwin/amd64 --CC=o64-clang --CXX=o64-clang++ --GOOS=darwin --GOARCH=amd64
+  FROM +package --NAME=$NAME

--- a/Earthfile
+++ b/Earthfile
@@ -1,30 +1,66 @@
-VERSION 0.6
+VERSION --new-platform 0.6
 
-FROM alpine:latest
+FROM --platform=linux/amd64 alpine:latest
 ARG version=develop
 WORKDIR /build
 
+build-all:
+  BUILD --platform=linux/amd64 --platform=linux/386 --platform=linux/arm64 --platform=linux/arm/v7 --platform=darwin/amd64 +build
+
+package-all:
+  BUILD --platform=linux/amd64 --platform=linux/386 --platform=linux/arm64 --platform=linux/arm/v7 --platform=darwin/amd64 +package
+
 crosscompiler:
   # This image is missing a few platforms, so we'll add them locally
-  FROM bdwyertech/go-crosscompile
+  FROM --platform=linux/amd64 bdwyertech/go-crosscompile
   RUN curl -sfL "https://musl.cc/armv7l-linux-musleabihf-cross.tgz" | tar zxf - -C /usr/ --strip-components=1
   RUN curl -sfL "https://musl.cc/i686-linux-musl-cross.tgz" | tar zxf - -C /usr/ --strip-components=1
   RUN curl -sfL "https://musl.cc/x86_64-linux-musl-cross.tgz" | tar zxf - -C /usr/ --strip-components=1
 
 code:
-  FROM +crosscompiler
+  FROM --platform=linux/amd64 +crosscompiler
   # COPY . /build
   GIT CLONE --branch=$version git@github.com:owncast/owncast.git /build
 
 build:
-  FROM +code
+  ARG EARTHLY_GIT_HASH # provided by Earthly
+  ARG TARGETPLATFORM   # provided by Earthly
+  ARG TARGETOS         # provided by Earthly
+  ARG TARGETARCH       # provided by Earthly
+  ARG GOOS=$TARGETOS
+  ARG GOARCH=$TARGETARCH
+
+  FROM --platform=linux/amd64 +code
+
   RUN echo $EARTHLY_GIT_HASH
-  ARG NAME
-  ARG GOOS
-  ARG GOARCH
-  ARG GOARM
-  ARG CC=clang
-  ARG CXX=clang++
+  RUN echo "Finding CC configuration for $TARGETPLATFORM"
+  IF [ "$TARGETPLATFORM" = "linux/amd64" ]
+    ARG NAME=linux-64bit
+    ARG CC=x86_64-linux-musl-gcc
+    ARG CXX=x86_64-linux-musl-g++
+  ELSE IF [ "$TARGETPLATFORM" = "linux/386" ]
+    ARG NAME=linux-32bit
+    ARG CC=i686-linux-musl-gcc
+    ARG CXX=i686-linux-musl-g++
+  ELSE IF [ "$TARGETPLATFORM" = "linux/arm64" ]
+    ARG NAME=linux-arm64
+    ARG CC=aarch64-linux-musl-gcc
+    ARG CXX=aarch64-linux-musl-g++
+  ELSE IF [ "$TARGETPLATFORM" = "linux/arm/v7" ]
+    ARG NAME=linux-arm7
+    ARG CC=armv7l-linux-musleabihf-gcc
+    ARG CXX=armv7l-linux-musleabihf-g++
+    ARG GOARM=7
+  ELSE IF [ "$TARGETPLATFORM" = "darwin/amd64" ]
+    ARG NAME=macOS-64bit
+    ARG CC=o64-clang
+    ARG CXX=o64-clang++
+  ELSE
+    RUN echo "Failed to find CC configuration for $TARGETPLATFORM"
+    ARG --required CC
+    ARG --required CXX
+  END
+
   ENV CGO_ENABLED=1
   ENV GOOS=$GOOS
   ENV GOARCH=$GOARCH
@@ -34,7 +70,9 @@ build:
 
   WORKDIR /build
   # MacOSX disallows static executables, so we omit the static flag on this platform
-  RUN go build -a -installsuffix cgo -ldflags "$([ $GOOS != darwin ] && echo "-linkmode external -extldflags -static ") -s -w -X github.com/owncast/owncast/config.GitCommit=$EARTHLY_GIT_HASH -X github.com/owncast/owncast/config.VersionNumber=$version -X github.com/owncast/owncast/config.BuildPlatform=$NAME" -o owncast main.go
+  RUN go build -a -installsuffix cgo -ldflags "$([ "$GOOS"z != darwinz ] && echo "-linkmode external -extldflags -static ") -s -w -X github.com/owncast/owncast/config.GitCommit=$EARTHLY_GIT_HASH -X github.com/owncast/owncast/config.VersionNumber=$version -X github.com/owncast/owncast/config.BuildPlatform=$NAME" -o owncast main.go
+  COPY +tailwind/prod-tailwind.min.css /build/dist/webroot/js/web_modules/tailwindcss/dist/tailwind.min.css
+
   SAVE ARTIFACT owncast owncast
   SAVE ARTIFACT webroot webroot
   SAVE ARTIFACT README.md README.md
@@ -46,44 +84,30 @@ tailwind:
   ENV NODE_ENV=production
   RUN cd /build/build/javascript && npm install --quiet --no-progress >> /dev/null && npm install -g cssnano postcss postcss-cli --quiet --no-progress --save-dev >> /dev/null && ./node_modules/.bin/tailwind build > /build/tailwind.min.css
   RUN npx postcss /build/tailwind.min.css > /build/prod-tailwind.min.css
-  SAVE ARTIFACT /build/prod-tailwind.min.css
+  SAVE ARTIFACT /build/prod-tailwind.min.css prod-tailwind.min.css
 
 package:
   RUN apk add --update --no-cache zip >> /dev/null
 
-  ARG NAME
+  ARG TARGETPLATFORM   # provided by Earthly
+  IF [ "$TARGETPLATFORM" = "linux/amd64" ]
+    ARG NAME=linux-64bit
+  ELSE IF [ "$TARGETPLATFORM" = "linux/386" ]
+    ARG NAME=linux-32bit
+  ELSE IF [ "$TARGETPLATFORM" = "linux/arm64" ]
+    ARG NAME=linux-arm64
+  ELSE IF [ "$TARGETPLATFORM" = "linux/arm/v7" ]
+    ARG NAME=linux-arm7
+  ELSE IF [ "$TARGETPLATFORM" = "darwin/amd64" ]
+    ARG NAME=macOS-64bit
+  ELSE
+    ARG NAME=custom
+  END
 
-  COPY +build/webroot /build/dist/webroot
-  COPY +build/owncast /build/dist/owncast
-  COPY +tailwind/prod-tailwind.min.css /build/dist/webroot/js/web_modules/tailwindcss/dist/tailwind.min.css
-  COPY +build/README.md /build/dist/README.md
+  COPY (+build/webroot --platform $TARGETPLATFORM) /build/dist/webroot
+  COPY (+build/owncast --platform $TARGETPLATFORM) /build/dist/owncast
+  COPY (+build/README.md --platform $TARGETPLATFORM) /build/dist/README.md
   ENV ZIPNAME owncast-$version-$NAME.zip
   RUN cd /build/dist && zip -r -q -8 /build/dist/owncast.zip .
   SAVE ARTIFACT /build/dist/owncast.zip owncast.zip AS LOCAL dist/$ZIPNAME
 
-build-all:
-  BUILD +linux-arm64
-  BUILD +linux-arm7
-  BUILD +linux-amd64
-  BUILD +linux-i386
-  BUILD +darwin-amd64
-
-linux-arm64:
-  ARG NAME=linux-arm64
-  BUILD +package --NAME=$NAME --GOOS=linux --GOARCH=arm64 --CC=aarch64-linux-musl-gcc --CXX=aarch64-linux-musl-g++
-
-linux-arm7:
-  ARG NAME=linux-arm7
-  BUILD +package --NAME=$NAME --GOOS=linux --GOARCH=arm --GOARM=7 --CC=armv7l-linux-musleabihf-gcc --CXX=armv7l-linux-musleabihf-g++
-
-linux-amd64:
-  ARG NAME=linux-64bit
-  BUILD +package --NAME=$NAME --GOOS=linux --GOARCH=amd64 --CC=x86_64-linux-musl-gcc --CXX=x86_64-linux-musl-g++
-
-linux-i386:
-  ARG NAME=linux-32bit
-  BUILD +package --NAME=$NAME --GOOS=linux --GOARCH=386 --CC=i686-linux-musl-gcc --CXX=i686-linux-musl-g++
-
-darwin-amd64:
-  ARG NAME=macOS-64bit
-  BUILD +package --NAME=$NAME --GOOS=darwin --GOARCH=amd64 --CC=o64-clang --CXX=o64-clang++


### PR DESCRIPTION
Finalizes the initial Earthfile to produce artifacts for all supported platforms.
`earthly +package` should compile and product a distribution artifact for the current platform.
`earthly +package-all` should produce distribution artifacts for all platforms.
`earthly +docker` should produce a docker image for the current platform.
`earthly +docker-all` should produce docker images for all platforms, but requires emulation.
`earthly --push +docker-all` should publish docker images for all platforms, you might consider using a specific --version tag. It doesn't currently change the :latest tag.

Fixes #1756 - Removes xgo from the build tooling
Works towards #1953 but needs CI integration next.