### PR TITLE
Sanitize user submitted values before logging

### DIFF
--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -140,7 +140,7 @@ func (s *Server) userMessageSent(eventData chatClientEvent) {
 }
 
 func logSanitize(userValue string) string {
-	// strip carriage return and newline to prevent
+	// strip carriage return and newline from user-submitted values to prevent log injection
 	sanitizedValue := strings.Replace(userValue, "\n", "", -1)
 	sanitizedValue = strings.Replace(sanitizedValue, "\r", "", -1)
 

--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -36,7 +36,7 @@ func (s *Server) userNameChanged(eventData chatClientEvent) {
 		normalizedName = strings.ToLower(normalizedName)
 		if strings.Contains(normalizedName, proposedUsername) {
 			// Denied.
-			log.Debugln(eventData.client.User.DisplayName, "blocked from changing name to", proposedUsername, "due to blocked name", normalizedName)
+			log.Debugln(logSanitize(eventData.client.User.DisplayName), "blocked from changing name to", logSanitize(proposedUsername), "due to blocked name", normalizedName)
 			message := fmt.Sprintf("You cannot change your name to **%s**.", proposedUsername)
 			s.sendActionToClient(eventData.client, message)
 
@@ -137,4 +137,12 @@ func (s *Server) userMessageSent(eventData chatClientEvent) {
 	SaveUserMessage(event)
 	eventData.client.MessageCount++
 	_lastSeenCache[event.User.ID] = time.Now()
+}
+
+func logSanitize(userValue string) string {
+	// strip carriage return and newline to prevent
+	sanitizedValue := strings.Replace(userValue, "\n", "", -1)
+	sanitizedValue = strings.Replace(sanitizedValue, "\r", "", -1)
+
+	return fmt.Sprintf("userSuppliedValue(%s)", sanitizedValue)
 }

--- a/core/chat/server.go
+++ b/core/chat/server.go
@@ -355,7 +355,7 @@ func (s *Server) eventReceived(event chatClientEvent) {
 		s.userNameChanged(event)
 
 	default:
-		log.Debugln(eventType, "event not found:", typecheck)
+		log.Debugln(logSanitize(fmt.Sprint(eventType)), "event not found:", logSanitize(fmt.Sprint(typecheck)))
 	}
 }
 


### PR DESCRIPTION
Please include a summary of the change and which issue number is fixed, including relevant motivation and context. Feel free to mark this as a Draft or WIP and write up some details later.

# Description
I think this should fix the issue - I added a function to strip out newline and carriage returns and used that in the 4 spots codeql flagged.

Fixes #2117



---

Some things you might want to mention:

1. Why are you making the change?
2. Explain how it works and decisions you made.
3. If you're fixing something, what was wrong? How should we stop from having this issue happen again?
4. If this is a new feature or addition to functionality, why should it be added? What are the use cases? Who was asking for this functionality?

If this is an unsolicited change or have no issue associated please do your best to detail the motivations behind this PR.
