### PR TITLE
clarified in README.md about musl compatible compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ OBS, Streamlabs, Restream and many others have been used with Owncast. [Read mor
 ## Building from Source
 
 1. Ensure you have pre-requisites installed.
-    - [gcc compiler](https://gcc.gnu.org/install/download.html)
+    - C compiler, such as [GCC compiler](https://gcc.gnu.org/install/download.html) or a [Musl-compatible compiler](https://musl.libc.org/)
     - [ffmpeg](https://ffmpeg.org/download.html)
-1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above).
+1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above). If your package manager has an older version of go, then you can install and use a newer version with the [Go Version Manager](https://github.com/moovweb/gvm).
 1. Clone the repo. `git clone https://github.com/owncast/owncast`
-1. `go run main.go` will run from source.
+1. `go run main.go` will run from source (or alternatively run `go build main.go` to build a binary from source and then run it)
 1. Visit `http://yourserver:8080` to access the web interface or `http://yourserver:8080/admin` to access the admin.
 1. Point your [broadcasting software](https://owncast.online/docs/broadcasting/) at your new server and start streaming.
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ OBS, Streamlabs, Restream and many others have been used with Owncast. [Read mor
 1. Ensure you have pre-requisites installed.
     - C compiler, such as [GCC compiler](https://gcc.gnu.org/install/download.html) or a [Musl-compatible compiler](https://musl.libc.org/)
     - [ffmpeg](https://ffmpeg.org/download.html)
-1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above). If your package manager has an older version of go, then you can install and use a newer version with the [Go Version Manager](https://github.com/moovweb/gvm).
+1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above)
 1. Clone the repo. `git clone https://github.com/owncast/owncast`
-1. `go run main.go` will run from source (or alternatively run `go build main.go` to build a binary from source and then run it)
+1. `go run main.go` will run from source
 1. Visit `http://yourserver:8080` to access the web interface or `http://yourserver:8080/admin` to access the admin.
 1. Point your [broadcasting software](https://owncast.online/docs/broadcasting/) at your new server and start streaming.
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ OBS, Streamlabs, Restream and many others have been used with Owncast. [Read mor
 1. Ensure you have pre-requisites installed.
     - C compiler, such as [GCC compiler](https://gcc.gnu.org/install/download.html) or a [Musl-compatible compiler](https://musl.libc.org/)
     - [ffmpeg](https://ffmpeg.org/download.html)
-1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above)
+1. Install the [Go toolchain](https://golang.org/dl/) (1.16 or above).
 1. Clone the repo. `git clone https://github.com/owncast/owncast`
-1. `go run main.go` will run from source
+1. `go run main.go` will run from source.
 1. Visit `http://yourserver:8080` to access the web interface or `http://yourserver:8080/admin` to access the admin.
 1. Point your [broadcasting software](https://owncast.online/docs/broadcasting/) at your new server and start streaming.
 


### PR DESCRIPTION
README.md now includes that a musl compatible compiler can be used to build owncast. This is to resolve issue https://github.com/owncast/owncast/issues/2009

happy #hacktoberfest