### PR TITLE
Messages table fixes to improve query performance

### DIFF
--- a/core/data/data.go
+++ b/core/data/data.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	schemaVersion = 5
+	schemaVersion = 6
 )
 
 var (

--- a/core/data/messages.go
+++ b/core/data/messages.go
@@ -24,15 +24,15 @@ func CreateMessagesTable(db *sql.DB) {
 		"link" TEXT,
 		PRIMARY KEY (id)
 	);`
-	MustExec(createTableSQL, db)
+	mustExec(createTableSQL, db)
 
 	// Create indexes
-	MustExec(`CREATE INDEX IF NOT EXISTS user_id_hidden_at_timestamp ON messages (id, user_id, hidden_at, timestamp);`, db)
-	MustExec(`CREATE INDEX IF NOT EXISTS idx_id ON messages (id);`, db)
-	MustExec(`CREATE INDEX IF NOT EXISTS idx_user_id ON messages (user_id);`, db)
-	MustExec(`CREATE INDEX IF NOT EXISTS idx_hidden_at ON messages (hidden_at);`, db)
-	MustExec(`CREATE INDEX IF NOT EXISTS idx_timestamp ON messages (timestamp);`, db)
-	MustExec(`CREATE INDEX IF NOT EXISTS idx_messages_hidden_at_timestamp on messages(hidden_at, timestamp);`, db)
+	mustExec(`CREATE INDEX IF NOT EXISTS user_id_hidden_at_timestamp ON messages (id, user_id, hidden_at, timestamp);`, db)
+	mustExec(`CREATE INDEX IF NOT EXISTS idx_id ON messages (id);`, db)
+	mustExec(`CREATE INDEX IF NOT EXISTS idx_user_id ON messages (user_id);`, db)
+	mustExec(`CREATE INDEX IF NOT EXISTS idx_hidden_at ON messages (hidden_at);`, db)
+	mustExec(`CREATE INDEX IF NOT EXISTS idx_timestamp ON messages (timestamp);`, db)
+	mustExec(`CREATE INDEX IF NOT EXISTS idx_messages_hidden_at_timestamp on messages(hidden_at, timestamp);`, db)
 }
 
 // GetMessagesCount will return the number of messages in the database.

--- a/core/data/messages.go
+++ b/core/data/messages.go
@@ -23,11 +23,10 @@ func CreateMessagesTable(db *sql.DB) {
 		"image" TEXT,
 		"link" TEXT,
 		PRIMARY KEY (id)
-	);
-	`
+	);`
 	MustExec(createTableSQL, db)
 
-	// Crate indexes
+	// Create indexes
 	MustExec(`CREATE INDEX IF NOT EXISTS user_id_hidden_at_timestamp ON messages (id, user_id, hidden_at, timestamp);`, db)
 	MustExec(`CREATE INDEX IF NOT EXISTS idx_id ON messages (id);`, db)
 	MustExec(`CREATE INDEX IF NOT EXISTS idx_user_id ON messages (user_id);`, db)

--- a/core/data/messages.go
+++ b/core/data/messages.go
@@ -28,12 +28,12 @@ func CreateMessagesTable(db *sql.DB) {
 	MustExec(createTableSQL, db)
 
 	// Crate indexes
-	MustExec(`CREATE INDEX user_id_hidden_at_timestamp ON messages (id, user_id, hidden_at, timestamp);`, db)
-	MustExec(`CREATE INDEX idx_id ON messages (id);`, db)
-	MustExec(`CREATE INDEX idx_user_id ON messages (user_id);`, db)
-	MustExec(`CREATE INDEX idx_hidden_at ON messages (hidden_at);`, db)
-	MustExec(`CREATE INDEX idx_timestamp ON messages (timestamp);`, db)
-	MustExec(`CREATE INDEX idx_messages_hidden_at_timestamp on messages(hidden_at, timestamp);`, db)
+	MustExec(`CREATE INDEX IF NOT EXISTS user_id_hidden_at_timestamp ON messages (id, user_id, hidden_at, timestamp);`, db)
+	MustExec(`CREATE INDEX IF NOT EXISTS idx_id ON messages (id);`, db)
+	MustExec(`CREATE INDEX IF NOT EXISTS idx_user_id ON messages (user_id);`, db)
+	MustExec(`CREATE INDEX IF NOT EXISTS idx_hidden_at ON messages (hidden_at);`, db)
+	MustExec(`CREATE INDEX IF NOT EXISTS idx_timestamp ON messages (timestamp);`, db)
+	MustExec(`CREATE INDEX IF NOT EXISTS idx_messages_hidden_at_timestamp on messages(hidden_at, timestamp);`, db)
 }
 
 // GetMessagesCount will return the number of messages in the database.

--- a/core/data/messages.go
+++ b/core/data/messages.go
@@ -13,30 +13,27 @@ import (
 func CreateMessagesTable(db *sql.DB) {
 	createTableSQL := `CREATE TABLE IF NOT EXISTS messages (
 		"id" string NOT NULL,
-		"user_id" INTEGER,
+		"user_id" TEXT,
 		"body" TEXT,
 		"eventType" TEXT,
 		"hidden_at" DATETIME,
 		"timestamp" DATETIME,
-    "title" TEXT,
-    "subtitle" TEXT,
-    "image" TEXT,
-    "link" TEXT,
+		"title" TEXT,
+		"subtitle" TEXT,
+		"image" TEXT,
+		"link" TEXT,
 		PRIMARY KEY (id)
-	);CREATE INDEX index ON messages (id, user_id, hidden_at, timestamp);
-	CREATE INDEX id ON messages (id);
-	CREATE INDEX user_id ON messages (user_id);
-	CREATE INDEX hidden_at ON messages (hidden_at);
-	CREATE INDEX timestamp ON messages (timestamp);`
+	);
+	`
+	MustExec(createTableSQL, db)
 
