### PR TITLE
Draft: rough-ish draft of proposed color theme changes

### DIFF
--- a/web/components/action-buttons/ActionButton.tsx
+++ b/web/components/action-buttons/ActionButton.tsx
@@ -6,10 +6,15 @@ import s from './ActionButton.module.scss';
 
 interface Props {
   action: ExternalAction;
+  primary?: boolean;
 }
+ActionButton.defaultProps = {
+  primary: false,
+};
 
 export default function ActionButton({
   action: { url, title, description, icon, color, openExternally },
+  primary = false,
 }: Props) {
   const [showModal, setShowModal] = useState(false);
 
@@ -24,7 +29,7 @@ export default function ActionButton({
   return (
     <>
       <Button
-        type="primary"
+        type={primary ? 'primary' : 'default'}
         className={`${s.button}`}
         onClick={buttonClicked}
         style={{ backgroundColor: color }}

--- a/web/components/chat/ChatSystemMessage/ChatSystemMessage.module.scss
+++ b/web/components/chat/ChatSystemMessage/ChatSystemMessage.module.scss
@@ -1,5 +1,5 @@
 .chatSystemMessage {
-  background: var(--theme-background-secondary);
+  background: var(--theme-color-background-main);
   background: linear-gradient(
     70deg,
     rgb(78, 54, 114) 0%,
@@ -31,8 +31,7 @@
     mark {
       padding-left: 0.35em;
       padding-right: 0.35em;
-      color: var(--theme-text-highlight);
-      background-color: var(--color-bg-highlight);
+      background-color: var(--theme-color-palette-12);
     }
   }
 }

--- a/web/components/chat/ChatTextField/ChatTextField.module.scss
+++ b/web/components/chat/ChatTextField/ChatTextField.module.scss
@@ -4,8 +4,7 @@
   bottom: 0px;
   width: 100%;
   padding: 0.3rem;
-  // color: var(--text-secondry);
-  color: var(--form-field-text);
+  color: var(--theme-color-components-form-field-text);
   overflow-x: hidden;
 
   div[role='textbox'] {
@@ -13,9 +12,8 @@
     border-radius: 0.2rem;
     padding: 0.6rem;
     padding-right: calc(0.6rem + 44px);
-    // background-color: var(--color-owncast-gray-700);
-    background-color: var(--form-field-background);
-    border-color: var(--form-field-border);
+    background-color: var(--theme-color-components-form-field-background);
+    border-color: var(--theme-color-components-form-field-border);
     box-shadow: 0;
     transition: box-shadow 50ms ease-in-out;
     &:focus {

--- a/web/components/chat/ChatTextField/ChatTextField.module.scss
+++ b/web/components/chat/ChatTextField/ChatTextField.module.scss
@@ -4,14 +4,18 @@
   bottom: 0px;
   width: 100%;
   padding: 0.3rem;
-  color: var(--theme-text-secondary);
+  // color: var(--text-secondry);
+  color: var(--form-field-text);
   overflow-x: hidden;
+
   div[role='textbox'] {
     font-size: 0.9rem;
     border-radius: 0.2rem;
     padding: 0.6rem;
     padding-right: calc(0.6rem + 44px);
-    background-color: var(--color-owncast-gray-700);
+    // background-color: var(--color-owncast-gray-700);
+    background-color: var(--form-field-background);
+    border-color: var(--form-field-border);
     box-shadow: 0;
     transition: box-shadow 50ms ease-in-out;
     &:focus {

--- a/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
@@ -13,13 +13,12 @@
     font-weight: bold;
   }
   .message {
-    // color: var(--theme-text-primary);
-		color: var(--chat-text);
+    color: var(--theme-color-components-chat-text);
 
     mark {
       padding-left: 0.35em;
       padding-right: 0.35em;
-      color: var(--theme-text-highlight);
+      color: var(--theme-color-palette-12);
     }
   }
 

--- a/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
@@ -13,7 +13,8 @@
     font-weight: bold;
   }
   .message {
-    color: var(--theme-text-primary);
+    // color: var(--theme-text-primary);
+		color: var(--chat-text);
 
     mark {
       padding-left: 0.35em;

--- a/web/components/common/ContentHeader/ContentHeader.module.scss
+++ b/web/components/common/ContentHeader/ContentHeader.module.scss
@@ -1,7 +1,7 @@
 .root {
   position: relative;
   display: grid;
-	padding: 20px 10px;
+	padding: 20px;
 }
 
 .buttonsLogoTitleSection {
@@ -33,10 +33,10 @@
 
   .title {
 		font-family: var(--theme-text-display-font-family);
+		color: var(--primary-dark);
     font-size: 32px;
     font-weight: bold;
-    color: black;
-    text-transform: uppercase;
+    // text-transform: uppercase;
     line-height: 30px;
   }
 
@@ -44,18 +44,20 @@
     font-size: 22px;
     font-weight: 300;
 		line-height: 1.3;
-    color: var(--theme-text-secondary);
+    // color: var(--theme-text-secondary);
+    color: var(--secondary-dark);
   }
 }
 
 .tagList {
-  // font-family: var(--theme-text-display-font-family);
-  color: var(--theme-text-primary);
+  // font-family: var(--theme-text-display-font-family); // don't need this
+  // color: var(--theme-text-primary);
+  color: var(--neutral-gray-light);
 
   span {
     display: inline-block;
     margin-right: 8px;
     font-size: 14px;
-    font-weight: 400;
+    font-weight: 500;
   }
 }

--- a/web/components/common/ContentHeader/ContentHeader.module.scss
+++ b/web/components/common/ContentHeader/ContentHeader.module.scss
@@ -1,7 +1,7 @@
 .root {
   position: relative;
   display: grid;
-	padding: 20px;
+  padding: 20px;
 }
 
 .buttonsLogoTitleSection {
@@ -29,30 +29,26 @@
 .titleSection {
   display: flex;
   flex-direction: column;
-	margin-left: 10px;
+  margin-left: 10px;
 
   .title {
-		font-family: var(--theme-text-display-font-family);
-		color: var(--primary-dark);
+    font-family: var(--theme-text-display-font-family);
+    color: var(--theme-color-palette-0);
     font-size: 32px;
     font-weight: bold;
-    // text-transform: uppercase;
     line-height: 30px;
   }
 
   .subtitle {
     font-size: 22px;
     font-weight: 300;
-		line-height: 1.3;
-    // color: var(--theme-text-secondary);
-    color: var(--secondary-dark);
+    line-height: 1.3;
+    color: var(--theme-color-background-header);
   }
 }
 
 .tagList {
-  // font-family: var(--theme-text-display-font-family); // don't need this
-  // color: var(--theme-text-primary);
-  color: var(--neutral-gray-light);
+  color: var(--theme-color-palette-10);
 
   span {
     display: inline-block;

--- a/web/components/common/ContentHeader/ContentHeader.module.scss
+++ b/web/components/common/ContentHeader/ContentHeader.module.scss
@@ -1,6 +1,7 @@
 .root {
   position: relative;
   display: grid;
+	padding: 20px 10px;
 }
 
 .buttonsLogoTitleSection {
@@ -28,8 +29,10 @@
 .titleSection {
   display: flex;
   flex-direction: column;
+	margin-left: 10px;
 
   .title {
+		font-family: var(--theme-text-display-font-family);
     font-size: 32px;
     font-weight: bold;
     color: black;
@@ -38,21 +41,21 @@
   }
 
   .subtitle {
-    font-size: 24px;
-    font-weight: 400;
-    line-height: 22px;
+    font-size: 22px;
+    font-weight: 300;
+		line-height: 1.3;
     color: var(--theme-text-secondary);
   }
 }
 
 .tagList {
-  font-family: var(--theme-text-display-font-family);
+  // font-family: var(--theme-text-display-font-family);
   color: var(--theme-text-primary);
 
   span {
     display: inline-block;
     margin-right: 8px;
     font-size: 14px;
-    font-weight: 300;
+    font-weight: 400;
   }
 }

--- a/web/components/common/Logo/Logo.module.scss
+++ b/web/components/common/Logo/Logo.module.scss
@@ -12,7 +12,6 @@
 .contrast {
   padding: 5px;
   border-radius: 50%;
-  background-color: var(--color-owncast-gray-100);
   svg {
     width: clamp(2rem, 7vw, 40px);
     height: clamp(2rem, 7vw, 40px);

--- a/web/components/common/UserDropdown/UserDropdown.module.scss
+++ b/web/components/common/UserDropdown/UserDropdown.module.scss
@@ -1,5 +1,10 @@
 .root {
   button {
     border: none;
+		.ant-space {
+			.ant-space-item {
+				color: var(--theme-unknown-2);
+			}
+		}
   }
 }

--- a/web/components/common/UserDropdown/UserDropdown.tsx
+++ b/web/components/common/UserDropdown/UserDropdown.tsx
@@ -68,7 +68,7 @@ export default function UserDropdown({ username: defaultUsername }: Props) {
   return (
     <div className={`${s.root}`}>
       <Dropdown overlay={menu} trigger={['click']}>
-        <Button icon={<UserOutlined style={{ marginRight: '.5rem' }} />}>
+        <Button type="primary" icon={<UserOutlined style={{ marginRight: '.5rem' }} />}>
           <Space>
             {username}
             <CaretDownOutlined />

--- a/web/components/modals/Follow/FollowModal.tsx
+++ b/web/components/modals/Follow/FollowModal.tsx
@@ -111,10 +111,12 @@ export default function FollowModal(props: Props) {
           </div>
         </div>
         <Space className={s.buttons}>
-          <Button disabled={!valid} onClick={remoteFollowButtonPressed}>
+          <Button disabled={!valid} type="primary" onClick={remoteFollowButtonPressed}>
             Follow
           </Button>
-          <Button onClick={joinButtonPressed}>Join the Fediverse</Button>
+          <Button onClick={joinButtonPressed} type="primary">
+            Join the Fediverse
+          </Button>
         </Space>
       </Spin>
     </Space>

--- a/web/components/modals/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal.tsx
@@ -18,7 +18,7 @@ function UserColor(props: { color: number }): React.ReactElement {
   const { color } = props;
   const style: CSSProperties = {
     textAlign: 'center',
-    backgroundColor: `var(--theme-user-colors-${color})`,
+    backgroundColor: `var(--theme-color-users-${color})`,
     width: '100%',
     height: '100%',
   };

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -2,15 +2,15 @@
   display: grid;
   grid-template-columns: 1fr auto;
 
-	background-color: var(--main-background);
+  background-color: var(--theme-color-background-main);
 
-	.topSection {
-		padding: 0;
-		background-color: var(--background-video)
-	}
-	.lowerSection {
-		padding: 0em 2em;
-	}
+  .topSection {
+    padding: 0;
+    background-color: var(--theme-color-components-video-background);
+  }
+  .lowerSection {
+    padding: 0em 2em;
+  }
 }
 
 .leftCol {
@@ -35,7 +35,6 @@
       display: grid;
       grid-template-rows: 30vh 5vh 5vh;
       height: 40vh;
-      // overflow: hidden;
     }
     .lowerSection {
       height: 60vh;

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -1,7 +1,13 @@
 .root {
   display: grid;
   grid-template-columns: 1fr auto;
-  padding: 0.7em;
+
+	.topHalf {
+		padding: 1em;
+	}
+	.lowerHalf {
+		padding: 0em 2em;
+	}
 }
 
 .leftCol {

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -2,10 +2,13 @@
   display: grid;
   grid-template-columns: 1fr auto;
 
-	.topHalf {
-		padding: 1em;
+	background-color: var(--main-background);
+
+	.topSection {
+		padding: 0;
+		background-color: var(--background-video)
 	}
-	.lowerHalf {
+	.lowerSection {
 		padding: 0em 2em;
 	}
 }
@@ -28,13 +31,13 @@
     flex-direction: column;
     height: calc(100vh - 64px);
     overflow: hidden;
-    .topHalf {
+    .topSection {
       display: grid;
       grid-template-rows: 30vh 5vh 5vh;
       height: 40vh;
       // overflow: hidden;
     }
-    .lowerHalf {
+    .lowerSection {
       height: 60vh;
     }
   }

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -113,7 +113,8 @@ export default function ContentComponent() {
     <Content className={rootClassName}>
       <div className={s.leftContent}>
         <Spin className={s.loadingSpinner} size="large" spinning={appState.appLoading} />
-        <div className={s.topHalf}>
+
+        <div className={s.topSection}>
           {online && <OwncastPlayer source="/hls/stream.m3u8" online={online} />}
           {!online && (
             <OfflineBanner
@@ -129,6 +130,8 @@ export default function ContentComponent() {
             lastDisconnectTime={lastDisconnectTime}
             viewerCount={viewerCount}
           />
+        </div>
+        <div className={s.midSection}>
           <div className={s.buttonsLogoTitleSection}>
             <ActionButtonRow>
               {externalActionButtons}
@@ -161,6 +164,9 @@ export default function ContentComponent() {
             links={socialHandles}
             logo="/logo"
           />
+        </div>
+
+        <div className={s.lowerSection}>
           <Tabs defaultActiveKey="0" style={{ height: '100%' }}>
             {isChatVisible && isMobile && (
               <TabPane tab="Chat" key="0" style={{ height: '100%' }}>

--- a/web/components/ui/CustomPageContent/CustomPageContent.module.scss
+++ b/web/components/ui/CustomPageContent/CustomPageContent.module.scss
@@ -9,12 +9,12 @@
   line-height: 1.5em;
   margin: 0;
   padding: 0;
-  width: 80%;
-  max-width: 1200px;
+  // width: 95%;
+  // max-width: 1200px;
 
-  color: var(--theme-text);
+  color: var(--theme-text-primary);
   background-color: var(--theme-background-secondary);
-  padding: 1em;
+  padding: 2.5em;
 
   // Allow the content to fill the width on narrow screens.
   @media only screen and (max-width: 768px) {

--- a/web/components/ui/CustomPageContent/CustomPageContent.module.scss
+++ b/web/components/ui/CustomPageContent/CustomPageContent.module.scss
@@ -12,9 +12,11 @@
   // width: 95%;
   // max-width: 1200px;
 
-  color: var(--theme-text-primary);
-  background-color: var(--theme-background-secondary);
-  padding: 2.5em;
+  // color: var(--theme-text-primary);
+  // background-color: var(--theme-background-secondary);
+  color: var(--primary-dark);
+  background-color: var(--secondary-light);
+  padding: calc(3 * var(--content-padding));
 
   // Allow the content to fill the width on narrow screens.
   @media only screen and (max-width: 768px) {

--- a/web/components/ui/CustomPageContent/CustomPageContent.module.scss
+++ b/web/components/ui/CustomPageContent/CustomPageContent.module.scss
@@ -9,14 +9,10 @@
   line-height: 1.5em;
   margin: 0;
   padding: 0;
-  // width: 95%;
-  // max-width: 1200px;
-
-  // color: var(--theme-text-primary);
-  // background-color: var(--theme-background-secondary);
-  color: var(--primary-dark);
-  background-color: var(--secondary-light);
+  color: var(--theme-color-palette-0);
+  background-color: var(--theme-color-palette-4);
   padding: calc(3 * var(--content-padding));
+  border-radius: var(--theme-rounded-corners);
 
   // Allow the content to fill the width on narrow screens.
   @media only screen and (max-width: 768px) {

--- a/web/components/ui/Footer/Footer.module.scss
+++ b/web/components/ui/Footer/Footer.module.scss
@@ -1,8 +1,7 @@
 .footer {
   font-size: 0.85em;
   font-weight: 500;
-  // color: var(--theme-text-secondary);
-  color: var(--secondary-dark);
-	background-color: transparent;
-	padding: var(--content-padding);
+  color: var(--theme-color-palette-1);
+  background-color: transparent;
+  padding: var(--content-padding);
 }

--- a/web/components/ui/Footer/Footer.module.scss
+++ b/web/components/ui/Footer/Footer.module.scss
@@ -1,5 +1,8 @@
 .footer {
   font-size: 0.85em;
   font-weight: 500;
-  color: var(--theme-text-secondary);
+  // color: var(--theme-text-secondary);
+  color: var(--secondary-dark);
+	background-color: transparent;
+	padding: var(--content-padding);
 }

--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -5,18 +5,18 @@
   align-items: center;
   justify-content: space-between;
   z-index: 20;
-  padding: 0.4rem .7rem;
-	box-shadow: 0px 1px 3px 1px rgb(0 0 0 / 10%);
+  padding: 0.4rem 0.7rem;
+  box-shadow: 0px 1px 3px 1px rgb(0 0 0 / 10%);
 
-	background-color: var(--header-background);
+  background-color: var(--theme-color-background-header);
 
   .logo {
     display: flex;
     align-items: center;
     span {
-			color: var(--general-text-on-dark);
-			font-family: var(--theme-text-display-font-family);
-      margin-left: .5rem;
+      color: var(--theme-color-components-text-on-dark);
+      font-family: var(--theme-text-display-font-family);
+      margin-left: 0.5rem;
       font-size: 1.5rem;
       font-weight: 600;
     }

--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -7,10 +7,14 @@
   z-index: 20;
   padding: 0.4rem .7rem;
 	box-shadow: 0px 1px 3px 1px rgb(0 0 0 / 10%);
+
+	background-color: var(--header-background);
+
   .logo {
     display: flex;
     align-items: center;
     span {
+			color: var(--general-text-on-dark);
 			font-family: var(--theme-text-display-font-family);
       margin-left: .5rem;
       font-size: 1.5rem;

--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -6,11 +6,12 @@
   justify-content: space-between;
   z-index: 20;
   padding: 0.4rem .7rem;
-  background-color: var(--default-bg-color);
+	box-shadow: 0px 1px 3px 1px rgb(0 0 0 / 10%);
   .logo {
     display: flex;
     align-items: center;
     span {
+			font-family: var(--theme-text-display-font-family);
       margin-left: .5rem;
       font-size: 1.5rem;
       font-weight: 600;

--- a/web/components/ui/Logo/Logo.module.scss
+++ b/web/components/ui/Logo/Logo.module.scss
@@ -10,8 +10,8 @@
   border-radius: 50%;
   border-width: 5px;
   border-style: solid;
-  border-color: var(--theme-primary-color);
-  background-color: var(--theme-background-secondary);
+  border-color: var(--theme-color-palette-0);
+  background-color: var(--theme-color-palette-4);
 }
 
 .container {

--- a/web/components/ui/Modal/Modal.module.scss
+++ b/web/components/ui/Modal/Modal.module.scss
@@ -8,4 +8,5 @@
   display: block;
   height: 100%;
   padding: 2vw;
+	background-color: var(--modal-content-background);
 }

--- a/web/components/ui/Modal/Modal.module.scss
+++ b/web/components/ui/Modal/Modal.module.scss
@@ -8,5 +8,5 @@
   display: block;
   height: 100%;
   padding: 2vw;
-	background-color: var(--modal-content-background);
+  background-color: var(--theme-color-components-modal-content-background);
 }

--- a/web/components/ui/OfflineBanner/OfflineBanner.module.scss
+++ b/web/components/ui/OfflineBanner/OfflineBanner.module.scss
@@ -7,7 +7,8 @@
   width: clamp(200px, 100%, 300px);
   display: flex;
   flex-direction: column;
-  background-color: var(--theme-background-secondary);
+  color: var(--theme-color-components-text-on-light);
+  background-color: var(--theme-color-background-main);
   margin: 1rem auto;
   border-radius: var(--theme-rounded-corners);
   padding: 1rem;

--- a/web/components/ui/Sidebar/Sidebar.module.scss
+++ b/web/components/ui/Sidebar/Sidebar.module.scss
@@ -1,5 +1,6 @@
 .root {
-  background-color: var(--theme-background-secondary);
+  // background-color: var(--theme-background-secondary);
+  background-color: var(--secondary-dark);
   display: none;
   --header-h: 64px;
 }
@@ -13,7 +14,7 @@
     max-height: calc(100vh - var(--header-h));
   }
 }
-/* 
+/*
 First div is .ant-layout-sider-children
 Only way to target it apparently
 */

--- a/web/components/ui/Sidebar/Sidebar.module.scss
+++ b/web/components/ui/Sidebar/Sidebar.module.scss
@@ -1,6 +1,5 @@
 .root {
-  // background-color: var(--theme-background-secondary);
-  background-color: var(--secondary-dark);
+  background-color: var(--theme-color-components-chat-background);
   display: none;
   --header-h: 64px;
 }
@@ -25,4 +24,3 @@ Only way to target it apparently
   flex-grow: 1 !important;
   height: 100% !important;
 }
-

--- a/web/components/ui/Statusbar/Statusbar.module.scss
+++ b/web/components/ui/Statusbar/Statusbar.module.scss
@@ -1,11 +1,10 @@
 .statusbar {
   display: flex;
   align-items: center;
-  font-size: .8rem;
+  font-size: 0.8rem;
   justify-content: space-between;
   height: 2rem;
   width: 100%;
-	padding: var(--content-padding);
-  color: var(--alt-light);
-  // background-color: var(--theme-background-secondary);
+  padding: var(--content-padding);
+  color: var(--theme-color-palette-5);
 }

--- a/web/components/ui/Statusbar/Statusbar.module.scss
+++ b/web/components/ui/Statusbar/Statusbar.module.scss
@@ -5,6 +5,7 @@
   justify-content: space-between;
   height: 2rem;
   width: 100%;
-  color: var(--theme-text-primary);
+	padding: var(--content-padding);
+  color: var(--alt-light);
   // background-color: var(--theme-background-secondary);
 }

--- a/web/components/ui/Statusbar/Statusbar.module.scss
+++ b/web/components/ui/Statusbar/Statusbar.module.scss
@@ -2,11 +2,9 @@
   display: flex;
   align-items: center;
   font-size: .8rem;
-  padding-left: 10px;
-  padding-right: 10px;
   justify-content: space-between;
   height: 2rem;
   width: 100%;
-  color: var(--color-owncast-gray-300);
-  background-color: var(--theme-background-secondary);
+  color: var(--theme-text-primary);
+  // background-color: var(--theme-background-secondary);
 }

--- a/web/components/video/player.scss
+++ b/web/components/video/player.scss
@@ -1,21 +1,19 @@
 /* Change all text and icon colors in the player. */
 .vjs-owncast.video-js {
-  color: var(--theme-text-secondary);
+  color: var(--theme-color-components-text-on-light);
 }
 
 .vjs-owncast .vjs-big-play-button {
   z-index: 10;
-  // color: var(--theme-text-secondary);
-  color: var(--action);
+  color: var(--theme-color-action);
   font-size: 8rem !important;
   border-color: transparent !important;
   border-radius: var(--theme-rounded-corners) !important;
   background-color: transparent !important;
   text-shadow: 2px 3px 4px #0000005f;
 
-	-webkit-text-stroke: 2px white;
-	text-stroke: 2px white;
-
+  -webkit-text-stroke: 2px white;
+  text-stroke: 2px white;
 
   :hover {
     transition: all 0.2s ease-in-out;
@@ -27,16 +25,16 @@
 .vjs-owncast .vjs-loading-spinner {
   z-index: 10;
   display: block;
-  color: var(--theme-text-secondary);
+  color: var(--theme-color-components-text-on-light);
 }
 
 .vjs-owncast .vjs-control-bar {
-  color: var(--theme-text-secondary);
-  background-color: var(--theme-background-primary) !important;
+  color: var(--theme-color-components-text-on-light);
+  background-color: var(--theme-color-background-main) !important;
 }
 
 .vjs-owncast .vjs-control {
-  color: var(--theme-text-secondary);
+  color: var(--theme-color-components-text-on-light);
 }
 
 .vjs-airplay .vjs-icon-placeholder::before {

--- a/web/components/video/player.scss
+++ b/web/components/video/player.scss
@@ -5,16 +5,21 @@
 
 .vjs-owncast .vjs-big-play-button {
   z-index: 10;
-  color: var(--theme-text-secondary);
-  font-size: 15rem !important;
+  // color: var(--theme-text-secondary);
+  color: var(--action);
+  font-size: 8rem !important;
   border-color: transparent !important;
   border-radius: var(--theme-rounded-corners) !important;
   background-color: transparent !important;
   text-shadow: 2px 3px 4px #0000005f;
 
+	-webkit-text-stroke: 2px white;
+	text-stroke: 2px white;
+
+
   :hover {
     transition: all 0.2s ease-in-out;
-    font-size: 20rem;
+    font-size: 10rem;
     text-shadow: 2px 5px 4px #00000093;
   }
 }

--- a/web/stories/Color.tsx
+++ b/web/stories/Color.tsx
@@ -1,3 +1,5 @@
+import he from 'date-fns/esm/locale/he/index.js';
+import { unset } from 'lodash';
 import PropTypes from 'prop-types';
 
 export function Color(props) {
@@ -35,8 +37,9 @@ export function Color(props) {
   const colorDescriptionStyle = {
     margin: '5px',
     color: 'gray',
-    fontSize: '0.9vw',
+    fontSize: '0.95vw',
     textAlign: 'center' as 'center',
+    lineHeight: 1.0,
   };
 
   return (

--- a/web/stories/Colors.stories.mdx
+++ b/web/stories/Colors.stories.mdx
@@ -58,8 +58,8 @@ These color names are assigned to specific component variables. They can be over
     'theme-color-components-chat-text',
     'theme-color-components-modal-header-background',
     'theme-color-components-modal-header-text',
-    'theme-color-components-modal-header-content-background',
-    'theme-color-components-modal-header-content-text',
+    'theme-color-components-modal-content-background',
+    'theme-color-components-modal-content-text',
     'theme-color-components-menu-background',
     'theme-color-components-menu-item-text',
     'theme-color-components-menu-item-bg',
@@ -99,13 +99,13 @@ They should not be overwritten, instead the theme variables should be overwritte
 
 <ColorRow
   colors={[
-    'color-owncast-user-0',
-    'color-owncast-user-1',
-    'color-owncast-user-2',
-    'color-owncast-user-3',
-    'color-owncast-user-4',
-    'color-owncast-user-5',
-    'color-owncast-user-6',
-    'color-owncast-user-7',
+    'theme-color-users-0',
+    'theme-color-users-1',
+    'theme-color-users-2',
+    'theme-color-users-3',
+    'theme-color-users-4',
+    'theme-color-users-5',
+    'theme-color-users-6',
+    'theme-color-users-7',
   ]}
 />

--- a/web/stories/Colors.stories.mdx
+++ b/web/stories/Colors.stories.mdx
@@ -1,34 +1,111 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { Color, ColorRow } from './Color';
 
-<Meta title="owncast/Style Guide/Colors" />
+<Meta title="owncast/Style Guide/Default Theme" />
 
-# Colors
+# Default theme colors
 
 These colors are assigned in our [color token](https://github.com/owncast/owncast/tree/webv2/web/style-definitions/tokens/color) files
-and get reflected here as they change. run `npm build-styles` to regenerate.
+and get reflected here as they change. run `npm run build-styles` to regenerate.
 
-Toggle dark mode on and off in the above toolbar to see how these colors look on a dark vs. light background.
+## Default Theme
 
-## Text
+These color names are assigned to specific component variables. They can be overwritten via CSS.
 
-<ColorRow colors={['theme-text-primary', 'theme-text-secondary', 'theme-text-link']} />
+<ColorRow
+  colors={[
+    'theme-color-palette-0',
+    'theme-color-palette-1',
+    'theme-color-palette-2',
+    'theme-color-palette-3',
+    'theme-color-palette-4',
+    'theme-color-palette-5',
+    'theme-color-palette-6',
+    'theme-color-palette-7',
+    'theme-color-palette-8',
+    'theme-color-palette-9',
+    'theme-color-palette-10',
+    'theme-color-palette-11',
+    'theme-color-palette-12',
+    'theme-color-palette-13',
+    'theme-color-palette-error',
+    'theme-color-palette-warning',
+    'theme-color-background-main',
+    'theme-color-background-header',
+    'theme-color-action',
+    'theme-color-action-hover',
+    'theme-color-action-disabled',
+  ]}
+/>
 
-## Backgrounds
+## Component Colors
 
-<ColorRow colors={['theme-background-primary', 'theme-background-secondary']} />
+<ColorRow
+  colors={[
+    'theme-color-components-text-on-light',
+    'theme-color-components-text-on-dark',
+    'theme-color-components-primary-button-background',
+    'theme-color-components-primary-button-background-disabled',
+    'theme-color-components-primary-button-text',
+    'theme-color-components-primary-button-text-disabled',
+    'theme-color-components-primary-button-border',
+    'theme-color-components-secondary-button-background',
+    'theme-color-components-secondary-button-background-disabled',
+    'theme-color-components-secondary-button-text',
+    'theme-color-components-secondary-button-text-disabled',
+    'theme-color-components-secondary-button-border',
+    'theme-color-components-chat-background',
+    'theme-color-components-chat-text',
+    'theme-color-components-modal-header-background',
+    'theme-color-components-modal-header-text',
+    'theme-color-components-modal-header-content-background',
+    'theme-color-components-modal-header-content-text',
+    'theme-color-components-menu-background',
+    'theme-color-components-menu-item-text',
+    'theme-color-components-menu-item-bg',
+    'theme-color-components-menu-item-hover-bg',
+    'theme-color-components-menu-item-focus-bg',
+    'theme-color-components-form-field-background',
+    'theme-color-components-form-field-placeholder',
+    'theme-color-components-form-field-text',
+    'theme-color-components-form-field-border',
+  ]}
+/>
+
+## Default Palette
+
+These are the core colors for the default, out of the box, Owncast web application theme.
+They should not be overwritten, instead the theme variables should be overwritten.
+
+<ColorRow
+  colors={[
+    'color-owncast-palette-0',
+    'color-owncast-palette-1',
+    'color-owncast-palette-2',
+    'color-owncast-palette-3',
+    'color-owncast-palette-4',
+    'color-owncast-palette-5',
+    'color-owncast-palette-6',
+    'color-owncast-palette-7',
+    'color-owncast-palette-9',
+    'color-owncast-palette-10',
+    'color-owncast-palette-11',
+    'color-owncast-palette-12',
+    'color-owncast-palette-13',
+  ]}
+/>
 
 ## User Colors
 
 <ColorRow
   colors={[
-    'theme-user-colors-0',
-    'theme-user-colors-1',
-    'theme-user-colors-2',
-    'theme-user-colors-3',
-    'theme-user-colors-4',
-    'theme-user-colors-5',
-    'theme-user-colors-6',
-    'theme-user-colors-7',
+    'color-owncast-user-0',
+    'color-owncast-user-1',
+    'color-owncast-user-2',
+    'color-owncast-user-3',
+    'color-owncast-user-4',
+    'color-owncast-user-5',
+    'color-owncast-user-6',
+    'color-owncast-user-7',
   ]}
 />

--- a/web/style-definitions/tokens/color/antd-overrides.yaml
+++ b/web/style-definitions/tokens/color/antd-overrides.yaml
@@ -2,23 +2,17 @@
 # You can find the variable names to override at:
 # https://github.com/ant-design/ant-design/blob/master/components/style/themes/dark.less
 
-text-color:
-  value: 'var(--theme-text-primary)'
-text-color-secondary:
-  value: 'var(--theme-text-secondary)'
 link-color:
-  value: 'var(--theme-text-link)'
-popover-background:
-  value: 'var(--theme-background-secondary)'
+  value: 'var(--theme-color-action)'
+link-hover-color:
+  value: 'var(--theme-color-action-hover)'
+modal-header-bg:
+  value: 'var(--theme-color-components-modal-header-background)'
 modal-content-bg:
-  value: '{color.unknown-2.value}'
-background-color-light:
-  value: 'var(--theme-background-secondary)'
-layout-body-background:
-  value: 'var(--theme-background-primary)'
-
-# These colors need to be explicitly set and cannot use CSS variables.
-component-background:
-  value: '{color.unknown.value}'
-warning-color:
-  value: '{color.unknown-2.value}'
+  value: 'var(--theme-color-background-main)'
+alert-error-bg-color:
+  value: 'var(--theme-color-palette-4)'
+alert-error-border-color:
+  value: 'var(--theme-color-palette-error)'
+popover-background:
+  value: 'var(--theme-color-components-menu-background)'

--- a/web/style-definitions/tokens/color/default-theme.yaml
+++ b/web/style-definitions/tokens/color/default-theme.yaml
@@ -17,176 +17,175 @@ theme:
     users:
       comment: 'Colors used to display chat users.'
       0:
-        value: '{color.owncast.user.0.value}'
+        value: 'var(--color-owncast-user-0)'
       1:
-        value: '{color.owncast.user.1.value}'
+        value: 'var(--color-owncast-user-1)'
       2:
-        value: '{color.owncast.user.2.value}'
+        value: 'var(--color-owncast-user-2)'
       3:
-        value: '{color.owncast.user.3.value}'
+        value: 'var(--color-owncast-user-3)'
       4:
-        value: '{color.owncast.user.4.value}'
+        value: 'var(--color-owncast-user-4)'
       5:
-        value: '{color.owncast.user.5.value}'
+        value: 'var(--color-owncast-user-5)'
       6:
-        value: '{color.owncast.user.6.value}'
+        value: 'var(--color-owncast-user-6)'
       7:
-        value: '{color.owncast.user.7.value}'
+        value: 'var(--color-owncast-user-7)'
 
     palette:
       comment: 'Colors used in the user interface for the default theme.'
       0:
-        value: '{color.owncast.palette.0.value}'
+        value: 'var(--color-owncast-palette-0)'
         comment: '{color.owncast.palette.0.comment}'
       1:
-        value: '{color.owncast.palette.1.value}'
+        value: 'var(--color-owncast-palette-1)'
         comment: '{color.owncast.palette.1.comment}'
       2:
-        value: '{color.owncast.palette.2.value}'
+        value: 'var(--color-owncast-palette-2)'
         comment: '{color.owncast.palette.2.comment}'
       3:
-        value: '{color.owncast.palette.3.value}'
+        value: 'var(--color-owncast-palette-3)'
         comment: '{color.owncast.palette.3.comment}'
       4:
-        value: '{color.owncast.palette.4.value}'
+        value: 'var(--color-owncast-palette-4)'
         comment: '{color.owncast.palette.4.comment}'
       5:
-        value: '{color.owncast.palette.5.value}'
+        value: 'var(--color-owncast-palette-5)'
         comment: '{color.owncast.palette.5.comment}'
       6:
-        value: '{color.owncast.palette.6.value}'
+        value: 'var(--color-owncast-palette-6)'
         comment: '{color.owncast.palette.6.comment}'
       7:
-        value: '{color.owncast.palette.7.value}'
+        value: 'var(--color-owncast-palette-7)'
         comment: '{color.owncast.palette.7.comment}'
       8:
-        value: '{color.owncast.palette.8.value}'
+        value: 'var(--color-owncast-palette-8)'
         comment: '{color.owncast.palette.8.comment}'
       9:
-        value: '{color.owncast.palette.9.value}'
+        value: 'var(--color-owncast-palette-9)'
         comment: '{color.owncast.palette.9.comment}'
       10:
-        value: '{color.owncast.palette.10.value}'
+        value: 'var(--color-owncast-palette-10)'
         comment: '{color.owncast.palette.10.comment}'
       11:
-        value: '{color.owncast.palette.11.value}'
+        value: 'var(--color-owncast-palette-11)'
         comment: '{color.owncast.palette.11.comment}'
       12:
-        value: '{color.owncast.palette.12.value}'
+        value: 'var(--color-owncast-palette-12)'
         comment: '{color.owncast.palette.12.comment}'
       13:
-        value: '{color.owncast.palette.13.value}'
+        value: 'var(--color-owncast-palette-13)'
         comment: '{color.owncast.palette.13.comment}'
       error:
-        value: '{color.owncast.palette.error.value}'
+        value: 'var(--color-owncast-palette-error)'
         comment: '{color.owncast.palette.error.comment}'
       warning:
-        value: '{color.owncast.palette.warning.value}'
+        value: 'var(--color-owncast-palette-warning)'
         comment: '{color.owncast.palette.warning.comment}'
 
     background:
       main:
-        value: '{theme.color.palette.3.value}'
+        value: 'var(--theme-color-palette-3)'
         comment: '{theme.color.palette.3.comment}'
       header:
-        value: '{theme.color.palette.0.value}'
+        value: 'var(--theme-color-palette-0)'
         comment: '{theme.color.palette.0.comment}'
     action:
-      value: '{theme.color.palette.6.value}'
+      value: 'var(--theme-color-palette-6)'
       comment: '{theme.color.palette.6.comment}'
     action-hover:
-      value: '{theme.color.palette.7.value}'
+      value: 'var(--theme-color-palette-7)'
       comment: '{theme.color.palette.7.comment}'
     action-disabled:
-      value: '{theme.color.palette.8.value}'
+      value: 'var(--theme-color-palette-8)'
       comment: '{theme.color.palette.8.comment}'
 
     error:
-      value: '{theme.color.palette.error.value}'
+      value: 'var(--theme-color-palette-error)'
       comment: '{theme.color.palette.error.comment}'
     warning:
-      value: '{theme.color.palette.warning.value}'
+      value: 'var(--theme-color-palette-warning)'
       comment: '{theme.color.palette.warning.comment}'
 
     components:
       text-on-light:
-        value: '{theme.color.palette.0.value}'
+        value: 'var(--theme-color-palette-0)'
         comment: '{theme.color.palette.0.comment}'
       text-on-dark:
-        value: '{theme.color.palette.3.value}'
+        value: 'var(--theme-color-palette-3)'
         comment: '{theme.color.palette.3.comment}'
 
       primary-button:
         background:
-          value: '{theme.color.action.value}'
+          value: 'var(--theme-color-action)'
           comment: '{theme.color.action.comment}'
         background-disabled:
-          value: '{theme.color.action-disabled.value}'
+          value: 'var(--theme-color-action-disabled)'
           comment: '{theme.color.action-disabled.comment}'
         text:
-          value: '{theme.color.palette.4.value}'
+          value: 'var(--theme-color-palette-4)'
           comment: '{theme.color.palette.4.comment}'
         text-disabled:
-          value: '{theme.color.palette.10.value}'
+          value: 'var(--theme-color-palette-10)'
           comment: '{theme.color.palette.10.comment}'
         border:
-          value: '{theme.color.palette.4.value}'
+          value: 'var(--theme-color-palette-4)'
           comment: '{theme.color.palette.4.comment}'
         border-disabled:
-          value: '{theme.color.action-disabled.value}'
+          value: 'var(--theme-color-action-disabled)'
           comment: '{theme.color.action-disabled.comment}'
 
       secondary-button:
         background:
-          value: '{theme.color.palette.4.value}'
+          value: 'var(--theme-color-palette-4)'
           comment: '{theme.color.palette.4.comment}'
         background-disabled:
           value: 'transparent'
-          comment: '{theme.color.action-disabled.comment}'
         text:
-          value: '{theme.color.action-disabled.value}'
+          value: 'var(--theme-color-action-disabled)'
           comment: '{theme.color.action-disabled.comment}'
         text-disabled:
-          value: '{theme.color.action-disabled.value}'
+          value: 'var(--theme-color-action-disabled)'
           comment: '{theme.color.action-disabled.comment}'
         border:
-          value: '{theme.color.action.value}'
+          value: 'var(--theme-color-action)'
           comment: '{theme.color.action.comment}'
         border-disabled:
-          value: '{theme.color.action-disabled.value}'
+          value: 'var(--theme-color-action-disabled)'
           comment: '{theme.color.action-disabled.comment}'
 
       chat:
         background:
-          value: '{theme.color.palette.1.value}'
+          value: 'var(--theme-color-palette-1)'
           comment: '{theme.color.palette.1.comment}'
         text:
-          value: '{theme.color.palette.3.value}'
+          value: 'var(--theme-color-palette-3)'
           comment: '{theme.color.palette.3.comment}'
 
       modal:
         header:
           background:
-            value: '{theme.color.palette.1.value}'
+            value: 'var(--theme-color-palette-1)'
             comment: '{theme.color.palette.1.comment}'
           text:
-            value: '{theme.color.palette.3.value}'
+            value: 'var(--theme-color-palette-3)'
             comment: '{theme.color.palette.3.comment}'
         content:
           background:
-            value: '{theme.color.palette.3.value}'
+            value: 'var(--theme-color-palette-3)'
             comment: '{theme.color.palette.3.comment}'
           text:
-            value: '{theme.color.palette.0.value}'
+            value: 'var(--theme-color-palette-0)'
             comment: '{theme.color.palette.0.comment}'
 
       menu:
         background:
-          value: '{theme.color.palette.3.value}'
+          value: 'var(--theme-color-palette-3)'
           comment: '{theme.color.palette.3.comment}'
         item:
           text:
-            value: '{theme.color.palette.0.value}'
+            value: 'var(--theme-color-palette-0)'
             comment: '{theme.color.palette.0.comment}'
           bg:
             value: 'transparent'
@@ -197,19 +196,19 @@ theme:
 
       form-field:
         background:
-          value: '{theme.color.palette.4.value}'
+          value: 'var(--theme-color-palette-4)'
           comment: '{theme.color.palette.4.comment}'
         placeholder:
-          value: '{theme.color.action-disabled.value}'
+          value: 'var(--theme-color-action-disabled)'
           comment: '{theme.color.action-disabled.comment}'
         text:
-          value: '{theme.color.palette.0.value}'
+          value: 'var(--theme-color-palette-0)'
           comment: '{theme.color.palette.0.comment}'
         border:
-          value: '{theme.color.palette.0.value}'
+          value: 'var(--theme-color-palette-0)'
           comment: '{theme.color.palette.0.comment}'
 
       video:
         background:
-          value: '{theme.color.palette.2.value}'
+          value: 'var(--theme-color-palette-2)'
           comment: '{theme.color.palette.2.comment}'

--- a/web/style-definitions/tokens/color/default-theme.yaml
+++ b/web/style-definitions/tokens/color/default-theme.yaml
@@ -4,51 +4,212 @@
 # The fewer there are the easier it'll be easier to customize and document.
 
 theme:
-  unknown:
-    value: '{color.unknown.value}'
-  unknown-2:
-    value: '{color.unknown-2.value}'
-  primary:
-    value: '{color.unknown.value}'
-    comment: 'The primary color of the application used for rendering controls.'
-  text:
-    primary:
-      value: '{color.owncast.text.primary.value}'
-      comment: 'The color of the text in the application.'
-    secondary:
-      value: '{color.owncast.text.secondary.value}'
-    link:
-      value: '{color.owncast.text.bright.value}'
-    body-font-family:
-      value: '{font.owncast.body.value}'
-    display-font-family:
-      value: '{font.owncast.display.value}'
-  background:
-    primary:
-      value: '{color.owncast.background.primary.value}'
-      comment: 'The main background color of the page.'
-    secondary:
-      value: '{color.owncast.background.secondary.value}'
-      comment: 'A secondary background color used in sections and controls.'
-
   rounded-corners:
-    value: '{rounded-corners.value}'
+    value: 0.5rem
+    comment: 'How much corners are rounded in places in the UI.'
+  unknown-1:
+    value: 'green'
+    comment: 'This should never be used and it means something is wrong.'
+  unknown-2:
+    value: 'red'
+    comment: 'This should never be used and it means something is wrong.'
+  color:
+    users:
+      comment: 'Colors used to display chat users.'
+      0:
+        value: '{color.owncast.user.0.value}'
+      1:
+        value: '{color.owncast.user.1.value}'
+      2:
+        value: '{color.owncast.user.2.value}'
+      3:
+        value: '{color.owncast.user.3.value}'
+      4:
+        value: '{color.owncast.user.4.value}'
+      5:
+        value: '{color.owncast.user.5.value}'
+      6:
+        value: '{color.owncast.user.6.value}'
+      7:
+        value: '{color.owncast.user.7.value}'
 
-  user-colors:
-    comment: 'Colors used to display chat users.'
-    0:
-      value: '{color.owncast.user.0.value}'
-    1:
-      value: '{color.owncast.user.1.value}'
-    2:
-      value: '{color.owncast.user.2.value}'
-    3:
-      value: '{color.owncast.user.3.value}'
-    4:
-      value: '{color.owncast.user.4.value}'
-    5:
-      value: '{color.owncast.user.5.value}'
-    6:
-      value: '{color.owncast.user.6.value}'
-    7:
-      value: '{color.owncast.user.7.value}'
+    palette:
+      comment: 'Colors used in the user interface for the default theme.'
+      0:
+        value: '{color.owncast.palette.0.value}'
+        comment: '{color.owncast.palette.0.comment}'
+      1:
+        value: '{color.owncast.palette.1.value}'
+        comment: '{color.owncast.palette.1.comment}'
+      2:
+        value: '{color.owncast.palette.2.value}'
+        comment: '{color.owncast.palette.2.comment}'
+      3:
+        value: '{color.owncast.palette.3.value}'
+        comment: '{color.owncast.palette.3.comment}'
+      4:
+        value: '{color.owncast.palette.4.value}'
+        comment: '{color.owncast.palette.4.comment}'
+      5:
+        value: '{color.owncast.palette.5.value}'
+        comment: '{color.owncast.palette.5.comment}'
+      6:
+        value: '{color.owncast.palette.6.value}'
+        comment: '{color.owncast.palette.6.comment}'
+      7:
+        value: '{color.owncast.palette.7.value}'
+        comment: '{color.owncast.palette.7.comment}'
+      8:
+        value: '{color.owncast.palette.8.value}'
+        comment: '{color.owncast.palette.8.comment}'
+      9:
+        value: '{color.owncast.palette.9.value}'
+        comment: '{color.owncast.palette.9.comment}'
+      10:
+        value: '{color.owncast.palette.10.value}'
+        comment: '{color.owncast.palette.10.comment}'
+      11:
+        value: '{color.owncast.palette.11.value}'
+        comment: '{color.owncast.palette.11.comment}'
+      12:
+        value: '{color.owncast.palette.12.value}'
+        comment: '{color.owncast.palette.12.comment}'
+      13:
+        value: '{color.owncast.palette.13.value}'
+        comment: '{color.owncast.palette.13.comment}'
+      error:
+        value: '{color.owncast.palette.error.value}'
+        comment: '{color.owncast.palette.error.comment}'
+      warning:
+        value: '{color.owncast.palette.warning.value}'
+        comment: '{color.owncast.palette.warning.comment}'
+
+    background:
+      main:
+        value: '{theme.color.palette.3.value}'
+        comment: '{theme.color.palette.3.comment}'
+      header:
+        value: '{theme.color.palette.0.value}'
+        comment: '{theme.color.palette.0.comment}'
+    action:
+      value: '{theme.color.palette.6.value}'
+      comment: '{theme.color.palette.6.comment}'
+    action-hover:
+      value: '{theme.color.palette.7.value}'
+      comment: '{theme.color.palette.7.comment}'
+    action-disabled:
+      value: '{theme.color.palette.8.value}'
+      comment: '{theme.color.palette.8.comment}'
+
+    error:
+      value: '{theme.color.palette.error.value}'
+      comment: '{theme.color.palette.error.comment}'
+    warning:
+      value: '{theme.color.palette.warning.value}'
+      comment: '{theme.color.palette.warning.comment}'
+
+    components:
+      text-on-light:
+        value: '{theme.color.palette.0.value}'
+        comment: '{theme.color.palette.0.comment}'
+      text-on-dark:
+        value: '{theme.color.palette.3.value}'
+        comment: '{theme.color.palette.3.comment}'
+
+      primary-button:
+        background:
+          value: '{theme.color.action.value}'
+          comment: '{theme.color.action.comment}'
+        background-disabled:
+          value: '{theme.color.action-disabled.value}'
+          comment: '{theme.color.action-disabled.comment}'
+        text:
+          value: '{theme.color.palette.4.value}'
+          comment: '{theme.color.palette.4.comment}'
+        text-disabled:
+          value: '{theme.color.palette.10.value}'
+          comment: '{theme.color.palette.10.comment}'
+        border:
+          value: '{theme.color.palette.4.value}'
+          comment: '{theme.color.palette.4.comment}'
+        border-disabled:
+          value: '{theme.color.action-disabled.value}'
+          comment: '{theme.color.action-disabled.comment}'
+
+      secondary-button:
+        background:
+          value: '{theme.color.palette.4.value}'
+          comment: '{theme.color.palette.4.comment}'
+        background-disabled:
+          value: 'transparent'
+          comment: '{theme.color.action-disabled.comment}'
+        text:
+          value: '{theme.color.action-disabled.value}'
+          comment: '{theme.color.action-disabled.comment}'
+        text-disabled:
+          value: '{theme.color.action-disabled.value}'
+          comment: '{theme.color.action-disabled.comment}'
+        border:
+          value: '{theme.color.action.value}'
+          comment: '{theme.color.action.comment}'
+        border-disabled:
+          value: '{theme.color.action-disabled.value}'
+          comment: '{theme.color.action-disabled.comment}'
+
+      chat:
+        background:
+          value: '{theme.color.palette.1.value}'
+          comment: '{theme.color.palette.1.comment}'
+        text:
+          value: '{theme.color.palette.3.value}'
+          comment: '{theme.color.palette.3.comment}'
+
+      modal:
+        header:
+          background:
+            value: '{theme.color.palette.1.value}'
+            comment: '{theme.color.palette.1.comment}'
+          text:
+            value: '{theme.color.palette.3.value}'
+            comment: '{theme.color.palette.3.comment}'
+        content:
+          background:
+            value: '{theme.color.palette.3.value}'
+            comment: '{theme.color.palette.3.comment}'
+          text:
+            value: '{theme.color.palette.0.value}'
+            comment: '{theme.color.palette.0.comment}'
+
+      menu:
+        background:
+          value: '{theme.color.palette.3.value}'
+          comment: '{theme.color.palette.3.comment}'
+        item:
+          text:
+            value: '{theme.color.palette.0.value}'
+            comment: '{theme.color.palette.0.comment}'
+          bg:
+            value: 'transparent'
+          hover-bg:
+            value: 'rgba(0, 0, 0, 0.05)'
+          focus-bg:
+            value: 'rgba(0, 0, 0, 0.1)'
+
+      form-field:
+        background:
+          value: '{theme.color.palette.4.value}'
+          comment: '{theme.color.palette.4.comment}'
+        placeholder:
+          value: '{theme.color.action-disabled.value}'
+          comment: '{theme.color.action-disabled.comment}'
+        text:
+          value: '{theme.color.palette.0.value}'
+          comment: '{theme.color.palette.0.comment}'
+        border:
+          value: '{theme.color.palette.0.value}'
+          comment: '{theme.color.palette.0.comment}'
+
+      video:
+        background:
+          value: '{theme.color.palette.2.value}'
+          comment: '{theme.color.palette.2.comment}'

--- a/web/style-definitions/tokens/color/owncast-admin.yaml
+++ b/web/style-definitions/tokens/color/owncast-admin.yaml
@@ -1,28 +1,28 @@
 # Values used in the admin and should be migrated to variables or removed.
 # See ant-overrides.scss.
-owncast-purple:
-  value: '{color.unknown.value}'
+# owncast-purple:
+#   value: '{color.unknown.value}'
 owncast-purple-25:
   value: 'rgba(120, 113, 255, 0.25)'
-owncast-purple-50:
-  value: 'rgba(120, 113, 255, 0.5)'
-online-color:
-  value: '#73dd3f'
-offline-color:
-  value: '#999'
-pink:
-  value: '{color.unknown.value}'
-purple:
-  value: '{color.unknown-2.value}'
-blue:
-  value: '{color.unknown.value}'
-white-88:
-  value: '{color.unknown-2.value}'
-purple-dark:
-  value: '{color.unknown.value}'
-default-link-color:
-  value: '{color.owncast.text.bright.value}'
-default-bg-color:
-  value: '{color.owncast.background.primary.value}'
-default-text-color:
-  value: '{color.owncast.text.primary.value}'
+# owncast-purple-50:
+#   value: 'rgba(120, 113, 255, 0.5)'
+# online-color:
+#   value: '#73dd3f'
+# offline-color:
+#   value: '#999'
+# pink:
+#   value: '{color.unknown.value}'
+# purple:
+#   value: '{color.unknown-2.value}'
+# blue:
+#   value: '{color.unknown.value}'
+# white-88:
+#   value: '{color.unknown-2.value}'
+# purple-dark:
+#   value: '{color.unknown.value}'
+# default-link-color:
+#   value: '{color.owncast.text.bright.value}'
+# default-bg-color:
+#   value: '{color.owncast.background.primary.value}'
+# default-text-color:
+#   value: '{color.owncast.text.primary.value}'

--- a/web/style-definitions/tokens/color/owncast-colors.yaml
+++ b/web/style-definitions/tokens/color/owncast-colors.yaml
@@ -1,9 +1,11 @@
 # These are colors that make up the Owncast-specific color palette.
 color:
   unknown:
-    value: '#00FF00'
+    value: '#7a5cf3'
+
+  # this ends up being primary button text
   unknown-2:
-    value: '#FF0000'
+    value: '#fffffe'
   owncast:
     # These are the colors assigned to chat users.
     # If you add more colors here make sure to add them to
@@ -29,20 +31,24 @@ color:
 
     text:
       primary:
-        value: '#030208'
+        value: '#2E282A'
+
       secondary:
-        value: '#63638E'
+        value: '#94a1b2'
+
       highlight:
         value: '#030208'
       bright:
         value: '#5353A6'
+
     background:
       highlight:
         value: '#F0E678'
+
       primary:
-        value: '#FFFCF2'
+        value: '#E2E8F0'
       secondary:
-        value: '#F0EFE4'
+        value: '#ffffff'
 
 rounded-corners:
   value: '0.5em'

--- a/web/style-definitions/tokens/color/owncast-colors.yaml
+++ b/web/style-definitions/tokens/color/owncast-colors.yaml
@@ -6,6 +6,7 @@ color:
   # this ends up being primary button text
   unknown-2:
     value: '#fffffe'
+
   owncast:
     # These are the colors assigned to chat users.
     # If you add more colors here make sure to add them to
@@ -29,34 +30,60 @@ color:
       7:
         value: 'rgb(244, 11, 244)'
 
-    text:
-      primary:
-        value: '#2E282A'
-
-      secondary:
-        value: '#94a1b2'
-
-      highlight:
-        value: '#030208'
-      bright:
-        value: '#5353A6'
-
-    background:
-      highlight:
-        value: '#F0E678'
-
-      primary:
-        value: '#E2E8F0'
-      secondary:
+    palette:
+      0:
+        value: '#12161d'
+        comment: 'Dark primary'
+      1:
+        value: '#2D3748'
+        comment: 'Dark secondary'
+      2:
+        value: '#000000'
+        comment: 'Dark alternate'
+      3:
+        value: '#e2e8f0'
+        comment: 'Light primary'
+      4:
         value: '#ffffff'
-
-rounded-corners:
-  value: '0.5em'
+        comment: 'Light secondary'
+      5:
+        value: '#c3dafe'
+        comment: 'Light alternate'
+      6:
+        value: '#7a5cf3'
+        comment: 'Text link/secondary light text'
+      7:
+        value: '#5d38f3'
+        comment: 'Text link hover'
+      8:
+        value: '#b6b3c6'
+        comment: 'Disabled background'
+      9:
+        value: '#39373d'
+        comment: 'Neutral dark'
+      10:
+        value: '#707283'
+        comment: 'Neutral gray light'
+      11:
+        value: '#2386e2'
+        comment: 'Fun color 1'
+      12:
+        value: '#da9eff'
+        comment: 'Fun color 2'
+      13:
+        value: '#42bea6'
+        comment: 'Fun color 3'
+      error:
+        value: '#ff4b39'
+        comment: 'Error'
+      warning:
+        value: '#ffc655'
+        comment: 'Warning'
 
 font:
   owncast:
     body:
-      value: "'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      value: "'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
         'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji'"
     display:

--- a/web/style-definitions/tokens/color/owncast-colors.yaml
+++ b/web/style-definitions/tokens/color/owncast-colors.yaml
@@ -56,7 +56,7 @@ rounded-corners:
 font:
   owncast:
     body:
-      value: "'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      value: "'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
         'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji'"
     display:

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -8,77 +8,67 @@
 
   font-size: 0.85rem;
   font-weight: bold;
-	border-width: 2px;
+  border-width: 2px;
   border-radius: var(--theme-rounded-corners);
 
-	background-color: var(--secondary-button-background); // or var(--var(--theme-unknown);
-  // border-color: transparent;
-  border-color: var(--secondary-button-text);
-  // color: var(--theme-unknown-2);
-  color: var(--secondary-button-text);
+  background-color: var(--theme-color-components-secondary-button-background);
+  border-color: var(--theme-color-components-secondary-button-text);
+  color: var(--theme-color-components-secondary-button-text);
 
-	&:hover,
+  &:hover,
   &:focus {
     // background-color: var(--theme-primary);
     // border-color: transparent;
     // color: var(--theme-unknown-2);
-		border-color: var(--action-hovered);
-		color: var(--action-hovered);
-		background-color: var(--secondary-button-background);
+    border-color: var(--theme-color-action-hover);
+    color: var(--theme-color-action-hover);
+    background-color: var(--theme-color-components-secondary-button-background);
   }
 
-	&:focus {
-    // border-color: var(--theme-unknown-2);
-    border-color: var(--secondary-button-text);
+  &:focus {
+    border-color: var(--theme-color-components-secondary-button-text);
   }
   &[ant-click-animating-without-extra-node]:after {
     animation: 0s !important;
   }
 }
 .ant-btn[disabled] {
-	background-color: var(--secondary-button-background-disabled);
-  color: var(--secondary-button-text-disabled);
-	border-color: var(--secondary-button-border-disabled);
-	&:hover,
-	&:focus {
-		background-color: var(--secondary-button-background-disabled);
-		color: var(--secondary-button-text-disabled);
-		border-color: var(--secondary-button-border-disabled);
-	}
+  background-color: var(--theme-color-components-secondary-button-background-disabled);
+  color: var(--theme-color-components-secondary-button-text-disabled);
+  border-color: var(--theme-color-components-secondary-button-border-disabled);
+  &:hover,
+  &:focus {
+    background-color: var(--theme-color-components-secondary-button-background-disabled);
+    color: var(--theme-color-components-secondary-button-text-disabled);
+    border-color: var(--theme-color-components-secondary-button-border-disabled);
+  }
 }
 
 .ant-btn-primary {
-  // background-color: var(--theme-unknown);
-  background-color: var(--primary-button-background);
-  color: var(--primary-button-text);
-	border-color: var(--primary-button-background);
-	&:hover {
-		background-color: var(--action-hovered);
-		color: var(--primary-button-text);
-		border-color: var(--action-hovered);
-	}
-	&:focus {
-		background-color: var(--action-hovered);
-		color: var(--primary-button-text);
-		border-color: var(--primary-button-text);
-	}
+  background-color: var(--theme-color-components-primary-button-background);
+  color: var(--theme-color-components-primary-button-text);
+  border-color: var(--theme-color-components-primary-button-background);
+  &:hover {
+    background-color: var(--theme-color-action-hover);
+    color: var(--theme-color-components-primary-button-text);
+    border-color: var(--theme-color-action-hover);
+  }
+  &:focus {
+    background-color: var(--theme-color-action-hover);
+    color: var(--theme-color-components-primary-button-text);
+    border-color: var(--theme-color-components-primary-button-text);
+  }
 }
 
 .ant-btn-primary[disabled] {
-	// background-color: var(--theme-unknown);
-  // color: var(--theme-unknown-2);
-  // &:hover {
-  //   background-color: var(--theme-unknown);
-  // }
-
-  background-color: var(--primary-button-background-disabled);
-	border-color: var(--primary-button-border-disabled);
-  color: var(--primary-button-text-disabled);
+  background-color: var(--theme-color-components-primary-button-background-disabled);
+  border-color: var(--theme-color-components-primary-button-border-disabled);
+  color: var(--theme-color-components-primary-button-text-disabled);
   &:hover,
-	&:focus {
-    background-color: var(--primary-button-background-disabled);
-		border-color: var(--primary-button-border-disabled);
-		color: var(--primary-button-text-disabled);
+  &:focus {
+    background-color: var(--theme-color-components-primary-button-background-disabled);
+    border-color: var(--theme-color-components-primary-button-border-disabled);
+    color: var(--theme-color-components-primary-button-text-disabled);
   }
 }
 
@@ -97,65 +87,68 @@
 
 .ant-dropdown-menu {
   border-radius: var(--theme-rounded-corners);
-  background-color: var(--theme-background-secondary);
+  background-color: var(--theme-color-components-menu-background);
 }
 .ant-dropdown-menu-item {
-	&:hover {
-		background-color: rgba(33,0,99,.05);
-	}
-	&:focus {
-		background-color: rgba(33,0,99,.1);
-	}
+  color: var(--theme-color-components-menu-item-text);
+  &:hover {
+    background-color: var(--theme-color-components-menu-item-hover-bg);
+  }
+  &:focus {
+    background-color: var(--theme-color-components-menu-item-focus-bg);
+  }
 }
-
 
 .ant-modal-header {
-	background-color: var(--modal-header-background);
-	color: var(--modal-header-text);
+  color: var(--theme-color-components-modal-header-text);
 }
 .ant-modal-title {
-	color: var(--modal-header-text);
+  color: var(--theme-color-components-modal-header-text);
+}
+
+.ant-modal {
+  color: var(--theme-color-components-text-on-light);
+  h1 {
+    color: var(--theme-color-components-text-on-light);
+  }
 }
 
 .ant-input {
-	background-color: var(--form-field-background);
-	color: var(--form-field-text);
-	border-color: var(--form-field-border);
-	&::placeholder {
-		color: var(--form-field-placeholder);
-	}
+  background-color: var(--theme-color-components-form-field-background);
+  color: var(--theme-color-components-form-field-text);
+  border-color: var(--theme-color-components-form-field-border);
+  &::placeholder {
+    color: var(--theme-color-components-form-field-placeholder);
+  }
 }
 
 .ant-alert-error {
-	border-color: var(--color-error);
-	background-color: var(--secondary-light);
-	.ant-alert-icon {
-		color: var(--color-error);
-	}
-	.ant-alert-message {
-		color: var(--color-error);
-	}
+  .ant-alert-icon {
+    color: var(--theme-color-palette-error);
+  }
+  .ant-alert-message {
+    color: var(--theme-color-palette-error);
+  }
 }
-
 
 .ant-tabs-tab {
-	padding: var(--content-padding);
-	background-color: transparent;
-	border-radius: var(--theme-rounded-corners) var(--theme-rounded-corners) 0 0 ;
-	font-weight: bold;
-	&+.ant-tabs-tab {
-		margin-left: var(--module-spacing);
-	}
-	&.ant-tabs-tab-active {
-		background-color: var(--secondary-light);
-		.ant-tabs-tab-btn {
-			color: var(--action);
-			&:hover {
-				color: var(--action-hovered)
-			}
-		}
-	}
+  padding: var(--content-padding);
+  background-color: transparent;
+  border-radius: var(--theme-rounded-corners) var(--theme-rounded-corners) 0 0;
+  font-weight: bold;
+  & + .ant-tabs-tab {
+    margin-left: var(--module-spacing);
+  }
+  &.ant-tabs-tab-active {
+    background-color: var(--theme-color-palette-4);
+    .ant-tabs-tab-btn {
+      color: var(--theme-color-action);
+      &:hover {
+        color: var(--theme-color-action-hover);
+      }
+    }
+  }
 }
 .ant-tabs-ink-bar {
-	background-color: var(--action);
+  background-color: var(--theme-color-action);
 }

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -4,36 +4,81 @@
 
 .ant-btn {
   height: 2rem;
-  padding: 0.3rem 1rem;
-  background-color: var(--theme-unknown);
+  // padding: 0.3rem 1rem; // not doing this looks better.
+
   font-size: 0.85rem;
   font-weight: bold;
+	border-width: 2px;
   border-radius: var(--theme-rounded-corners);
-  border-color: transparent;
-  color: var(--theme-unknown-2);
-  &:hover,
+
+	background-color: var(--secondary-button-background); // or var(--var(--theme-unknown);
+  // border-color: transparent;
+  border-color: var(--secondary-button-text);
+  // color: var(--theme-unknown-2);
+  color: var(--secondary-button-text);
+
+	&:hover,
   &:focus {
-    background-color: var(--theme-primary);
-    border-color: transparent;
-    color: var(--theme-unknown-2);
+    // background-color: var(--theme-primary);
+    // border-color: transparent;
+    // color: var(--theme-unknown-2);
+		border-color: var(--action-hovered);
+		color: var(--action-hovered);
+		background-color: var(--secondary-button-background);
   }
-  &:focus {
-    border-color: var(--theme-unknown-2);
+
+	&:focus {
+    // border-color: var(--theme-unknown-2);
+    border-color: var(--secondary-button-text);
   }
   &[ant-click-animating-without-extra-node]:after {
     animation: 0s !important;
   }
 }
+.ant-btn[disabled] {
+	background-color: var(--secondary-button-background-disabled);
+  color: var(--secondary-button-text-disabled);
+	border-color: var(--secondary-button-border-disabled);
+	&:hover,
+	&:focus {
+		background-color: var(--secondary-button-background-disabled);
+		color: var(--secondary-button-text-disabled);
+		border-color: var(--secondary-button-border-disabled);
+	}
+}
 
 .ant-btn-primary {
-  background-color: var(--theme-unknown);
+  // background-color: var(--theme-unknown);
+  background-color: var(--primary-button-background);
+  color: var(--primary-button-text);
+	border-color: var(--primary-button-background);
+	&:hover {
+		background-color: var(--action-hovered);
+		color: var(--primary-button-text);
+		border-color: var(--action-hovered);
+	}
+	&:focus {
+		background-color: var(--action-hovered);
+		color: var(--primary-button-text);
+		border-color: var(--primary-button-text);
+	}
 }
 
 .ant-btn-primary[disabled] {
-  background-color: var(--theme-unknown);
-  color: var(--theme-unknown-2);
-  &:hover {
-    background-color: var(--theme-unknown);
+	// background-color: var(--theme-unknown);
+  // color: var(--theme-unknown-2);
+  // &:hover {
+  //   background-color: var(--theme-unknown);
+  // }
+
+  background-color: var(--primary-button-background-disabled);
+	border-color: var(--primary-button-border-disabled);
+  color: var(--primary-button-text-disabled);
+  &:hover,
+	&:focus {
+    background-color: var(--primary-button-background-disabled);
+		border-color: var(--primary-button-border-disabled);
+		color: var(--primary-button-text-disabled);
   }
 }
 
@@ -53,4 +98,64 @@
 .ant-dropdown-menu {
   border-radius: var(--theme-rounded-corners);
   background-color: var(--theme-background-secondary);
+}
+.ant-dropdown-menu-item {
+	&:hover {
+		background-color: rgba(33,0,99,.05);
+	}
+	&:focus {
+		background-color: rgba(33,0,99,.1);
+	}
+}
+
+
+.ant-modal-header {
+	background-color: var(--modal-header-background);
+	color: var(--modal-header-text);
+}
+.ant-modal-title {
+	color: var(--modal-header-text);
+}
+
+.ant-input {
+	background-color: var(--form-field-background);
+	color: var(--form-field-text);
+	border-color: var(--form-field-border);
+	&::placeholder {
+		color: var(--form-field-placeholder);
+	}
+}
+
+.ant-alert-error {
+	border-color: var(--color-error);
+	background-color: var(--secondary-light);
+	.ant-alert-icon {
+		color: var(--color-error);
+	}
+	.ant-alert-message {
+		color: var(--color-error);
+	}
+}
+
+
+.ant-tabs-tab {
+	padding: var(--content-padding);
+	background-color: transparent;
+	border-radius: var(--theme-rounded-corners) var(--theme-rounded-corners) 0 0 ;
+	font-weight: bold;
+	&+.ant-tabs-tab {
+		margin-left: var(--module-spacing);
+	}
+	&.ant-tabs-tab-active {
+		background-color: var(--secondary-light);
+		.ant-tabs-tab-btn {
+			color: var(--action);
+			&:hover {
+				color: var(--action-hovered)
+			}
+		}
+	}
+}
+.ant-tabs-ink-bar {
+	background-color: var(--action);
 }

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -4,22 +4,16 @@
 
 .ant-btn {
   height: 2rem;
-  // padding: 0.3rem 1rem; // not doing this looks better.
 
   font-size: 0.85rem;
   font-weight: bold;
   border-width: 2px;
   border-radius: var(--theme-rounded-corners);
-
-  background-color: var(--theme-color-components-secondary-button-background);
-  border-color: var(--theme-color-components-secondary-button-text);
-  color: var(--theme-color-components-secondary-button-text);
+  color: var(--theme-color-components-primary-button-text);
+  border-color: var(--theme-color-action);
 
   &:hover,
   &:focus {
-    // background-color: var(--theme-primary);
-    // border-color: transparent;
-    // color: var(--theme-unknown-2);
     border-color: var(--theme-color-action-hover);
     color: var(--theme-color-action-hover);
     background-color: var(--theme-color-components-secondary-button-background);

--- a/web/styles/globals.scss
+++ b/web/styles/globals.scss
@@ -1,87 +1,87 @@
-@import '@fontsource/open-sans/variable.css';
+@import '@fontsource/open-sans/300.css';
+@import '@fontsource/open-sans/400.css';
+@import '@fontsource/open-sans/600.css';
+@import '@fontsource/open-sans/800.css';
 @import '@fontsource/poppins/400.css';
 @import '@fontsource/poppins/600.css';
 
 :root {
-	--content-padding: 12px;
-	--module-spacing: 12px; // margin size between lines of stuff, if needed
+  --content-padding: 12px;
+  --module-spacing: 12px; // margin size between lines of stuff, if needed
 
-	--primary-dark: #12161d;
-	--secondary-dark: #2D3748;
-	--alt-dark: #000000;
+  --primary-dark: #12161d;
+  --secondary-dark: #2d3748;
+  --alt-dark: #000000;
 
-	--primary-light: #e2e8f0;
-	--secondary-light: #ffffff;
-	--alt-light: #c3dafe;
+  --primary-light: #e2e8f0;
+  --secondary-light: #ffffff;
+  --alt-light: #c3dafe;
 
-	--neutral-gray-light: #707283; //746f7d
-	--neutral-gray-dark: #39373d;
+  --neutral-gray-light: #707283; //746f7d
+  --neutral-gray-dark: #39373d;
 
-	--action: #7A5CF3;
-	--action-hovered: #5d38f3;
+  --action: #7a5cf3;
+  --action-hovered: #5d38f3;
 
-	--action-disabled: #b6b3c6; // AFA8BA?, //707283text, #494453
+  --action-disabled: #b6b3c6; // AFA8BA?, //707283text, #494453
 
-	--color-warning: #FFC655; //
-	--color-error: #ff4b39; // #CC4F00
-	--color-fun1: #2386e2;// just for fun
-	--color-fun2: #da9eff;// just for fun
-	--color-fun3: #42BEA6;// just for fun
+  --color-warning: #ffc655; //
+  --color-error: #ff4b39; // #CC4F00
+  --color-fun1: #2386e2; // just for fun
+  --color-fun2: #da9eff; // just for fun
+  --color-fun3: #42bea6; // just for fun
 
+  // layout
+  --main-background: var(--primary-light);
+  --header-background: var(--primary-dark);
+  --general-text-on-dark: var(--primary-light);
+  --general-text-on-light: var(--primary-dark);
 
-	// layout
-	--main-background: var(--primary-light);
-	--header-background: var(--primary-dark);
-	--general-text-on-dark: var(--primary-light);
-	--general-text-on-light: var(--primary-dark);
+  // buttons
+  --primary-button-background: var(--action);
+  --primary-button-text: var(--secondary-light);
+  --primary-button-border: var(--secondary-light);
 
-	// buttons
-	--primary-button-background: var(--action);
-	--primary-button-text: var(--secondary-light);
-	--primary-button-border: var(--secondary-light);
+  --primary-button-background-disabled: var(--action-disabled);
+  --primary-button-border-disabled: var(--action-disabled);
+  --primary-button-text-disabled: var(--neutral-gray-light);
 
-	--primary-button-background-disabled: var(--action-disabled);
-	--primary-button-border-disabled: var(--action-disabled);
-	--primary-button-text-disabled: var(--neutral-gray-light);
+  --secondary-button-background: var(--secondary-light); // or --secondary-light? white
+  --secondary-button-text: var(--action);
+  --secondary-button-border: var(--action);
 
-	--secondary-button-background: var(--secondary-light); // or --secondary-light? white
-	--secondary-button-text: var(--action);
-	--secondary-button-border: var(--action);
+  --secondary-button-background-disabled: transparent; // or --secondary-light? white
+  --secondary-button-text-disabled: var(--action-disabled);
+  --secondary-button-border-disabled: var(--action-disabled);
 
-	--secondary-button-background-disabled: transparent; // or --secondary-light? white
-	--secondary-button-text-disabled: var(--action-disabled);
-	--secondary-button-border-disabled: var(--action-disabled);
+  // chat
+  --chat-background: var(--secondary-dark);
+  --chat-text: var(--primary-light); // secondary works too
 
-	// chat
-	--chat-background: var(--secondary-dark);
-	--chat-text: var(--primary-light);  // secondary works too
+  // video
+  --background-video: var(--alt-dark);
 
-	// video
-	--background-video: var(--alt-dark);
+  // modal
+  --modal-header-background: var(--secondary-dark);
+  --modal-header-text: var(--primary-light);
+  --modal-content-background: var(--primary-light);
+  --modal-content-text: var(--primary-dark);
 
-	// modal
-	--modal-header-background: var(--secondary-dark);
-	--modal-header-text: var(--primary-light);
-	--modal-content-background: var(--primary-light);
-	--modal-content-text: var(--primary-dark);
+  // dropdown menu
+  --menu-background: var(--primary-light);
+  --menu-item-text: var(--primary-dark);
+  --menu-item-bg: transparent;
+  --menu-item-hover-bg: rgba(0, 0, 0, 0.05);
+  --menu-item-focus-bg: rgba(0, 0, 0, 0.1);
 
-	// dropdown menu
-	--menu-background: var(--primary-light);
-	--menu-item-text: var(--primary-dark);
-	--menu-item-bg: transparent;
-	--menu-item-hover-bg: rgba(0,0,0,.05);
-	--menu-item-focus-bg: rgba(0,0,0,.1);
-
-	// forms
-	--form-field-background: var(--secondary-light);
-	--form-field-placeholder: var(--action-disabled);
-	--form-field-text: var(--primary-dark);
-	--form-field-border: var(--primary-dark); // if needed
-
-
+  // forms
+  --form-field-background: var(--secondary-light);
+  --form-field-placeholder: var(--action-disabled);
+  --form-field-text: var(--primary-dark);
+  --form-field-border: var(--primary-dark); // if needed
 }
 ::selection {
-	background-color: var(--color-fun2);
+  background-color: var(--color-fun2);
 }
 
 body {
@@ -113,7 +113,7 @@ body {
   h5,
   h6 {
     font-family: var(--theme-text-display-font-family);
-		color: unset; // reset some colors from global.less file
+    color: unset; // reset some colors from global.less file
   }
 
   h1 {

--- a/web/styles/globals.scss
+++ b/web/styles/globals.scss
@@ -8,80 +8,10 @@
 :root {
   --content-padding: 12px;
   --module-spacing: 12px; // margin size between lines of stuff, if needed
-
-  --primary-dark: #12161d;
-  --secondary-dark: #2d3748;
-  --alt-dark: #000000;
-
-  --primary-light: #e2e8f0;
-  --secondary-light: #ffffff;
-  --alt-light: #c3dafe;
-
-  --neutral-gray-light: #707283; //746f7d
-  --neutral-gray-dark: #39373d;
-
-  --action: #7a5cf3;
-  --action-hovered: #5d38f3;
-
-  --action-disabled: #b6b3c6; // AFA8BA?, //707283text, #494453
-
-  --color-warning: #ffc655; //
-  --color-error: #ff4b39; // #CC4F00
-  --color-fun1: #2386e2; // just for fun
-  --color-fun2: #da9eff; // just for fun
-  --color-fun3: #42bea6; // just for fun
-
-  // layout
-  --main-background: var(--primary-light);
-  --header-background: var(--primary-dark);
-  --general-text-on-dark: var(--primary-light);
-  --general-text-on-light: var(--primary-dark);
-
-  // buttons
-  --primary-button-background: var(--action);
-  --primary-button-text: var(--secondary-light);
-  --primary-button-border: var(--secondary-light);
-
-  --primary-button-background-disabled: var(--action-disabled);
-  --primary-button-border-disabled: var(--action-disabled);
-  --primary-button-text-disabled: var(--neutral-gray-light);
-
-  --secondary-button-background: var(--secondary-light); // or --secondary-light? white
-  --secondary-button-text: var(--action);
-  --secondary-button-border: var(--action);
-
-  --secondary-button-background-disabled: transparent; // or --secondary-light? white
-  --secondary-button-text-disabled: var(--action-disabled);
-  --secondary-button-border-disabled: var(--action-disabled);
-
-  // chat
-  --chat-background: var(--secondary-dark);
-  --chat-text: var(--primary-light); // secondary works too
-
-  // video
-  --background-video: var(--alt-dark);
-
-  // modal
-  --modal-header-background: var(--secondary-dark);
-  --modal-header-text: var(--primary-light);
-  --modal-content-background: var(--primary-light);
-  --modal-content-text: var(--primary-dark);
-
-  // dropdown menu
-  --menu-background: var(--primary-light);
-  --menu-item-text: var(--primary-dark);
-  --menu-item-bg: transparent;
-  --menu-item-hover-bg: rgba(0, 0, 0, 0.05);
-  --menu-item-focus-bg: rgba(0, 0, 0, 0.1);
-
-  // forms
-  --form-field-background: var(--secondary-light);
-  --form-field-placeholder: var(--action-disabled);
-  --form-field-text: var(--primary-dark);
-  --form-field-border: var(--primary-dark); // if needed
 }
+
 ::selection {
-  background-color: var(--color-fun2);
+  background-color: var(--theme-color-palette-12);
 }
 
 body {
@@ -90,9 +20,7 @@ body {
   line-height: 1.5em;
   margin: 0;
 
-  // color: var(--theme-text-primary); // remove
-  // background-color: var(--theme-background-primary);
-  background-color: var(--main-background);
+  background-color: var(--theme-color-background-main);
 
   div,
   h1,
@@ -103,7 +31,6 @@ body {
   h6,
   p {
     padding: 0;
-    // color: var(--theme-text-primary); // remove
   }
 
   h1,
@@ -155,10 +82,10 @@ body {
   }
 
   a {
-    color: var(--action);
+    color: var(--theme-color-action);
 
     &:hover {
-      color: var(--color-fun2);
+      color: var(--theme-color-palette-12);
     }
   }
 

--- a/web/styles/globals.scss
+++ b/web/styles/globals.scss
@@ -2,14 +2,94 @@
 @import '@fontsource/poppins/400.css';
 @import '@fontsource/poppins/600.css';
 
+:root {
+	--content-padding: 12px;
+	--module-spacing: 12px; // margin size between lines of stuff, if needed
+
+	--primary-dark: #12161d;
+	--secondary-dark: #2D3748;
+	--alt-dark: #000000;
+
+	--primary-light: #e2e8f0;
+	--secondary-light: #ffffff;
+	--alt-light: #c3dafe;
+
+	--neutral-gray-light: #707283; //746f7d
+	--neutral-gray-dark: #39373d;
+
+	--action: #7A5CF3;
+	--action-hovered: #5d38f3;
+
+	--action-disabled: #b6b3c6; // AFA8BA?, //707283text, #494453
+
+	--color-warning: #FFC655; //
+	--color-error: #ff4b39; // #CC4F00
+	--color-fun1: #2386e2;// just for fun
+	--color-fun2: #da9eff;// just for fun
+	--color-fun3: #42BEA6;// just for fun
+
+
+	// layout
+	--main-background: var(--primary-light);
+	--header-background: var(--primary-dark);
+	--general-text-on-dark: var(--primary-light);
+	--general-text-on-light: var(--primary-dark);
+
+	// buttons
+	--primary-button-background: var(--action);
+	--primary-button-text: var(--secondary-light);
+	--primary-button-border: var(--secondary-light);
+
+	--primary-button-background-disabled: var(--action-disabled);
+	--primary-button-border-disabled: var(--action-disabled);
+	--primary-button-text-disabled: var(--neutral-gray-light);
+
+	--secondary-button-background: var(--secondary-light); // or --secondary-light? white
+	--secondary-button-text: var(--action);
+	--secondary-button-border: var(--action);
+
+	--secondary-button-background-disabled: transparent; // or --secondary-light? white
+	--secondary-button-text-disabled: var(--action-disabled);
+	--secondary-button-border-disabled: var(--action-disabled);
+
+	// chat
+	--chat-background: var(--secondary-dark);
+	--chat-text: var(--primary-light);  // secondary works too
+
+	// video
+	--background-video: var(--alt-dark);
+
+	// modal
+	--modal-header-background: var(--secondary-dark);
+	--modal-header-text: var(--primary-light);
+	--modal-content-background: var(--primary-light);
+	--modal-content-text: var(--primary-dark);
+
+	// dropdown menu
+	--menu-background: var(--primary-light);
+	--menu-item-text: var(--primary-dark);
+	--menu-item-bg: transparent;
+	--menu-item-hover-bg: rgba(0,0,0,.05);
+	--menu-item-focus-bg: rgba(0,0,0,.1);
+
+	// forms
+	--form-field-background: var(--secondary-light);
+	--form-field-placeholder: var(--action-disabled);
+	--form-field-text: var(--primary-dark);
+	--form-field-border: var(--primary-dark); // if needed
+
+
+}
+
 body {
   font-family: var(--theme-text-body-font-family);
   font-size: 16px;
   line-height: 1.5em;
   margin: 0;
 
-  color: var(--theme-text-primary);
-  background-color: var(--theme-background-primary);
+  // color: var(--theme-text-primary); // remove
+  // background-color: var(--theme-background-primary);
+  background-color: var(--main-background);
 
   div,
   h1,
@@ -20,7 +100,7 @@ body {
   h6,
   p {
     padding: 0;
-    color: var(--theme-text-primary);
+    // color: var(--theme-text-primary); // remove
   }
 
   h1,
@@ -30,6 +110,7 @@ body {
   h5,
   h6 {
     font-family: var(--theme-text-display-font-family);
+		color: unset; // reset some colors from global.less file
   }
 
   h1 {
@@ -71,10 +152,10 @@ body {
   }
 
   a {
-    color: var(--theme-text-link);
+    color: var(--action);
 
-    &:visited {
-      color: var(--theme-text-primary);
+    &:hover {
+      color: var(--color-fun2);
     }
   }
 

--- a/web/styles/globals.scss
+++ b/web/styles/globals.scss
@@ -80,6 +80,9 @@
 
 
 }
+::selection {
+	background-color: var(--color-fun2);
+}
 
 body {
   font-family: var(--theme-text-body-font-family);

--- a/web/styles/theme.less
+++ b/web/styles/theme.less
@@ -1,52 +1,83 @@
 
 // Do not edit directly
-// Generated on Mon, 29 Aug 2022 07:35:46 GMT
+// Generated on Tue, 30 Aug 2022 05:24:37 GMT
 // 
 // How to edit these values:
 // Edit the corresponding token file under the style-definitions directory
 // in the Owncast web project.
 
-@text-color: var(--theme-text-primary);
-@text-color-secondary: var(--theme-text-secondary);
-@link-color: var(--theme-text-link);
-@popover-background: var(--theme-background-secondary);
-@modal-content-bg: #fffffe;
-@background-color-light: var(--theme-background-secondary);
-@layout-body-background: var(--theme-background-primary);
-@component-background: #7a5cf3;
-@warning-color: #fffffe;
-@theme-unknown: #7a5cf3;
-@theme-unknown-2: #fffffe;
-@theme-primary: #7a5cf3; // The primary color of the application used for rendering controls.
-@theme-text-primary: #2e282a; // The color of the text in the application.
-@theme-text-secondary: #94a1b2;
-@theme-text-link: #5353a6;
-@theme-text-body-font-family: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-@theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-@theme-background-primary: #e2e8f0; // The main background color of the page.
-@theme-background-secondary: #ffffff; // A secondary background color used in sections and controls.
-@theme-rounded-corners: 0.5em;
-@theme-user-colors-0: #f40b0b;
-@theme-user-colors-1: #f4800b;
-@theme-user-colors-2: #f4f40b;
-@theme-user-colors-3: #58f40b;
-@theme-user-colors-4: #0bf4f4;
-@theme-user-colors-5: #0ba6f4;
-@theme-user-colors-6: #6666ff;
-@theme-user-colors-7: #f40bf4;
-@owncast-purple: #7a5cf3;
+@link-color: var(--theme-color-action);
+@link-hover-color: var(--theme-color-action-hover);
+@modal-header-bg: var(--theme-color-components-modal-header-background);
+@modal-content-bg: var(--theme-color-background-main);
+@alert-error-bg-color: var(--theme-color-palette-4);
+@alert-error-border-color: var(--theme-color-palette-error);
+@popover-background: var(--theme-color-components-menu-background);
+@theme-rounded-corners: 0.5rem; // How much corners are rounded in places in the UI.
+@theme-unknown-1: green; // This should never be used and it means something is wrong.
+@theme-unknown-2: red; // This should never be used and it means something is wrong.
+@theme-color-users-0: #f40b0b;
+@theme-color-users-1: #f4800b;
+@theme-color-users-2: #f4f40b;
+@theme-color-users-3: #58f40b;
+@theme-color-users-4: #0bf4f4;
+@theme-color-users-5: #0ba6f4;
+@theme-color-users-6: #6666ff;
+@theme-color-users-7: #f40bf4;
+@theme-color-palette-0: #12161d; // Dark primary
+@theme-color-palette-1: #2d3748; // Dark secondary
+@theme-color-palette-2: #000000; // Dark alternate
+@theme-color-palette-3: #e2e8f0; // Light primary
+@theme-color-palette-4: #ffffff; // Light secondary
+@theme-color-palette-5: #c3dafe; // Light alternate
+@theme-color-palette-6: #7a5cf3; // Text link/secondary light text
+@theme-color-palette-7: #5d38f3; // Text link hover
+@theme-color-palette-8: #b6b3c6; // Disabled background
+@theme-color-palette-9: #39373d; // Neutral dark
+@theme-color-palette-10: #707283; // Neutral gray light
+@theme-color-palette-11: #2386e2; // Fun color 1
+@theme-color-palette-12: #da9eff; // Fun color 2
+@theme-color-palette-13: #42bea6; // Fun color 3
+@theme-color-palette-error: #ff4b39; // Error
+@theme-color-palette-warning: #ffc655; // Warning
+@theme-color-background-main: #e2e8f0; // Light primary
+@theme-color-background-header: #12161d; // Dark primary
+@theme-color-action: #7a5cf3; // Text link/secondary light text
+@theme-color-action-hover: #5d38f3; // Text link hover
+@theme-color-action-disabled: #b6b3c6; // Disabled background
+@theme-color-error: #ff4b39; // Error
+@theme-color-warning: #ffc655; // Warning
+@theme-color-components-text-on-light: #12161d; // Dark primary
+@theme-color-components-text-on-dark: #e2e8f0; // Light primary
+@theme-color-components-primary-button-background: #7a5cf3; // Text link/secondary light text
+@theme-color-components-primary-button-background-disabled: #b6b3c6; // Disabled background
+@theme-color-components-primary-button-text: #ffffff; // Light secondary
+@theme-color-components-primary-button-text-disabled: #707283; // Neutral gray light
+@theme-color-components-primary-button-border: #ffffff; // Light secondary
+@theme-color-components-primary-button-border-disabled: #b6b3c6; // Disabled background
+@theme-color-components-secondary-button-background: #ffffff; // Light secondary
+@theme-color-components-secondary-button-background-disabled: transparent; // Disabled background
+@theme-color-components-secondary-button-text: #b6b3c6; // Disabled background
+@theme-color-components-secondary-button-text-disabled: #b6b3c6; // Disabled background
+@theme-color-components-secondary-button-border: #7a5cf3; // Text link/secondary light text
+@theme-color-components-secondary-button-border-disabled: #b6b3c6; // Disabled background
+@theme-color-components-chat-background: #2d3748; // Dark secondary
+@theme-color-components-chat-text: #e2e8f0; // Light primary
+@theme-color-components-modal-header-background: #2d3748; // Dark secondary
+@theme-color-components-modal-header-text: #e2e8f0; // Light primary
+@theme-color-components-modal-content-background: #e2e8f0; // Light primary
+@theme-color-components-modal-content-text: #12161d; // Dark primary
+@theme-color-components-menu-background: #e2e8f0; // Light primary
+@theme-color-components-menu-item-text: #12161d; // Dark primary
+@theme-color-components-menu-item-bg: transparent;
+@theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
+@theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
+@theme-color-components-form-field-background: #ffffff; // Light secondary
+@theme-color-components-form-field-placeholder: #b6b3c6; // Disabled background
+@theme-color-components-form-field-text: #12161d; // Dark primary
+@theme-color-components-form-field-border: #12161d; // Dark primary
+@theme-color-components-video-background: #000000; // Dark alternate
 @owncast-purple-25: rgba(120, 113, 255, 0.25);
-@owncast-purple-50: rgba(120, 113, 255, 0.5);
-@online-color: #73dd3f;
-@offline-color: #999;
-@pink: #7a5cf3;
-@purple: #fffffe;
-@blue: #7a5cf3;
-@white-88: #fffffe;
-@purple-dark: #7a5cf3;
-@default-link-color: #5353a6;
-@default-bg-color: #e2e8f0;
-@default-text-color: #2e282a;
 @color-unknown: #7a5cf3;
 @color-unknown-2: #fffffe;
 @color-owncast-user-0: #f40b0b;
@@ -57,13 +88,21 @@
 @color-owncast-user-5: #0ba6f4;
 @color-owncast-user-6: #6666ff;
 @color-owncast-user-7: #f40bf4;
-@color-owncast-text-primary: #2e282a;
-@color-owncast-text-secondary: #94a1b2;
-@color-owncast-text-highlight: #030208;
-@color-owncast-text-bright: #5353a6;
-@color-owncast-background-highlight: #f0e678;
-@color-owncast-background-primary: #e2e8f0;
-@color-owncast-background-secondary: #ffffff;
-@rounded-corners: 0.5em;
-@font-owncast-body: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+@color-owncast-palette-0: #12161d; // Dark primary
+@color-owncast-palette-1: #2d3748; // Dark secondary
+@color-owncast-palette-2: #000000; // Dark alternate
+@color-owncast-palette-3: #e2e8f0; // Light primary
+@color-owncast-palette-4: #ffffff; // Light secondary
+@color-owncast-palette-5: #c3dafe; // Light alternate
+@color-owncast-palette-6: #7a5cf3; // Text link/secondary light text
+@color-owncast-palette-7: #5d38f3; // Text link hover
+@color-owncast-palette-8: #b6b3c6; // Disabled background
+@color-owncast-palette-9: #39373d; // Neutral dark
+@color-owncast-palette-10: #707283; // Neutral gray light
+@color-owncast-palette-11: #2386e2; // Fun color 1
+@color-owncast-palette-12: #da9eff; // Fun color 2
+@color-owncast-palette-13: #42bea6; // Fun color 3
+@color-owncast-palette-error: #ff4b39; // Error
+@color-owncast-palette-warning: #ffc655; // Warning
+@font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 @font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';

--- a/web/styles/theme.less
+++ b/web/styles/theme.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Sat, 27 Aug 2022 21:18:14 GMT
+// Generated on Mon, 29 Aug 2022 07:35:46 GMT
 // 
 // How to edit these values:
 // Edit the corresponding token file under the style-definitions directory
@@ -21,9 +21,9 @@
 @theme-text-primary: #2e282a; // The color of the text in the application.
 @theme-text-secondary: #94a1b2;
 @theme-text-link: #5353a6;
-@theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+@theme-text-body-font-family: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 @theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-@theme-background-primary: #f0f1ee; // The main background color of the page.
+@theme-background-primary: #e2e8f0; // The main background color of the page.
 @theme-background-secondary: #ffffff; // A secondary background color used in sections and controls.
 @theme-rounded-corners: 0.5em;
 @theme-user-colors-0: #f40b0b;
@@ -45,7 +45,7 @@
 @white-88: #fffffe;
 @purple-dark: #7a5cf3;
 @default-link-color: #5353a6;
-@default-bg-color: #f0f1ee;
+@default-bg-color: #e2e8f0;
 @default-text-color: #2e282a;
 @color-unknown: #7a5cf3;
 @color-unknown-2: #fffffe;
@@ -62,8 +62,8 @@
 @color-owncast-text-highlight: #030208;
 @color-owncast-text-bright: #5353a6;
 @color-owncast-background-highlight: #f0e678;
-@color-owncast-background-primary: #f0f1ee;
+@color-owncast-background-primary: #e2e8f0;
 @color-owncast-background-secondary: #ffffff;
 @rounded-corners: 0.5em;
-@font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+@font-owncast-body: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 @font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';

--- a/web/styles/theme.less
+++ b/web/styles/theme.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 30 Aug 2022 05:24:37 GMT
+// Generated on Tue, 30 Aug 2022 06:12:22 GMT
 // 
 // How to edit these values:
 // Edit the corresponding token file under the style-definitions directory
@@ -16,67 +16,67 @@
 @theme-rounded-corners: 0.5rem; // How much corners are rounded in places in the UI.
 @theme-unknown-1: green; // This should never be used and it means something is wrong.
 @theme-unknown-2: red; // This should never be used and it means something is wrong.
-@theme-color-users-0: #f40b0b;
-@theme-color-users-1: #f4800b;
-@theme-color-users-2: #f4f40b;
-@theme-color-users-3: #58f40b;
-@theme-color-users-4: #0bf4f4;
-@theme-color-users-5: #0ba6f4;
-@theme-color-users-6: #6666ff;
-@theme-color-users-7: #f40bf4;
-@theme-color-palette-0: #12161d; // Dark primary
-@theme-color-palette-1: #2d3748; // Dark secondary
-@theme-color-palette-2: #000000; // Dark alternate
-@theme-color-palette-3: #e2e8f0; // Light primary
-@theme-color-palette-4: #ffffff; // Light secondary
-@theme-color-palette-5: #c3dafe; // Light alternate
-@theme-color-palette-6: #7a5cf3; // Text link/secondary light text
-@theme-color-palette-7: #5d38f3; // Text link hover
-@theme-color-palette-8: #b6b3c6; // Disabled background
-@theme-color-palette-9: #39373d; // Neutral dark
-@theme-color-palette-10: #707283; // Neutral gray light
-@theme-color-palette-11: #2386e2; // Fun color 1
-@theme-color-palette-12: #da9eff; // Fun color 2
-@theme-color-palette-13: #42bea6; // Fun color 3
-@theme-color-palette-error: #ff4b39; // Error
-@theme-color-palette-warning: #ffc655; // Warning
-@theme-color-background-main: #e2e8f0; // Light primary
-@theme-color-background-header: #12161d; // Dark primary
-@theme-color-action: #7a5cf3; // Text link/secondary light text
-@theme-color-action-hover: #5d38f3; // Text link hover
-@theme-color-action-disabled: #b6b3c6; // Disabled background
-@theme-color-error: #ff4b39; // Error
-@theme-color-warning: #ffc655; // Warning
-@theme-color-components-text-on-light: #12161d; // Dark primary
-@theme-color-components-text-on-dark: #e2e8f0; // Light primary
-@theme-color-components-primary-button-background: #7a5cf3; // Text link/secondary light text
-@theme-color-components-primary-button-background-disabled: #b6b3c6; // Disabled background
-@theme-color-components-primary-button-text: #ffffff; // Light secondary
-@theme-color-components-primary-button-text-disabled: #707283; // Neutral gray light
-@theme-color-components-primary-button-border: #ffffff; // Light secondary
-@theme-color-components-primary-button-border-disabled: #b6b3c6; // Disabled background
-@theme-color-components-secondary-button-background: #ffffff; // Light secondary
-@theme-color-components-secondary-button-background-disabled: transparent; // Disabled background
-@theme-color-components-secondary-button-text: #b6b3c6; // Disabled background
-@theme-color-components-secondary-button-text-disabled: #b6b3c6; // Disabled background
-@theme-color-components-secondary-button-border: #7a5cf3; // Text link/secondary light text
-@theme-color-components-secondary-button-border-disabled: #b6b3c6; // Disabled background
-@theme-color-components-chat-background: #2d3748; // Dark secondary
-@theme-color-components-chat-text: #e2e8f0; // Light primary
-@theme-color-components-modal-header-background: #2d3748; // Dark secondary
-@theme-color-components-modal-header-text: #e2e8f0; // Light primary
-@theme-color-components-modal-content-background: #e2e8f0; // Light primary
-@theme-color-components-modal-content-text: #12161d; // Dark primary
-@theme-color-components-menu-background: #e2e8f0; // Light primary
-@theme-color-components-menu-item-text: #12161d; // Dark primary
+@theme-color-users-0: var(--color-owncast-user-0);
+@theme-color-users-1: var(--color-owncast-user-1);
+@theme-color-users-2: var(--color-owncast-user-2);
+@theme-color-users-3: var(--color-owncast-user-3);
+@theme-color-users-4: var(--color-owncast-user-4);
+@theme-color-users-5: var(--color-owncast-user-5);
+@theme-color-users-6: var(--color-owncast-user-6);
+@theme-color-users-7: var(--color-owncast-user-7);
+@theme-color-palette-0: var(--color-owncast-palette-0); // Dark primary
+@theme-color-palette-1: var(--color-owncast-palette-1); // Dark secondary
+@theme-color-palette-2: var(--color-owncast-palette-2); // Dark alternate
+@theme-color-palette-3: var(--color-owncast-palette-3); // Light primary
+@theme-color-palette-4: var(--color-owncast-palette-4); // Light secondary
+@theme-color-palette-5: var(--color-owncast-palette-5); // Light alternate
+@theme-color-palette-6: var(--color-owncast-palette-6); // Text link/secondary light text
+@theme-color-palette-7: var(--color-owncast-palette-7); // Text link hover
+@theme-color-palette-8: var(--color-owncast-palette-8); // Disabled background
+@theme-color-palette-9: var(--color-owncast-palette-9); // Neutral dark
+@theme-color-palette-10: var(--color-owncast-palette-10); // Neutral gray light
+@theme-color-palette-11: var(--color-owncast-palette-11); // Fun color 1
+@theme-color-palette-12: var(--color-owncast-palette-12); // Fun color 2
+@theme-color-palette-13: var(--color-owncast-palette-13); // Fun color 3
+@theme-color-palette-error: var(--color-owncast-palette-error); // Error
+@theme-color-palette-warning: var(--color-owncast-palette-warning); // Warning
+@theme-color-background-main: var(--theme-color-palette-3); // Light primary
+@theme-color-background-header: var(--theme-color-palette-0); // Dark primary
+@theme-color-action: var(--theme-color-palette-6); // Text link/secondary light text
+@theme-color-action-hover: var(--theme-color-palette-7); // Text link hover
+@theme-color-action-disabled: var(--theme-color-palette-8); // Disabled background
+@theme-color-error: var(--theme-color-palette-error); // Error
+@theme-color-warning: var(--theme-color-palette-warning); // Warning
+@theme-color-components-text-on-light: var(--theme-color-palette-0); // Dark primary
+@theme-color-components-text-on-dark: var(--theme-color-palette-3); // Light primary
+@theme-color-components-primary-button-background: var(--theme-color-action); // Text link/secondary light text
+@theme-color-components-primary-button-background-disabled: var(--theme-color-action-disabled); // Disabled background
+@theme-color-components-primary-button-text: var(--theme-color-palette-4); // Light secondary
+@theme-color-components-primary-button-text-disabled: var(--theme-color-palette-10); // Neutral gray light
+@theme-color-components-primary-button-border: var(--theme-color-palette-4); // Light secondary
+@theme-color-components-primary-button-border-disabled: var(--theme-color-action-disabled); // Disabled background
+@theme-color-components-secondary-button-background: var(--theme-color-palette-4); // Light secondary
+@theme-color-components-secondary-button-background-disabled: transparent;
+@theme-color-components-secondary-button-text: var(--theme-color-action-disabled); // Disabled background
+@theme-color-components-secondary-button-text-disabled: var(--theme-color-action-disabled); // Disabled background
+@theme-color-components-secondary-button-border: var(--theme-color-action); // Text link/secondary light text
+@theme-color-components-secondary-button-border-disabled: var(--theme-color-action-disabled); // Disabled background
+@theme-color-components-chat-background: var(--theme-color-palette-1); // Dark secondary
+@theme-color-components-chat-text: var(--theme-color-palette-3); // Light primary
+@theme-color-components-modal-header-background: var(--theme-color-palette-1); // Dark secondary
+@theme-color-components-modal-header-text: var(--theme-color-palette-3); // Light primary
+@theme-color-components-modal-content-background: var(--theme-color-palette-3); // Light primary
+@theme-color-components-modal-content-text: var(--theme-color-palette-0); // Dark primary
+@theme-color-components-menu-background: var(--theme-color-palette-3); // Light primary
+@theme-color-components-menu-item-text: var(--theme-color-palette-0); // Dark primary
 @theme-color-components-menu-item-bg: transparent;
 @theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
 @theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
-@theme-color-components-form-field-background: #ffffff; // Light secondary
-@theme-color-components-form-field-placeholder: #b6b3c6; // Disabled background
-@theme-color-components-form-field-text: #12161d; // Dark primary
-@theme-color-components-form-field-border: #12161d; // Dark primary
-@theme-color-components-video-background: #000000; // Dark alternate
+@theme-color-components-form-field-background: var(--theme-color-palette-4); // Light secondary
+@theme-color-components-form-field-placeholder: var(--theme-color-action-disabled); // Disabled background
+@theme-color-components-form-field-text: var(--theme-color-palette-0); // Dark primary
+@theme-color-components-form-field-border: var(--theme-color-palette-0); // Dark primary
+@theme-color-components-video-background: var(--theme-color-palette-2); // Dark alternate
 @owncast-purple-25: rgba(120, 113, 255, 0.25);
 @color-unknown: #7a5cf3;
 @color-unknown-2: #fffffe;

--- a/web/styles/theme.less
+++ b/web/styles/theme.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 16 Aug 2022 03:27:53 GMT
+// Generated on Sat, 27 Aug 2022 21:18:14 GMT
 // 
 // How to edit these values:
 // Edit the corresponding token file under the style-definitions directory
@@ -10,21 +10,21 @@
 @text-color-secondary: var(--theme-text-secondary);
 @link-color: var(--theme-text-link);
 @popover-background: var(--theme-background-secondary);
-@modal-content-bg: #ff0000;
+@modal-content-bg: #fffffe;
 @background-color-light: var(--theme-background-secondary);
 @layout-body-background: var(--theme-background-primary);
-@component-background: #00ff00;
-@warning-color: #ff0000;
-@theme-unknown: #00ff00;
-@theme-unknown-2: #ff0000;
-@theme-primary: #00ff00; // The primary color of the application used for rendering controls.
-@theme-text-primary: #030208; // The color of the text in the application.
-@theme-text-secondary: #63638e;
+@component-background: #7a5cf3;
+@warning-color: #fffffe;
+@theme-unknown: #7a5cf3;
+@theme-unknown-2: #fffffe;
+@theme-primary: #7a5cf3; // The primary color of the application used for rendering controls.
+@theme-text-primary: #2e282a; // The color of the text in the application.
+@theme-text-secondary: #94a1b2;
 @theme-text-link: #5353a6;
 @theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 @theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-@theme-background-primary: #fffcf2; // The main background color of the page.
-@theme-background-secondary: #f0efe4; // A secondary background color used in sections and controls.
+@theme-background-primary: #f0f1ee; // The main background color of the page.
+@theme-background-secondary: #ffffff; // A secondary background color used in sections and controls.
 @theme-rounded-corners: 0.5em;
 @theme-user-colors-0: #f40b0b;
 @theme-user-colors-1: #f4800b;
@@ -34,21 +34,21 @@
 @theme-user-colors-5: #0ba6f4;
 @theme-user-colors-6: #6666ff;
 @theme-user-colors-7: #f40bf4;
-@owncast-purple: #00ff00;
+@owncast-purple: #7a5cf3;
 @owncast-purple-25: rgba(120, 113, 255, 0.25);
 @owncast-purple-50: rgba(120, 113, 255, 0.5);
 @online-color: #73dd3f;
 @offline-color: #999;
-@pink: #00ff00;
-@purple: #ff0000;
-@blue: #00ff00;
-@white-88: #ff0000;
-@purple-dark: #00ff00;
+@pink: #7a5cf3;
+@purple: #fffffe;
+@blue: #7a5cf3;
+@white-88: #fffffe;
+@purple-dark: #7a5cf3;
 @default-link-color: #5353a6;
-@default-bg-color: #fffcf2;
-@default-text-color: #030208;
-@color-unknown: #00ff00;
-@color-unknown-2: #ff0000;
+@default-bg-color: #f0f1ee;
+@default-text-color: #2e282a;
+@color-unknown: #7a5cf3;
+@color-unknown-2: #fffffe;
 @color-owncast-user-0: #f40b0b;
 @color-owncast-user-1: #f4800b;
 @color-owncast-user-2: #f4f40b;
@@ -57,13 +57,13 @@
 @color-owncast-user-5: #0ba6f4;
 @color-owncast-user-6: #6666ff;
 @color-owncast-user-7: #f40bf4;
-@color-owncast-text-primary: #030208;
-@color-owncast-text-secondary: #63638e;
+@color-owncast-text-primary: #2e282a;
+@color-owncast-text-secondary: #94a1b2;
 @color-owncast-text-highlight: #030208;
 @color-owncast-text-bright: #5353a6;
 @color-owncast-background-highlight: #f0e678;
-@color-owncast-background-primary: #fffcf2;
-@color-owncast-background-secondary: #f0efe4;
+@color-owncast-background-primary: #f0f1ee;
+@color-owncast-background-secondary: #ffffff;
 @rounded-corners: 0.5em;
 @font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 @font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 27 Aug 2022 21:18:14 GMT
+ * Generated on Mon, 29 Aug 2022 07:35:46 GMT
  * 
  * How to edit these values:
  * Edit the corresponding token file under the style-definitions directory
@@ -23,13 +23,9 @@
   --theme-text-primary: #2e282a; /* The color of the text in the application. */
   --theme-text-secondary: #94a1b2;
   --theme-text-link: #5353a6;
-  --theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-background-primary: #f0f1ee; /* The main background color of the page. */
+  --theme-text-body-font-family: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-background-primary: #e2e8f0; /* The main background color of the page. */
   --theme-background-secondary: #ffffff; /* A secondary background color used in sections and controls. */
   --theme-rounded-corners: 0.5em;
   --theme-user-colors-0: #f40b0b;
@@ -51,7 +47,7 @@
   --white-88: #fffffe;
   --purple-dark: #7a5cf3;
   --default-link-color: #5353a6;
-  --default-bg-color: #f0f1ee;
+  --default-bg-color: #e2e8f0;
   --default-text-color: #2e282a;
   --color-unknown: #7a5cf3;
   --color-unknown-2: #fffffe;
@@ -68,13 +64,9 @@
   --color-owncast-text-highlight: #030208;
   --color-owncast-text-bright: #5353a6;
   --color-owncast-background-highlight: #f0e678;
-  --color-owncast-background-primary: #f0f1ee;
+  --color-owncast-background-primary: #e2e8f0;
   --color-owncast-background-secondary: #ffffff;
   --rounded-corners: 0.5em;
-  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -51,31 +51,59 @@
   --theme-color-warning: var(--theme-color-palette-warning); /* Warning */
   --theme-color-components-text-on-light: var(--theme-color-palette-0); /* Dark primary */
   --theme-color-components-text-on-dark: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-components-primary-button-background: var(--theme-color-action); /* Text link/secondary light text */
-  --theme-color-components-primary-button-background-disabled: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-primary-button-background: var(
+    --theme-color-action
+  ); /* Text link/secondary light text */
+  --theme-color-components-primary-button-background-disabled: var(
+    --theme-color-action-disabled
+  ); /* Disabled background */
   --theme-color-components-primary-button-text: var(--theme-color-palette-4); /* Light secondary */
-  --theme-color-components-primary-button-text-disabled: var(--theme-color-palette-10); /* Neutral gray light */
-  --theme-color-components-primary-button-border: var(--theme-color-palette-4); /* Light secondary */
-  --theme-color-components-primary-button-border-disabled: var(--theme-color-action-disabled); /* Disabled background */
-  --theme-color-components-secondary-button-background: var(--theme-color-palette-4); /* Light secondary */
+  --theme-color-components-primary-button-text-disabled: var(
+    --theme-color-palette-10
+  ); /* Neutral gray light */
+  --theme-color-components-primary-button-border: var(
+    --theme-color-palette-4
+  ); /* Light secondary */
+  --theme-color-components-primary-button-border-disabled: var(
+    --theme-color-action-disabled
+  ); /* Disabled background */
+  --theme-color-components-secondary-button-background: var(
+    --theme-color-palette-4
+  ); /* Light secondary */
   --theme-color-components-secondary-button-background-disabled: transparent;
-  --theme-color-components-secondary-button-text: var(--theme-color-action-disabled); /* Disabled background */
-  --theme-color-components-secondary-button-text-disabled: var(--theme-color-action-disabled); /* Disabled background */
-  --theme-color-components-secondary-button-border: var(--theme-color-action); /* Text link/secondary light text */
-  --theme-color-components-secondary-button-border-disabled: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-secondary-button-text: var(
+    --theme-color-action-disabled
+  ); /* Disabled background */
+  --theme-color-components-secondary-button-text-disabled: var(
+    --theme-color-action-disabled
+  ); /* Disabled background */
+  --theme-color-components-secondary-button-border: var(
+    --theme-color-action
+  ); /* Text link/secondary light text */
+  --theme-color-components-secondary-button-border-disabled: var(
+    --theme-color-action-disabled
+  ); /* Disabled background */
   --theme-color-components-chat-background: var(--theme-color-palette-1); /* Dark secondary */
   --theme-color-components-chat-text: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-components-modal-header-background: var(--theme-color-palette-1); /* Dark secondary */
+  --theme-color-components-modal-header-background: var(
+    --theme-color-palette-1
+  ); /* Dark secondary */
   --theme-color-components-modal-header-text: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-components-modal-content-background: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-components-modal-content-background: var(
+    --theme-color-palette-3
+  ); /* Light primary */
   --theme-color-components-modal-content-text: var(--theme-color-palette-0); /* Dark primary */
   --theme-color-components-menu-background: var(--theme-color-palette-3); /* Light primary */
   --theme-color-components-menu-item-text: var(--theme-color-palette-0); /* Dark primary */
   --theme-color-components-menu-item-bg: transparent;
   --theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
   --theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
-  --theme-color-components-form-field-background: var(--theme-color-palette-4); /* Light secondary */
-  --theme-color-components-form-field-placeholder: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-form-field-background: var(
+    --theme-color-palette-4
+  ); /* Light secondary */
+  --theme-color-components-form-field-placeholder: var(
+    --theme-color-action-disabled
+  ); /* Disabled background */
   --theme-color-components-form-field-text: var(--theme-color-palette-0); /* Dark primary */
   --theme-color-components-form-field-border: var(--theme-color-palette-0); /* Dark primary */
   --theme-color-components-video-background: var(--theme-color-palette-2); /* Dark alternate */
@@ -106,6 +134,10 @@
   --color-owncast-palette-13: #42bea6; /* Fun color 3 */
   --color-owncast-palette-error: #ff4b39; /* Error */
   --color-owncast-palette-warning: #ffc655; /* Warning */
-  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -106,6 +106,10 @@
   --color-owncast-palette-13: #42bea6; /* Fun color 3 */
   --color-owncast-palette-error: #ff4b39; /* Error */
   --color-owncast-palette-warning: #ffc655; /* Warning */
-  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 16 Aug 2022 03:27:53 GMT
+ * Generated on Sat, 27 Aug 2022 21:18:14 GMT
  * 
  * How to edit these values:
  * Edit the corresponding token file under the style-definitions directory
@@ -12,25 +12,21 @@
   --text-color-secondary: var(--theme-text-secondary);
   --link-color: var(--theme-text-link);
   --popover-background: var(--theme-background-secondary);
-  --modal-content-bg: #ff0000;
+  --modal-content-bg: #fffffe;
   --background-color-light: var(--theme-background-secondary);
   --layout-body-background: var(--theme-background-primary);
-  --component-background: #00ff00;
-  --warning-color: #ff0000;
-  --theme-unknown: #00ff00;
-  --theme-unknown-2: #ff0000;
-  --theme-primary: #00ff00; /* The primary color of the application used for rendering controls. */
-  --theme-text-primary: #030208; /* The color of the text in the application. */
-  --theme-text-secondary: #63638e;
+  --component-background: #7a5cf3;
+  --warning-color: #fffffe;
+  --theme-unknown: #7a5cf3;
+  --theme-unknown-2: #fffffe;
+  --theme-primary: #7a5cf3; /* The primary color of the application used for rendering controls. */
+  --theme-text-primary: #2e282a; /* The color of the text in the application. */
+  --theme-text-secondary: #94a1b2;
   --theme-text-link: #5353a6;
-  --theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-background-primary: #fffcf2; /* The main background color of the page. */
-  --theme-background-secondary: #f0efe4; /* A secondary background color used in sections and controls. */
+  --theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-background-primary: #f0f1ee; /* The main background color of the page. */
+  --theme-background-secondary: #ffffff; /* A secondary background color used in sections and controls. */
   --theme-rounded-corners: 0.5em;
   --theme-user-colors-0: #f40b0b;
   --theme-user-colors-1: #f4800b;
@@ -40,21 +36,21 @@
   --theme-user-colors-5: #0ba6f4;
   --theme-user-colors-6: #6666ff;
   --theme-user-colors-7: #f40bf4;
-  --owncast-purple: #00ff00;
+  --owncast-purple: #7a5cf3;
   --owncast-purple-25: rgba(120, 113, 255, 0.25);
   --owncast-purple-50: rgba(120, 113, 255, 0.5);
   --online-color: #73dd3f;
   --offline-color: #999;
-  --pink: #00ff00;
-  --purple: #ff0000;
-  --blue: #00ff00;
-  --white-88: #ff0000;
-  --purple-dark: #00ff00;
+  --pink: #7a5cf3;
+  --purple: #fffffe;
+  --blue: #7a5cf3;
+  --white-88: #fffffe;
+  --purple-dark: #7a5cf3;
   --default-link-color: #5353a6;
-  --default-bg-color: #fffcf2;
-  --default-text-color: #030208;
-  --color-unknown: #00ff00;
-  --color-unknown-2: #ff0000;
+  --default-bg-color: #f0f1ee;
+  --default-text-color: #2e282a;
+  --color-unknown: #7a5cf3;
+  --color-unknown-2: #fffffe;
   --color-owncast-user-0: #f40b0b;
   --color-owncast-user-1: #f4800b;
   --color-owncast-user-2: #f4f40b;
@@ -63,18 +59,14 @@
   --color-owncast-user-5: #0ba6f4;
   --color-owncast-user-6: #6666ff;
   --color-owncast-user-7: #f40bf4;
-  --color-owncast-text-primary: #030208;
-  --color-owncast-text-secondary: #63638e;
+  --color-owncast-text-primary: #2e282a;
+  --color-owncast-text-secondary: #94a1b2;
   --color-owncast-text-highlight: #030208;
   --color-owncast-text-bright: #5353a6;
   --color-owncast-background-highlight: #f0e678;
-  --color-owncast-background-primary: #fffcf2;
-  --color-owncast-background-secondary: #f0efe4;
+  --color-owncast-background-primary: #f0f1ee;
+  --color-owncast-background-secondary: #ffffff;
   --rounded-corners: 0.5em;
-  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -23,8 +23,12 @@
   --theme-text-primary: #2e282a; /* The color of the text in the application. */
   --theme-text-secondary: #94a1b2;
   --theme-text-link: #5353a6;
-  --theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-text-body-font-family: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --theme-background-primary: #f0f1ee; /* The main background color of the page. */
   --theme-background-secondary: #ffffff; /* A secondary background color used in sections and controls. */
   --theme-rounded-corners: 0.5em;
@@ -67,6 +71,10 @@
   --color-owncast-background-primary: #f0f1ee;
   --color-owncast-background-secondary: #ffffff;
   --rounded-corners: 0.5em;
-  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Aug 2022 05:24:37 GMT
+ * Generated on Tue, 30 Aug 2022 06:12:22 GMT
  * 
  * How to edit these values:
  * Edit the corresponding token file under the style-definitions directory
@@ -18,67 +18,67 @@
   --theme-rounded-corners: 0.5rem; /* How much corners are rounded in places in the UI. */
   --theme-unknown-1: green; /* This should never be used and it means something is wrong. */
   --theme-unknown-2: red; /* This should never be used and it means something is wrong. */
-  --theme-color-users-0: #f40b0b;
-  --theme-color-users-1: #f4800b;
-  --theme-color-users-2: #f4f40b;
-  --theme-color-users-3: #58f40b;
-  --theme-color-users-4: #0bf4f4;
-  --theme-color-users-5: #0ba6f4;
-  --theme-color-users-6: #6666ff;
-  --theme-color-users-7: #f40bf4;
-  --theme-color-palette-0: #12161d; /* Dark primary */
-  --theme-color-palette-1: #2d3748; /* Dark secondary */
-  --theme-color-palette-2: #000000; /* Dark alternate */
-  --theme-color-palette-3: #e2e8f0; /* Light primary */
-  --theme-color-palette-4: #ffffff; /* Light secondary */
-  --theme-color-palette-5: #c3dafe; /* Light alternate */
-  --theme-color-palette-6: #7a5cf3; /* Text link/secondary light text */
-  --theme-color-palette-7: #5d38f3; /* Text link hover */
-  --theme-color-palette-8: #b6b3c6; /* Disabled background */
-  --theme-color-palette-9: #39373d; /* Neutral dark */
-  --theme-color-palette-10: #707283; /* Neutral gray light */
-  --theme-color-palette-11: #2386e2; /* Fun color 1 */
-  --theme-color-palette-12: #da9eff; /* Fun color 2 */
-  --theme-color-palette-13: #42bea6; /* Fun color 3 */
-  --theme-color-palette-error: #ff4b39; /* Error */
-  --theme-color-palette-warning: #ffc655; /* Warning */
-  --theme-color-background-main: #e2e8f0; /* Light primary */
-  --theme-color-background-header: #12161d; /* Dark primary */
-  --theme-color-action: #7a5cf3; /* Text link/secondary light text */
-  --theme-color-action-hover: #5d38f3; /* Text link hover */
-  --theme-color-action-disabled: #b6b3c6; /* Disabled background */
-  --theme-color-error: #ff4b39; /* Error */
-  --theme-color-warning: #ffc655; /* Warning */
-  --theme-color-components-text-on-light: #12161d; /* Dark primary */
-  --theme-color-components-text-on-dark: #e2e8f0; /* Light primary */
-  --theme-color-components-primary-button-background: #7a5cf3; /* Text link/secondary light text */
-  --theme-color-components-primary-button-background-disabled: #b6b3c6; /* Disabled background */
-  --theme-color-components-primary-button-text: #ffffff; /* Light secondary */
-  --theme-color-components-primary-button-text-disabled: #707283; /* Neutral gray light */
-  --theme-color-components-primary-button-border: #ffffff; /* Light secondary */
-  --theme-color-components-primary-button-border-disabled: #b6b3c6; /* Disabled background */
-  --theme-color-components-secondary-button-background: #ffffff; /* Light secondary */
-  --theme-color-components-secondary-button-background-disabled: transparent; /* Disabled background */
-  --theme-color-components-secondary-button-text: #b6b3c6; /* Disabled background */
-  --theme-color-components-secondary-button-text-disabled: #b6b3c6; /* Disabled background */
-  --theme-color-components-secondary-button-border: #7a5cf3; /* Text link/secondary light text */
-  --theme-color-components-secondary-button-border-disabled: #b6b3c6; /* Disabled background */
-  --theme-color-components-chat-background: #2d3748; /* Dark secondary */
-  --theme-color-components-chat-text: #e2e8f0; /* Light primary */
-  --theme-color-components-modal-header-background: #2d3748; /* Dark secondary */
-  --theme-color-components-modal-header-text: #e2e8f0; /* Light primary */
-  --theme-color-components-modal-content-background: #e2e8f0; /* Light primary */
-  --theme-color-components-modal-content-text: #12161d; /* Dark primary */
-  --theme-color-components-menu-background: #e2e8f0; /* Light primary */
-  --theme-color-components-menu-item-text: #12161d; /* Dark primary */
+  --theme-color-users-0: var(--color-owncast-user-0);
+  --theme-color-users-1: var(--color-owncast-user-1);
+  --theme-color-users-2: var(--color-owncast-user-2);
+  --theme-color-users-3: var(--color-owncast-user-3);
+  --theme-color-users-4: var(--color-owncast-user-4);
+  --theme-color-users-5: var(--color-owncast-user-5);
+  --theme-color-users-6: var(--color-owncast-user-6);
+  --theme-color-users-7: var(--color-owncast-user-7);
+  --theme-color-palette-0: var(--color-owncast-palette-0); /* Dark primary */
+  --theme-color-palette-1: var(--color-owncast-palette-1); /* Dark secondary */
+  --theme-color-palette-2: var(--color-owncast-palette-2); /* Dark alternate */
+  --theme-color-palette-3: var(--color-owncast-palette-3); /* Light primary */
+  --theme-color-palette-4: var(--color-owncast-palette-4); /* Light secondary */
+  --theme-color-palette-5: var(--color-owncast-palette-5); /* Light alternate */
+  --theme-color-palette-6: var(--color-owncast-palette-6); /* Text link/secondary light text */
+  --theme-color-palette-7: var(--color-owncast-palette-7); /* Text link hover */
+  --theme-color-palette-8: var(--color-owncast-palette-8); /* Disabled background */
+  --theme-color-palette-9: var(--color-owncast-palette-9); /* Neutral dark */
+  --theme-color-palette-10: var(--color-owncast-palette-10); /* Neutral gray light */
+  --theme-color-palette-11: var(--color-owncast-palette-11); /* Fun color 1 */
+  --theme-color-palette-12: var(--color-owncast-palette-12); /* Fun color 2 */
+  --theme-color-palette-13: var(--color-owncast-palette-13); /* Fun color 3 */
+  --theme-color-palette-error: var(--color-owncast-palette-error); /* Error */
+  --theme-color-palette-warning: var(--color-owncast-palette-warning); /* Warning */
+  --theme-color-background-main: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-background-header: var(--theme-color-palette-0); /* Dark primary */
+  --theme-color-action: var(--theme-color-palette-6); /* Text link/secondary light text */
+  --theme-color-action-hover: var(--theme-color-palette-7); /* Text link hover */
+  --theme-color-action-disabled: var(--theme-color-palette-8); /* Disabled background */
+  --theme-color-error: var(--theme-color-palette-error); /* Error */
+  --theme-color-warning: var(--theme-color-palette-warning); /* Warning */
+  --theme-color-components-text-on-light: var(--theme-color-palette-0); /* Dark primary */
+  --theme-color-components-text-on-dark: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-components-primary-button-background: var(--theme-color-action); /* Text link/secondary light text */
+  --theme-color-components-primary-button-background-disabled: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-primary-button-text: var(--theme-color-palette-4); /* Light secondary */
+  --theme-color-components-primary-button-text-disabled: var(--theme-color-palette-10); /* Neutral gray light */
+  --theme-color-components-primary-button-border: var(--theme-color-palette-4); /* Light secondary */
+  --theme-color-components-primary-button-border-disabled: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-secondary-button-background: var(--theme-color-palette-4); /* Light secondary */
+  --theme-color-components-secondary-button-background-disabled: transparent;
+  --theme-color-components-secondary-button-text: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-secondary-button-text-disabled: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-secondary-button-border: var(--theme-color-action); /* Text link/secondary light text */
+  --theme-color-components-secondary-button-border-disabled: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-chat-background: var(--theme-color-palette-1); /* Dark secondary */
+  --theme-color-components-chat-text: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-components-modal-header-background: var(--theme-color-palette-1); /* Dark secondary */
+  --theme-color-components-modal-header-text: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-components-modal-content-background: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-components-modal-content-text: var(--theme-color-palette-0); /* Dark primary */
+  --theme-color-components-menu-background: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-components-menu-item-text: var(--theme-color-palette-0); /* Dark primary */
   --theme-color-components-menu-item-bg: transparent;
   --theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
   --theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
-  --theme-color-components-form-field-background: #ffffff; /* Light secondary */
-  --theme-color-components-form-field-placeholder: #b6b3c6; /* Disabled background */
-  --theme-color-components-form-field-text: #12161d; /* Dark primary */
-  --theme-color-components-form-field-border: #12161d; /* Dark primary */
-  --theme-color-components-video-background: #000000; /* Dark alternate */
+  --theme-color-components-form-field-background: var(--theme-color-palette-4); /* Light secondary */
+  --theme-color-components-form-field-placeholder: var(--theme-color-action-disabled); /* Disabled background */
+  --theme-color-components-form-field-text: var(--theme-color-palette-0); /* Dark primary */
+  --theme-color-components-form-field-border: var(--theme-color-palette-0); /* Dark primary */
+  --theme-color-components-video-background: var(--theme-color-palette-2); /* Dark alternate */
   --owncast-purple-25: rgba(120, 113, 255, 0.25);
   --color-unknown: #7a5cf3;
   --color-unknown-2: #fffffe;
@@ -106,10 +106,6 @@
   --color-owncast-palette-13: #42bea6; /* Fun color 3 */
   --color-owncast-palette-error: #ff4b39; /* Error */
   --color-owncast-palette-warning: #ffc655; /* Warning */
-  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 29 Aug 2022 07:35:46 GMT
+ * Generated on Tue, 30 Aug 2022 05:24:37 GMT
  * 
  * How to edit these values:
  * Edit the corresponding token file under the style-definitions directory
@@ -8,51 +8,78 @@
  */
 
 :root {
-  --text-color: var(--theme-text-primary);
-  --text-color-secondary: var(--theme-text-secondary);
-  --link-color: var(--theme-text-link);
-  --popover-background: var(--theme-background-secondary);
-  --modal-content-bg: #fffffe;
-  --background-color-light: var(--theme-background-secondary);
-  --layout-body-background: var(--theme-background-primary);
-  --component-background: #7a5cf3;
-  --warning-color: #fffffe;
-  --theme-unknown: #7a5cf3;
-  --theme-unknown-2: #fffffe;
-  --theme-primary: #7a5cf3; /* The primary color of the application used for rendering controls. */
-  --theme-text-primary: #2e282a; /* The color of the text in the application. */
-  --theme-text-secondary: #94a1b2;
-  --theme-text-link: #5353a6;
-  --theme-text-body-font-family: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-background-primary: #e2e8f0; /* The main background color of the page. */
-  --theme-background-secondary: #ffffff; /* A secondary background color used in sections and controls. */
-  --theme-rounded-corners: 0.5em;
-  --theme-user-colors-0: #f40b0b;
-  --theme-user-colors-1: #f4800b;
-  --theme-user-colors-2: #f4f40b;
-  --theme-user-colors-3: #58f40b;
-  --theme-user-colors-4: #0bf4f4;
-  --theme-user-colors-5: #0ba6f4;
-  --theme-user-colors-6: #6666ff;
-  --theme-user-colors-7: #f40bf4;
-  --owncast-purple: #7a5cf3;
+  --link-color: var(--theme-color-action);
+  --link-hover-color: var(--theme-color-action-hover);
+  --modal-header-bg: var(--theme-color-components-modal-header-background);
+  --modal-content-bg: var(--theme-color-background-main);
+  --alert-error-bg-color: var(--theme-color-palette-4);
+  --alert-error-border-color: var(--theme-color-palette-error);
+  --popover-background: var(--theme-color-components-menu-background);
+  --theme-rounded-corners: 0.5rem; /* How much corners are rounded in places in the UI. */
+  --theme-unknown-1: green; /* This should never be used and it means something is wrong. */
+  --theme-unknown-2: red; /* This should never be used and it means something is wrong. */
+  --theme-color-users-0: #f40b0b;
+  --theme-color-users-1: #f4800b;
+  --theme-color-users-2: #f4f40b;
+  --theme-color-users-3: #58f40b;
+  --theme-color-users-4: #0bf4f4;
+  --theme-color-users-5: #0ba6f4;
+  --theme-color-users-6: #6666ff;
+  --theme-color-users-7: #f40bf4;
+  --theme-color-palette-0: #12161d; /* Dark primary */
+  --theme-color-palette-1: #2d3748; /* Dark secondary */
+  --theme-color-palette-2: #000000; /* Dark alternate */
+  --theme-color-palette-3: #e2e8f0; /* Light primary */
+  --theme-color-palette-4: #ffffff; /* Light secondary */
+  --theme-color-palette-5: #c3dafe; /* Light alternate */
+  --theme-color-palette-6: #7a5cf3; /* Text link/secondary light text */
+  --theme-color-palette-7: #5d38f3; /* Text link hover */
+  --theme-color-palette-8: #b6b3c6; /* Disabled background */
+  --theme-color-palette-9: #39373d; /* Neutral dark */
+  --theme-color-palette-10: #707283; /* Neutral gray light */
+  --theme-color-palette-11: #2386e2; /* Fun color 1 */
+  --theme-color-palette-12: #da9eff; /* Fun color 2 */
+  --theme-color-palette-13: #42bea6; /* Fun color 3 */
+  --theme-color-palette-error: #ff4b39; /* Error */
+  --theme-color-palette-warning: #ffc655; /* Warning */
+  --theme-color-background-main: #e2e8f0; /* Light primary */
+  --theme-color-background-header: #12161d; /* Dark primary */
+  --theme-color-action: #7a5cf3; /* Text link/secondary light text */
+  --theme-color-action-hover: #5d38f3; /* Text link hover */
+  --theme-color-action-disabled: #b6b3c6; /* Disabled background */
+  --theme-color-error: #ff4b39; /* Error */
+  --theme-color-warning: #ffc655; /* Warning */
+  --theme-color-components-text-on-light: #12161d; /* Dark primary */
+  --theme-color-components-text-on-dark: #e2e8f0; /* Light primary */
+  --theme-color-components-primary-button-background: #7a5cf3; /* Text link/secondary light text */
+  --theme-color-components-primary-button-background-disabled: #b6b3c6; /* Disabled background */
+  --theme-color-components-primary-button-text: #ffffff; /* Light secondary */
+  --theme-color-components-primary-button-text-disabled: #707283; /* Neutral gray light */
+  --theme-color-components-primary-button-border: #ffffff; /* Light secondary */
+  --theme-color-components-primary-button-border-disabled: #b6b3c6; /* Disabled background */
+  --theme-color-components-secondary-button-background: #ffffff; /* Light secondary */
+  --theme-color-components-secondary-button-background-disabled: transparent; /* Disabled background */
+  --theme-color-components-secondary-button-text: #b6b3c6; /* Disabled background */
+  --theme-color-components-secondary-button-text-disabled: #b6b3c6; /* Disabled background */
+  --theme-color-components-secondary-button-border: #7a5cf3; /* Text link/secondary light text */
+  --theme-color-components-secondary-button-border-disabled: #b6b3c6; /* Disabled background */
+  --theme-color-components-chat-background: #2d3748; /* Dark secondary */
+  --theme-color-components-chat-text: #e2e8f0; /* Light primary */
+  --theme-color-components-modal-header-background: #2d3748; /* Dark secondary */
+  --theme-color-components-modal-header-text: #e2e8f0; /* Light primary */
+  --theme-color-components-modal-content-background: #e2e8f0; /* Light primary */
+  --theme-color-components-modal-content-text: #12161d; /* Dark primary */
+  --theme-color-components-menu-background: #e2e8f0; /* Light primary */
+  --theme-color-components-menu-item-text: #12161d; /* Dark primary */
+  --theme-color-components-menu-item-bg: transparent;
+  --theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
+  --theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
+  --theme-color-components-form-field-background: #ffffff; /* Light secondary */
+  --theme-color-components-form-field-placeholder: #b6b3c6; /* Disabled background */
+  --theme-color-components-form-field-text: #12161d; /* Dark primary */
+  --theme-color-components-form-field-border: #12161d; /* Dark primary */
+  --theme-color-components-video-background: #000000; /* Dark alternate */
   --owncast-purple-25: rgba(120, 113, 255, 0.25);
-  --owncast-purple-50: rgba(120, 113, 255, 0.5);
-  --online-color: #73dd3f;
-  --offline-color: #999;
-  --pink: #7a5cf3;
-  --purple: #fffffe;
-  --blue: #7a5cf3;
-  --white-88: #fffffe;
-  --purple-dark: #7a5cf3;
-  --default-link-color: #5353a6;
-  --default-bg-color: #e2e8f0;
-  --default-text-color: #2e282a;
   --color-unknown: #7a5cf3;
   --color-unknown-2: #fffffe;
   --color-owncast-user-0: #f40b0b;
@@ -63,18 +90,22 @@
   --color-owncast-user-5: #0ba6f4;
   --color-owncast-user-6: #6666ff;
   --color-owncast-user-7: #f40bf4;
-  --color-owncast-text-primary: #2e282a;
-  --color-owncast-text-secondary: #94a1b2;
-  --color-owncast-text-highlight: #030208;
-  --color-owncast-text-bright: #5353a6;
-  --color-owncast-background-highlight: #f0e678;
-  --color-owncast-background-primary: #e2e8f0;
-  --color-owncast-background-secondary: #ffffff;
-  --rounded-corners: 0.5em;
-  --font-owncast-body: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
+  --color-owncast-palette-0: #12161d; /* Dark primary */
+  --color-owncast-palette-1: #2d3748; /* Dark secondary */
+  --color-owncast-palette-2: #000000; /* Dark alternate */
+  --color-owncast-palette-3: #e2e8f0; /* Light primary */
+  --color-owncast-palette-4: #ffffff; /* Light secondary */
+  --color-owncast-palette-5: #c3dafe; /* Light alternate */
+  --color-owncast-palette-6: #7a5cf3; /* Text link/secondary light text */
+  --color-owncast-palette-7: #5d38f3; /* Text link hover */
+  --color-owncast-palette-8: #b6b3c6; /* Disabled background */
+  --color-owncast-palette-9: #39373d; /* Neutral dark */
+  --color-owncast-palette-10: #707283; /* Neutral gray light */
+  --color-owncast-palette-11: #2386e2; /* Fun color 1 */
+  --color-owncast-palette-12: #da9eff; /* Fun color 2 */
+  --color-owncast-palette-13: #42bea6; /* Fun color 3 */
+  --color-owncast-palette-error: #ff4b39; /* Error */
+  --color-owncast-palette-warning: #ffc655; /* Warning */
+  --font-owncast-body: 'Open Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -23,8 +23,12 @@
   --theme-text-primary: #2e282a; /* The color of the text in the application. */
   --theme-text-secondary: #94a1b2;
   --theme-text-link: #5353a6;
-  --theme-text-body-font-family: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-text-body-font-family: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --theme-text-display-font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --theme-background-primary: #e2e8f0; /* The main background color of the page. */
   --theme-background-secondary: #ffffff; /* A secondary background color used in sections and controls. */
   --theme-rounded-corners: 0.5em;
@@ -67,6 +71,10 @@
   --color-owncast-background-primary: #e2e8f0;
   --color-owncast-background-secondary: #ffffff;
   --rounded-corners: 0.5em;
-  --font-owncast-body: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-body: 'Open SansVariable', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-owncast-display: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }

--- a/web/styles/variables.scss
+++ b/web/styles/variables.scss
@@ -1,5 +1,5 @@
-@import "@fontsource/open-sans";
-@import "@fontsource/poppins";
+@import '@fontsource/open-sans';
+@import '@fontsource/poppins';
 
 // See theme.less for specific Ant Design overrides.
 :root {
@@ -75,21 +75,7 @@
   --container-bg-color-alt: var(--purple-dark);
   --container-border-radius: 4px;
 
-  --code-color: #9cdcfe;
-  --code-bg-color: var(--owncast-purple-25);
-
   --nav-bg-color: var(--gray-dark);
-  --nav-text: #aaa;
-  --nav-selected-text: var(--pink); //#cd7cff;
-
-  --button-focused: var(--owncast-purple-50);
 
   --textfield-border: var(--white-25);
-  --textfield-bg: var(--black);
-
-  //
-  --popover-base-color: var(--gray);
-  --tooltip-base-color: var(--gray-medium);
-
-  --font-family: var(--theme-font-family);
 }


### PR DESCRIPTION
## Description 
Per offline conversation with @gabek , here is a proposed color theme based on the Owncast app's current color scheme.  Given the current scheme, I see it as having both a `light` and a `dark` palette at the same time. 

There are both `primary` and `secondary` lights and darks. The colors used across both are generally the same, to keep things simple. The lights would be used as texts on dark backgrounds; the darks would be used text on light backgrounds.  

For temporary purposes I added named color variables to the `globals.scss` file. If you look at the diffs, I've applied the vars to various areas of the current `webv2` branch, as well as created some more `ant-overrides` so you can see what things would look like.  Apologies for creating a mess here. This is definitely in a prototype mode! So please feel free to apply these names or colors to follow the theming conventions in the codebase.

I've also made some slight modifications to the current `webv2` layout which includes:
- making the video background black
- adjusting some divs in the Content area so that things are centered.
- added a `content-padding` and `module-spacing` vars that could be used as consistent padding value within and spacing values between containers. 
- I gave `ActionButton` an optional `primary` prop.  Because not all buttons should be "primary" by default.  Some buttons could be less -important secondary actions, which are styled to have a white background and border and not a solid color.


Ant-overrides (sorry I wasn't sure where to adjust these values, so I put them in `ant-overrides`.
- Tab coloring and spacing
- Dropdown menu
- Button coloring, primary button coloring
- Form field coloring
- Modal coloring


---


### Dev Screenshots

<img width="600" alt="image" src="https://user-images.githubusercontent.com/9563255/187112334-e6c73bad-72df-42fc-9ee2-8d36ba615275.png">

<img width="600" alt="image" src="https://user-images.githubusercontent.com/9563255/187112257-ec350365-1f9f-4caf-a8b0-6d155e7831ac.png">

### Palette
<img width="411" alt="image" src="https://user-images.githubusercontent.com/9563255/187114908-ab8d62c1-bc3a-4045-9866-2ca462da53a2.png">


### Notes
- There are a couple cases where the a11y contrast isn't quite enough. (error, warning text on white, disabled text). These can be easily adjusted at a later time in the theme. 
- The "fun" colors aren't really used anywhere. Totally optional.
- Chat - The custom user chat name colors will obviously need to be adjusted to work on a dark background.
