### PR TITLE
refactor(#2119): update button and button row to follow atomic design

### DIFF
--- a/web/components/.eslintrc.js
+++ b/web/components/.eslintrc.js
@@ -15,6 +15,15 @@ module.exports = {
     // In functional components, mostly ensures Props are defined above components.
     '@typescript-eslint/no-use-before-define': 'error',
 
+    // Allow dev dependencies in .stories.tsx files
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: ['**/*.stories.*'],
+        peerDependencies: true,
+      },
+    ],
+
     // React components tend to use named exports.
     // Additionally, the `export default function` syntax cannot be auto-fixed by eslint when using ts.
     'import/prefer-default-export': 'off',

--- a/web/components/action-buttons/ActionButton/ActionButton.stories.tsx
+++ b/web/components/action-buttons/ActionButton/ActionButton.stories.tsx
@@ -8,7 +8,10 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: `An **Action Button** or **External Action Button** is a button that is used to trigger either an internal or external action. Many will show a modal, but they can also open a new tab to allow navigating to external pages. They are rendered horizontally within the Action Button Row.`,
+        component: `DEPRECATED: Use atom/Button instead.
+        An **Action Button** or **External Action Button** is a button that is used to trigger either an internal or external action.
+        Many will show a modal, but they can also open a new tab to allow navigating to external pages.
+        They are rendered horizontally within the Action Button Row.`,
       },
     },
   },

--- a/web/components/action-buttons/ActionButton/ActionButton.tsx
+++ b/web/components/action-buttons/ActionButton/ActionButton.tsx
@@ -9,6 +9,9 @@ export type ActionButtonProps = {
   primary?: boolean;
 };
 
+/**
+ * @deprecated by #2119. Use {@link ../../atomic/atoms/Button} instead.
+ */
 export const ActionButton: FC<ActionButtonProps> = ({
   action: { url, title, description, icon, color, openExternally },
   primary = true,

--- a/web/components/atomic/atoms/Button/Button.module.scss
+++ b/web/components/atomic/atoms/Button/Button.module.scss
@@ -1,0 +1,10 @@
+.button {
+  margin: 3px;
+  font-weight: 400;
+  font-family: var(--theme-text-display-font-family);
+
+  .icon {
+    width: 20px;
+    margin-right: 3px;
+  }
+}

--- a/web/components/atomic/atoms/Button/Button.stories.tsx
+++ b/web/components/atomic/atoms/Button/Button.stories.tsx
@@ -1,27 +1,28 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { disableControls } from '../../../../utils/storybook-utils';
 import { Button, ButtonProps } from './Button';
-import {action} from "@storybook/addon-actions";
-import {disableControls} from "../../../../utils/storybook-utils";
 
 export default {
   title: 'atoms/Button',
   component: Button,
-	argTypes: { ...disableControls('onClick') }
+  argTypes: { ...disableControls('onClick') },
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = args => <Button {...args} />;
 
-export const withIcon = Template.bind({});
-withIcon.args = {
-	iconSrc: 'https://owncast.online/images/logo.svg',
-	iconAltText: '',
-	onClick: action('button clicked'),
-	text: 'foo',
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  iconSrc: 'https://owncast.online/images/logo.svg',
+  iconAltText: '',
+  onClick: action('button clicked'),
+  text: 'foo',
 } as ButtonProps;
 
-export const withoutIcon = Template.bind({});
-withoutIcon.args = {
-	onClick: action('button clicked'),
-	text: 'foo',
+export const WithoutIcon = Template.bind({});
+WithoutIcon.args = {
+  onClick: action('button clicked'),
+  text: 'foo',
 } as ButtonProps;

--- a/web/components/atomic/atoms/Button/Button.stories.tsx
+++ b/web/components/atomic/atoms/Button/Button.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Button, ButtonProps } from './Button';
+import {action} from "@storybook/addon-actions";
+import {disableControls} from "../../../../utils/storybook-utils";
+
+export default {
+  title: 'atoms/Button',
+  component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component: `A styled button.`,
+      },
+    },
+  },
+	argTypes: { ...disableControls('onClick') }
+} as ComponentMeta<typeof Button>;
+
+const Template: ComponentStory<typeof Button> = args => <Button {...args} />;
+
+export const withIcon = Template.bind({});
+withIcon.args = {
+	iconSrc: 'https://owncast.online/images/logo.svg',
+	iconAltText: '',
+	onClick: action('button clicked'),
+	text: 'foo',
+} as ButtonProps;
+
+export const withoutIcon = Template.bind({});
+withoutIcon.args = {
+	onClick: action('button clicked'),
+	text: 'foo',
+} as ButtonProps;

