### PR TITLE
Fix height of Modal content.

### DIFF
--- a/web/components/ui/Modal/Modal.tsx
+++ b/web/components/ui/Modal/Modal.tsx
@@ -30,6 +30,7 @@ export const Modal: FC<ModalProps> = ({
   const modalStyle = {
     padding: '0px',
     minHeight: height,
+    height: height ?? '100%',
   };
 
   const iframe = url && (


### PR DESCRIPTION
This seems to make the Storybook preview of a "Modal -> Container -> Url Example" look more like I expect. The bottom corners aren't rounded, but they aren't in the other kind of Modal example, either. There's a thin border on the bottom and right edges, but I think that's the Owncast site's CSS.

I'm not sure how to test how this looks in the actual application, but figured I'd get it submitted for further discussion.

Re #2070.