-	stmt, err := db.Prepare(createTableSQL)
-	if err != nil {
-		log.Fatal("error creating chat messages table", err)
-	}
-	defer stmt.Close()
-	if _, err := stmt.Exec(); err != nil {
-		log.Fatal("error creating chat messages table", err)
-	}
+	// Crate indexes
+	MustExec(`CREATE INDEX user_id_hidden_at_timestamp ON messages (id, user_id, hidden_at, timestamp);`, db)
+	MustExec(`CREATE INDEX idx_id ON messages (id);`, db)
+	MustExec(`CREATE INDEX idx_user_id ON messages (user_id);`, db)
+	MustExec(`CREATE INDEX idx_hidden_at ON messages (hidden_at);`, db)
+	MustExec(`CREATE INDEX idx_timestamp ON messages (timestamp);`, db)
+	MustExec(`CREATE INDEX idx_messages_hidden_at_timestamp on messages(hidden_at, timestamp);`, db)
 }
 
 // GetMessagesCount will return the number of messages in the database.

--- a/core/data/migrations.go
+++ b/core/data/migrations.go
@@ -29,6 +29,8 @@ func migrateDatabaseSchema(db *sql.DB, from, to int) error {
 			migrateToSchema4(db)
 		case 4:
 			migrateToSchema5(db)
+		case 5:
+			migrateToSchema6(db)
 		default:
 			log.Fatalln("missing database migration step")
 		}
@@ -40,6 +42,16 @@ func migrateDatabaseSchema(db *sql.DB, from, to int) error {
 	}
 
 	return nil
+}
+
+func migrateToSchema6(db *sql.DB) {
+	// Fix chat messages table schema. Since chat is ephemeral we can drop
+	// the table and recreate it.
+	// Drop the old messages table
+	MustExec(`DROP TABLE messages`, db)
+
+	// Recreate it
+	CreateMessagesTable(db)
 }
 
 // nolint:cyclop

--- a/core/data/migrations.go
+++ b/core/data/migrations.go
@@ -48,7 +48,7 @@ func migrateToSchema6(db *sql.DB) {
 	// Fix chat messages table schema. Since chat is ephemeral we can drop
 	// the table and recreate it.
 	// Drop the old messages table
-	MustExec(`DROP TABLE messages`, db)
+	mustExec(`DROP TABLE messages`, db)
 
 	// Recreate it
 	CreateMessagesTable(db)

--- a/core/data/utils.go
+++ b/core/data/utils.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// MustExec will execute a SQL statement on a provided database instance.
-func MustExec(s string, db *sql.DB) {
+// mustExec will execute a SQL statement on a provided database instance.
+func mustExec(s string, db *sql.DB) {
 	stmt, err := db.Prepare(s)
 	if err != nil {
 		log.Fatal(err)

--- a/core/data/utils.go
+++ b/core/data/utils.go
@@ -1,0 +1,20 @@
+package data
+
+import (
+	"database/sql"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// MustExec will execute a SQL statement on a provided database instance.
+func MustExec(s string, db *sql.DB) {
+	stmt, err := db.Prepare(s)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer stmt.Close()
+	_, err = stmt.Exec()
+	if err != nil {
+		log.Warnln(err)
+	}
+}

--- a/sqlc.json
+++ b/sqlc.json
@@ -1,9 +1,0 @@
-{
-    "version": "1",
-    "packages": [{
-      "schema": "db/schema.sql",
-      "queries": "db/query.sql",
-      "name": "db",
-      "path": "db"
-    }]
-  } 

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -1,0 +1,6 @@
+version: 1
+packages:
+  - path: db
+    name: db
+    schema: 'db/schema.sql'
+    queries: 'db/query.sql'


### PR DESCRIPTION
- Fixes messages table schema user_id type from `INTEGER` to `TEXT`.
- Add index `idx_messages_hidden_at_timestamp`.
- Fix index name.
- Fix how indexes were being created.
- Add migration that simply drops the `messages` table and recreates it.

Ultimately not a huge improvement, but things are way more correct with these changes.

---

Query plan before changes:
![image](https://user-images.githubusercontent.com/414923/182501783-3c9dc12a-c66c-405a-a32e-6fa81bc77b48.png)

Query duration before changes:
Limit 50: 0.2s

Query plan after changes:
![image](https://user-images.githubusercontent.com/414923/182483309-1723a8e9-0e73-4d4c-9f47-5498469e97ba.png)

Query duration after changes:
Limit 50: 0.14s

Fixes #1890