--- a/web/components/atomic/atoms/Button/Button.stories.tsx
+++ b/web/components/atomic/atoms/Button/Button.stories.tsx
@@ -7,13 +7,6 @@ import {disableControls} from "../../../../utils/storybook-utils";
 export default {
   title: 'atoms/Button',
   component: Button,
-  parameters: {
-    docs: {
-      description: {
-        component: `A styled button.`,
-      },
-    },
-  },
 	argTypes: { ...disableControls('onClick') }
 } as ComponentMeta<typeof Button>;
 

--- a/web/components/atomic/atoms/Button/Button.tsx
+++ b/web/components/atomic/atoms/Button/Button.tsx
@@ -1,0 +1,28 @@
+import { Button as AntButton, ButtonProps as AntButtonProps } from 'antd';
+import { FC } from 'react';
+
+import styles from './Button.module.scss';
+
+export type ButtonProps = Omit<AntButtonProps, 'children' | 'icon' | 'title' | 'target'> & {
+	text: string;
+	iconSrc?: string;
+	iconAltText?: string;
+};
+
+/**
+ * A customised and styled Ant Design button.
+ *
+ * An icon can be set. Both `iconSrc` and `iconAltText` must be set for the icon to be shown.
+ */
+export const Button: FC<ButtonProps> = ({ text, iconSrc, iconAltText, type = "primary", ...props }) => (
+	<AntButton
+		type={type}
+		className={styles.button}
+		{...props}
+	>
+		{iconSrc && iconAltText !== undefined && (
+			<img src={iconSrc} className={`${styles.icon}`} alt={iconAltText}/>
+		)}
+		{text}
+	</AntButton>
+);

--- a/web/components/atomic/atoms/Button/Button.tsx
+++ b/web/components/atomic/atoms/Button/Button.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 
 import styles from './Button.module.scss';
 
