### PR TITLE
On narrow screens, bump the footer links to a second row. Re #2260.

### DIFF
--- a/web/components/ui/Footer/Footer.module.scss
+++ b/web/components/ui/Footer/Footer.module.scss
@@ -1,6 +1,7 @@
 .footer {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   height: var(--footer-height);
   justify-content: space-between;
   flex-direction: row;
@@ -19,11 +20,10 @@
   }
 
   .links {
+    column-gap: 2rem;
+    width: auto;
     display: flex;
     justify-content: space-between;
     flex-direction: row;
-    .item {
-      margin-left: 1.2em;
-    }
   }
 }

--- a/web/components/ui/Footer/Footer.tsx
+++ b/web/components/ui/Footer/Footer.tsx
@@ -7,26 +7,20 @@ export type FooterProps = {
 
 export const Footer: FC<FooterProps> = ({ version }) => (
   <div className={styles.footer}>
-    <div className={styles.text}>
+    <span>
       Powered by <a href="https://owncast.online">{version}</a>
-    </div>
-    <div className={styles.links}>
-      <div className={styles.item}>
+    </span>
+    <span className={styles.links}>
         <a href="https://owncast.online/docs" target="_blank" rel="noreferrer">
           Documentation
         </a>
-      </div>
-      <div className={styles.item}>
         <a href="https://owncast.online/help" target="_blank" rel="noreferrer">
           Contribute
         </a>
-      </div>
-      <div className={styles.item}>
         <a href="https://github.com/owncast/owncast" target="_blank" rel="noreferrer">
           Source
         </a>
-      </div>
-    </div>
+    </span>
   </div>
 );
 export default Footer;

--- a/web/components/ui/Footer/Footer.tsx
+++ b/web/components/ui/Footer/Footer.tsx
@@ -11,15 +11,15 @@ export const Footer: FC<FooterProps> = ({ version }) => (
       Powered by <a href="https://owncast.online">{version}</a>
     </span>
     <span className={styles.links}>
-        <a href="https://owncast.online/docs" target="_blank" rel="noreferrer">
-          Documentation
-        </a>
-        <a href="https://owncast.online/help" target="_blank" rel="noreferrer">
-          Contribute
-        </a>
-        <a href="https://github.com/owncast/owncast" target="_blank" rel="noreferrer">
-          Source
-        </a>
+      <a href="https://owncast.online/docs" target="_blank" rel="noreferrer">
+        Documentation
+      </a>
+      <a href="https://owncast.online/help" target="_blank" rel="noreferrer">
+        Contribute
+      </a>
+      <a href="https://github.com/owncast/owncast" target="_blank" rel="noreferrer">
+        Source
+      </a>
     </span>
   </div>
 );


### PR DESCRIPTION
There's a little bit of empty space on the right but it's not too bad.

<img width="462" alt="image" src="https://user-images.githubusercontent.com/32307/198143447-43c81b26-d65f-4b1e-b051-a7fc7ddd114e.png">

<img width="614" alt="image" src="https://user-images.githubusercontent.com/32307/198143490-609c52e3-f46f-4c4a-9f26-f20582829a70.png">
