### PR TITLE
fix ui: make navbar cover whole width of page

### DIFF
--- a/web/styles/globals.scss
+++ b/web/styles/globals.scss
@@ -86,6 +86,7 @@ body {
 
   a {
     color: var(--theme-color-action);
+    word-break: break-word;
 
     &:hover {
       color: var(--theme-color-palette-12);


### PR DESCRIPTION
Previously, there was a large url on the page, and the a tag did not have word break property set - which resulted in the browser trying to display the whole page with increased width. Allowing the a tag to have a word break fixes this issue.

Screenshots:
Before:
![image](https://user-images.githubusercontent.com/20909078/196004204-5f5d9179-bdfb-4a40-a70f-4d631aaf3b0f.png)


After:
![image](https://user-images.githubusercontent.com/20909078/196004190-fbef4961-5d08-4957-963f-3bef2623a291.png)