-export type ButtonProps = Omit<AntButtonProps, 'children' | 'icon' | 'title' | 'target'> & {
+export type ButtonProps = Omit<AntButtonProps, 'children' | 'icon' | 'title'> & {
 	text: string;
 	iconSrc?: string;
 	iconAltText?: string;

--- a/web/components/atomic/atoms/Button/Button.tsx
+++ b/web/components/atomic/atoms/Button/Button.tsx
@@ -4,9 +4,9 @@ import { FC } from 'react';
 import styles from './Button.module.scss';
 
 export type ButtonProps = Omit<AntButtonProps, 'children' | 'icon' | 'title'> & {
-	text: string;
-	iconSrc?: string;
-	iconAltText?: string;
+  text: string;
+  iconSrc?: string;
+  iconAltText?: string;
 };
 
 /**
@@ -14,15 +14,17 @@ export type ButtonProps = Omit<AntButtonProps, 'children' | 'icon' | 'title'> & 
  *
  * An icon can be set. Both `iconSrc` and `iconAltText` must be set for the icon to be shown.
  */
-export const Button: FC<ButtonProps> = ({ text, iconSrc, iconAltText, type = "primary", ...props }) => (
-	<AntButton
-		type={type}
-		className={styles.button}
-		{...props}
-	>
-		{iconSrc && iconAltText !== undefined && (
-			<img src={iconSrc} className={`${styles.icon}`} alt={iconAltText}/>
-		)}
-		{text}
-	</AntButton>
+export const Button: FC<ButtonProps> = ({
+  text,
+  iconSrc,
+  iconAltText,
+  type = 'primary',
+  ...props
+}) => (
+  <AntButton type={type} className={styles.button} {...props}>
+    {iconSrc && iconAltText !== undefined && (
+      <img src={iconSrc} className={`${styles.icon}`} alt={iconAltText} />
+    )}
+    {text}
+  </AntButton>
 );

--- a/web/components/atomic/atoms/ButtonRow/ButtonRow.module.scss
+++ b/web/components/atomic/atoms/ButtonRow/ButtonRow.module.scss
@@ -1,0 +1,11 @@
+.row {
+  padding: .3rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+
+  button {
+    margin-left: .3rem;
+    margin-right: .3rem;
+  }
+}

--- a/web/components/atomic/atoms/ButtonRow/ButtonRow.stories.tsx
+++ b/web/components/atomic/atoms/ButtonRow/ButtonRow.stories.tsx
@@ -9,16 +9,9 @@ import {disableControls} from "../../../../utils/storybook-utils";
 export default {
   title: 'atoms/ButtonRow',
   component: ButtonRow,
-  parameters: {
-    docs: {
-      description: {
-        component: 'A horizontal row of buttons',
-      },
-    },
+  argTypes: {
+    ...disableControls('children'),
   },
-	argTypes: {
-		...disableControls('children'),
-	},
 } as ComponentMeta<typeof ButtonRow>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/web/components/atomic/atoms/ButtonRow/ButtonRow.stories.tsx
+++ b/web/components/atomic/atoms/ButtonRow/ButtonRow.stories.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
+import { disableControls } from '../../../../utils/storybook-utils';
 import { Button } from '../Button/Button';
-import { ButtonRow, ButtonRowProps } from './ButtonRow';
-import {action} from "@storybook/addon-actions";
-import {disableControls} from "../../../../utils/storybook-utils";
+import { ButtonRow as ButtonRowComponent, ButtonRowProps } from './ButtonRow';
 
 export default {
   title: 'atoms/ButtonRow',
-  component: ButtonRow,
+  component: ButtonRowComponent,
   argTypes: {
     ...disableControls('children'),
   },
-} as ComponentMeta<typeof ButtonRow>;
+} as ComponentMeta<typeof ButtonRowComponent>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const Template: ComponentStory<typeof ButtonRow> = ({ children }) => (<ButtonRow>{children}</ButtonRow>);
+const Template: ComponentStory<typeof ButtonRowComponent> = ({ children }) => (
+  <ButtonRowComponent>{children}</ButtonRowComponent>
+);
 
-export const buttonRow = Template.bind({});
-buttonRow.args = {
+export const ButtonRow = Template.bind({});
+ButtonRow.args = {
   children: [
-		<Button text="foo" onClick={action('foo clicked')} />,
-		<Button text="bar" onClick={action('bar clicked')} />,
-		<Button text="tin" onClick={action('tin clicked')} />,
-	],
+    <Button text="foo" onClick={action('foo clicked')} />,
+    <Button text="bar" onClick={action('bar clicked')} />,
+    <Button text="tin" onClick={action('tin clicked')} />,
+  ],
 } as ButtonRowProps;

--- a/web/components/atomic/atoms/ButtonRow/ButtonRow.stories.tsx
+++ b/web/components/atomic/atoms/ButtonRow/ButtonRow.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Button } from '../Button/Button';
+import { ButtonRow, ButtonRowProps } from './ButtonRow';
+import {action} from "@storybook/addon-actions";
+import {disableControls} from "../../../../utils/storybook-utils";
+
+export default {
+  title: 'atoms/ButtonRow',
+  component: ButtonRow,
+  parameters: {
+    docs: {
+      description: {
+        component: 'A horizontal row of buttons',
+      },
+    },
+  },
+	argTypes: {
+		...disableControls('children'),
+	},
+} as ComponentMeta<typeof ButtonRow>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const Template: ComponentStory<typeof ButtonRow> = ({ children }) => (<ButtonRow>{children}</ButtonRow>);
+
+export const buttonRow = Template.bind({});
+buttonRow.args = {
+  children: [
+		<Button text="foo" onClick={action('foo clicked')} />,
+		<Button text="bar" onClick={action('bar clicked')} />,
+		<Button text="tin" onClick={action('tin clicked')} />,
+	],
+} as ButtonRowProps;

--- a/web/components/atomic/atoms/ButtonRow/ButtonRow.tsx
+++ b/web/components/atomic/atoms/ButtonRow/ButtonRow.tsx
@@ -5,6 +5,9 @@ export type ButtonRowProps = {
   children: ReactNode;
 };
 
+/**
+ * A horizontal row to wrap multiple {@link ../Button}.
+ */
 export const ButtonRow: FC<ButtonRowProps> = ({ children }) => (
   <div className={styles.row}>{children}</div>
 );

--- a/web/components/atomic/atoms/ButtonRow/ButtonRow.tsx
+++ b/web/components/atomic/atoms/ButtonRow/ButtonRow.tsx
@@ -1,0 +1,10 @@
+import { FC, ReactNode } from 'react';
+import styles from './ButtonRow.module.scss';
+
+export type ButtonRowProps = {
+  children: ReactNode;
+};
+
+export const ButtonRow: FC<ButtonRowProps> = ({ children }) => (
+  <div className={styles.row}>{children}</div>
+);

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -24,8 +24,8 @@ import styles from './Content.module.scss';
 import { Sidebar } from '../Sidebar/Sidebar';
 import { Footer } from '../Footer/Footer';
 
+import { Button } from "../../atomic/atoms/Button/Button";
 import { ActionButtonRow } from '../../action-buttons/ActionButtonRow/ActionButtonRow';
-import { ActionButton } from '../../action-buttons/ActionButton/ActionButton';
 import { NotifyReminderPopup } from '../NotifyReminderPopup/NotifyReminderPopup';
 import { OfflineBanner } from '../OfflineBanner/OfflineBanner';
 import { AppStateOptions } from '../../stores/application-state';
@@ -38,6 +38,7 @@ import { ServerStatus } from '../../../interfaces/server-status.model';
 import { Statusbar } from '../Statusbar/Statusbar';
 import { ChatContainer } from '../../chat/ChatContainer/ChatContainer';
 import { ChatMessage } from '../../../interfaces/chat-message.model';
+import { ExternalAction } from "../../../interfaces/external-action";
 
 const { TabPane } = Tabs;
 const { Content: AntContent } = Layout;
@@ -138,8 +139,16 @@ export const Content: FC = () => {
   const [showNotifyReminder, setShowNotifyReminder] = useState(false);
   const [showNotifyPopup, setShowNotifyPopup] = useState(false);
 
-  const externalActionButtons = externalActions.map(action => (
-    <ActionButton key={action.url} action={action} />
+  const externalActionButtons = (externalActions as ExternalAction[]).map(action => (
+    <Button
+			key={action.url}
+			text={action.title}
+			href={action.url}
+			iconSrc={action.icon}
+			iconAltText=""
+			color={action.color}
+			target={action.openExternally ? '_blank' : '_self'}
+		/>
   ));
 
   const incrementVisitCounter = () => {

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -24,7 +24,7 @@ import styles from './Content.module.scss';
 import { Sidebar } from '../Sidebar/Sidebar';
 import { Footer } from '../Footer/Footer';
 
-import { Button } from "../../atomic/atoms/Button/Button";
+import { Button } from '../../atomic/atoms/Button/Button';
 import { ActionButtonRow } from '../../action-buttons/ActionButtonRow/ActionButtonRow';
 import { NotifyReminderPopup } from '../NotifyReminderPopup/NotifyReminderPopup';
 import { OfflineBanner } from '../OfflineBanner/OfflineBanner';
@@ -38,7 +38,7 @@ import { ServerStatus } from '../../../interfaces/server-status.model';
 import { Statusbar } from '../Statusbar/Statusbar';
 import { ChatContainer } from '../../chat/ChatContainer/ChatContainer';
 import { ChatMessage } from '../../../interfaces/chat-message.model';
-import { ExternalAction } from "../../../interfaces/external-action";
+import { ExternalAction } from '../../../interfaces/external-action';
 
 const { TabPane } = Tabs;
 const { Content: AntContent } = Layout;
@@ -141,14 +141,14 @@ export const Content: FC = () => {
 
   const externalActionButtons = (externalActions as ExternalAction[]).map(action => (
     <Button
-			key={action.url}
-			text={action.title}
-			href={action.url}
-			iconSrc={action.icon}
-			iconAltText=""
-			color={action.color}
-			target={action.openExternally ? '_blank' : '_self'}
-		/>
+      key={action.url}
+      text={action.title}
+      href={action.url}
+      iconSrc={action.icon}
+      iconAltText=""
+      color={action.color}
+      target={action.openExternally ? '_blank' : '_self'}
+    />
   ));
 
   const incrementVisitCounter = () => {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -81,7 +81,7 @@
 				"babel-loader": "8.2.5",
 				"chromatic": "6.9.0",
 				"css-loader": "6.7.1",
-				"eslint": "8.23.1",
+				"eslint": "8.22",
 				"eslint-config-airbnb": "19.0.4",
 				"eslint-config-next": "12.3.0",
 				"eslint-config-prettier": "8.5.0",
@@ -2247,19 +2247,6 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
 			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
 			"devOptional": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@humanwhocodes/module-importer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-			"devOptional": true,
-			"engines": {
-				"node": ">=12.22"
-			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
@@ -14672,15 +14659,14 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.23.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+			"integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
 			"devOptional": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.2",
+				"@eslint/eslintrc": "^1.3.0",
 				"@humanwhocodes/config-array": "^0.10.4",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -14690,12 +14676,13 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
+				"espree": "^9.3.3",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
+				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
 				"globby": "^11.1.0",
@@ -14704,7 +14691,6 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -14715,7 +14701,8 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0"
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -16569,7 +16556,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/functions-have-names": {
 			"version": "1.2.3",
@@ -18640,12 +18627,6 @@
 			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
 			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
 			"dev": true
-		},
-		"node_modules/js-sdsl": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-			"integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
-			"devOptional": true
 		},
 		"node_modules/js-string-escape": {
 			"version": "1.0.1",
@@ -27886,6 +27867,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/v8-compile-cache": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+			"devOptional": true
+		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -30239,12 +30226,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
 			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-			"devOptional": true
-		},
-		"@humanwhocodes/module-importer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"devOptional": true
 		},
 		"@humanwhocodes/object-schema": {
@@ -39614,15 +39595,14 @@
 			}
 		},
 		"eslint": {
-			"version": "8.23.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-			"integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+			"integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
 			"devOptional": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.2",
+				"@eslint/eslintrc": "^1.3.0",
 				"@humanwhocodes/config-array": "^0.10.4",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
-				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -39632,12 +39612,13 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
+				"espree": "^9.3.3",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
+				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
 				"globby": "^11.1.0",
@@ -39646,7 +39627,6 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -39657,7 +39637,8 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0"
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -41085,7 +41066,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
+			"devOptional": true
 		},
 		"functions-have-names": {
 			"version": "1.2.3",
@@ -42572,12 +42553,6 @@
 			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
 			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
 			"dev": true
-		},
-		"js-sdsl": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-			"integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
-			"devOptional": true
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -49462,6 +49437,12 @@
 					"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
 				}
 			}
+		},
+		"v8-compile-cache": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+			"devOptional": true
 		},
 		"v8-to-istanbul": {
 			"version": "9.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -85,7 +85,7 @@
 		"babel-loader": "8.2.5",
 		"chromatic": "6.9.0",
 		"css-loader": "6.7.1",
-		"eslint": "8.23.1",
+		"eslint": "8.22",
 		"eslint-config-airbnb": "19.0.4",
 		"eslint-config-next": "12.3.0",
 		"eslint-config-prettier": "8.5.0",

--- a/web/utils/storybook-utils.ts
+++ b/web/utils/storybook-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns an object that can be used to disable a value in a Storybook story's "Controls" panel.
+ * To use: spread the returned object into the 'argTypes' property of story's ComponentMeta.
+ *
+ * @param controls to be hidden. Can be a single control, or many.
+ * @returns an object that should be spread into argTypes.
+ *
+ * @example `{ argTypes: { ...disableControls('foo', 'bar') } }`
+ */
+export const disableControls = (...controls: string[]) =>
+	controls
+		.map((control) => ({
+			[control]: {
+				control: false,
+			},
+		}))
+		.reduce((prev, current) => ({ ...prev, ...current }), {});


### PR DESCRIPTION
# Description

Refactor the `ActionButton` and `ActionButtonRow` components to be atomic, replacing them with cleaner `Button` and `ButtonRow` components.

NOTE: WIP; This PR does not yet handle the integration of these components.

Fixes # (issue)
Part of the ongoing work towards #2119 

---

Some things you might want to mention:

1. Why are you making the change?

The `Button` component no-longer includes a modal. Instead, the modal and button are seperate components. This preserves the actual DOM structure in the components; the modal isn't _inside_ the button in the DOM, so its not in the components.

Also, the button's props have been updated to expose _most_ of the underlying Ant Design button's props. This may not be desired in most components but I though it may be useful for these very low-level "Ant Design wrapper" components. This behaviour can be updated as we continue the Atomic Design updates.
