### PR TITLE
Add va-api support in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 
 # Create the image by copying the result of the build into a new alpine image
 FROM alpine
-RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs ca-certificates && update-ca-certificates
+RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs libva-intel-driver mesa-va-gallium mesa-vdpau-gallium intel-media-driver libva-vdpau-driver ca-certificates && update-ca-certificates
 
 # Copy owncast assets
 WORKDIR /app

--- a/Earthfile
+++ b/Earthfile
@@ -121,7 +121,7 @@ docker:
   ARG tag=develop
   ARG TARGETPLATFORM
   FROM --platform=$TARGETPLATFORM alpine:3.15.5
-  RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs ca-certificates unzip && update-ca-certificates
+  RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs libva-intel-driver mesa-va-gallium mesa-vdpau-gallium intel-media-driver ca-certificates unzip && apk add --no-cache libva-vdpau-driver --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community && update-ca-certificates
   WORKDIR /app
   COPY --platform=$TARGETPLATFORM +package/owncast.zip /app
   RUN unzip -x owncast.zip && mkdir data


### PR DESCRIPTION
# Description

Fixes #2025

This PR adds the necessary libraries/drivers to use va-api in a docker container.

This has been tested so far only on Intel GPUs. I don't currently own or have access to an AMD one. If someone with an amd cpu could test this that would be awesome.

In order to use va-api in docker you need to add `--device=/dev/dri` to the `docker run` command or 
```yaml
devices:
  - /dev/dri:/dev/dri
```
in docker compose

The docker image currently uses the latest version of alpine that has ffmpeg 5.0.1 
This PR will not work until #2071 is fixed. Alternatively we could downgrade the alpine version in the container in order to use ffmpeg 4 for now but I'm not sure about doing that