### PR TITLE
Fix slider marks by changing the corresponding labels to non-empty string

### DIFF
--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -370,11 +370,11 @@ export const FRAMERATE_DEFAULTS = {
 };
 export const FRAMERATE_SLIDER_MARKS = {
   [FRAMERATE_DEFAULTS.min]: `${FRAMERATE_DEFAULTS.min} ${FRAMERATE_DEFAULTS.unit}`,
-  25: '',
-  30: '',
-  50: '',
-  60: '',
-  90: '',
+  25: ' ',
+  30: ' ',
+  50: ' ',
+  60: ' ',
+  90: ' ',
   [FRAMERATE_DEFAULTS.max]: `${FRAMERATE_DEFAULTS.max} ${FRAMERATE_DEFAULTS.unit}`,
 };
 export const FRAMERATE_TOOLTIPS = {


### PR DESCRIPTION
Slider marks seem to be ignored when the corresponding label is an empty string. The workaround of changing it to a single space seems to be doing the trick, while not introducing any visual changes.

Fixes https://github.com/owncast/owncast/issues/2159