### PR TITLE
Treat fediverse usernames as case-insensitive

### DIFF
--- a/auth/fediverse/fediverse.go
+++ b/auth/fediverse/fediverse.go
@@ -3,6 +3,7 @@ package fediverse
 import (
 	"crypto/rand"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -37,7 +38,7 @@ func RegisterFediverseOTP(accessToken, userID, userDisplayName, account string) 
 		Code:            code,
 		UserID:          userID,
 		UserDisplayName: userDisplayName,
-		Account:         account,
+		Account:         strings.ToLower(account),
 		Timestamp:       time.Now(),
 	}
 	pendingAuthRequests[accessToken] = r

--- a/auth/fediverse/fediverse_test.go
+++ b/auth/fediverse/fediverse_test.go
@@ -1,6 +1,9 @@
 package fediverse
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const (
 	accessToken     = "fake-access-token"
@@ -56,5 +59,19 @@ func TestSingleOTPFlowRequest(t *testing.T) {
 
 	if s2 {
 		t.Error("Second registration should not be permitted.")
+	}
+}
+
+func TestAccountCaseInsensitive(t *testing.T) {
+	account1 := "Account"
+	r1, _ := RegisterFediverseOTP(accessToken, userID, userDisplayName, account1)
+	_, reg1 := ValidateFediverseOTP(accessToken, r1.Code)
+
+	// Simulate second auth with account in different case
+	r2, _ := RegisterFediverseOTP(accessToken, userID, r1.UserDisplayName, strings.ToUpper(account1))
+	_, reg2 := ValidateFediverseOTP(accessToken, r2.Code)
+
+	if reg1.Account != reg2.Account {
+		t.Error("Account names should be case-insensitive")
 	}
 }

--- a/auth/fediverse/fediverse_test.go
+++ b/auth/fediverse/fediverse_test.go
@@ -63,15 +63,16 @@ func TestSingleOTPFlowRequest(t *testing.T) {
 }
 
 func TestAccountCaseInsensitive(t *testing.T) {
-	account1 := "Account"
-	r1, _ := RegisterFediverseOTP(accessToken, userID, userDisplayName, account1)
+	account := "Account"
+	accessToken := "another-fake-access-token"
+	r1, _ := RegisterFediverseOTP(accessToken, userID, userDisplayName, account)
 	_, reg1 := ValidateFediverseOTP(accessToken, r1.Code)
 
 	// Simulate second auth with account in different case
-	r2, _ := RegisterFediverseOTP(accessToken, userID, r1.UserDisplayName, strings.ToUpper(account1))
+	r2, _ := RegisterFediverseOTP(accessToken, userID, userDisplayName, strings.ToUpper(account))
 	_, reg2 := ValidateFediverseOTP(accessToken, r2.Code)
 
 	if reg1.Account != reg2.Account {
-		t.Error("Account names should be case-insensitive")
+		t.Errorf("Account names should be case-insensitive: %s %s", reg1.Account, reg2.Account)
 	}
 }

--- a/controllers/auth/fediverse/fediverse.go
+++ b/controllers/auth/fediverse/fediverse.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/owncast/owncast/activitypub"
 	"github.com/owncast/owncast/auth"
-	"github.com/owncast/owncast/auth/fediverse"
 	fediverseauth "github.com/owncast/owncast/auth/fediverse"
 	"github.com/owncast/owncast/controllers"
 	"github.com/owncast/owncast/core/chat"
@@ -57,7 +56,7 @@ func VerifyFediverseOTPRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	accessToken := r.URL.Query().Get("accessToken")
-	valid, authRegistration := fediverse.ValidateFediverseOTP(accessToken, req.Code)
+	valid, authRegistration := fediverseauth.ValidateFediverseOTP(accessToken, req.Code)
 	if !valid {
 		w.WriteHeader(http.StatusForbidden)
 		return


### PR DESCRIPTION
Fixes https://github.com/owncast/owncast/issues/2048

I believe this should fix the issue, since it's the account from `OTPRegistration` that gets stored. I didn't attempt to handle usernames that were already stored with capital letters, so those users would restore a new user when authenticating. I can take a look at trying to handle existing users if you think that's necessary.