### PR TITLE
preallocate memory

### DIFF
--- a/controllers/admin/viewers.go
+++ b/controllers/admin/viewers.go
@@ -37,7 +37,7 @@ func GetViewersOverTime(w http.ResponseWriter, r *http.Request) {
 // GetActiveViewers returns currently connected clients.
 func GetActiveViewers(w http.ResponseWriter, r *http.Request) {
 	c := core.GetActiveViewers()
-	viewers := []models.Viewer{}
+	viewers := make([]models.Viewer, 0, len(c))
 	for _, v := range c {
 		viewers = append(viewers, *v)
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

Preallocate memory instead of enforcing an incremental growth. This will result in less work for the garbage collector.