### PR TITLE
Change validation in social link modal to URI over URL

### DIFF
--- a/web/components/config/edit-social-links.tsx
+++ b/web/components/config/edit-social-links.tsx
@@ -13,7 +13,7 @@ import {
   OTHER_SOCIAL_HANDLE_OPTION,
 } from '../../utils/config-constants';
 import { SocialHandle, UpdateArgs } from '../../types/config-section';
-import isValidUrl, { DEFAULT_TEXTFIELD_URL_PATTERN } from '../../utils/urls';
+import isValidURI from '../../utils/uris';
 import TextField from './form-textfield';
 import { createInputStatus, STATUS_ERROR, STATUS_SUCCESS } from '../../utils/input-statuses';
 import FormStatusIndicator from './form-status-indicator';
@@ -239,7 +239,7 @@ export default function EditSocialLinks() {
   ];
 
   const okButtonProps = {
-    disabled: !isValidUrl(modalDataState.url),
+    disabled: !isValidURI(modalDataState.url),
   };
 
   const otherField = (
@@ -299,7 +299,6 @@ export default function EditSocialLinks() {
             onChange={handleUrlChange}
             useTrim
             type="url"
-            pattern={DEFAULT_TEXTFIELD_URL_PATTERN}
           />
           <FormStatusIndicator status={submitStatus} />
         </div>

--- a/web/utils/uris.ts
+++ b/web/utils/uris.ts
@@ -1,0 +1,3 @@
+export default function isValidURI(uri: string): boolean {
+  return uri.includes(':');
+}

--- a/web/utils/uris.ts
+++ b/web/utils/uris.ts
@@ -1,3 +1,28 @@
 export default function isValidURI(uri: string): boolean {
-  return uri.includes(':');
+  if (uri.includes(':')) {
+    const splittedURI = uri.split(':', 2);
+    if (
+      splittedURI[0] === ''
+    ) {
+      return false;
+    } else if (
+      splittedURI[1] === ''
+    ) {
+      return false;
+    } else if (
+      splittedURI[0] === 'http' ||
+      splittedURI[0] === 'https'
+    ) {
+      if (
+        (uri.slice(0,7) === 'http://' ||
+        uri.slice(0,8) === 'https://') &&
+        splittedURI[1].includes('.')
+      ) {
+        return true;
+      }
+      return false;
+    }
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
This goes along with my last commit (#2044), in order to accept adding of XMPP (and in the future other) URIs in social links instead of just http/https URLs.