### PR TITLE
Add ffmpeg as required pre-requisite to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ OBS, Streamlabs, Restream and many others have been used with Owncast. [Read mor
 
 ## Building from Source
 
-1. Ensure you have the gcc compiler installed.
+1. Ensure you have pre-requisites installed.
+    - [gcc compiler](https://gcc.gnu.org/install/download.html)
+    - [ffmpeg](https://ffmpeg.org/download.html)
 1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above).
 1. Clone the repo. `git clone https://github.com/owncast/owncast`
 1. `go run main.go` will run from source.


### PR DESCRIPTION
Trying to get `owncast` up & running I discovered that `ffmpeg` is a required pre-requisite for `owncast` to run, even though that's not mentioned in the `README.md`.

```
$ go run main.go
INFO[2022-10-03T22:25:25+02:00] Owncast v0.0.12-dev (20221003)
FATA[2022-10-03T22:25:25+02:00] Unable to determine path to ffmpeg. Please specify it in the admin or place a copy in the Owncast directory.
exit status 1
```

This PR adds information about `ffmpeg` being required to run to the README.