### PR TITLE
remove extra w.WriteHeader call in fediverse auth

### DIFF
--- a/controllers/auth/fediverse/fediverse.go
+++ b/controllers/auth/fediverse/fediverse.go
@@ -98,5 +98,4 @@ func VerifyFediverseOTPRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	controllers.WriteSimpleResponse(w, true, "")
-	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Fixes https://github.com/owncast/owncast/issues/2157

I saw this issue and looked at it since I was just looking at these files yesterday. The duplicate call is because `WriteHeader` is already called in `WriteSimpleResponse`. It ignores the second call, so it doesn't look like it's sending anything odd back to the browser, just logging the warning.