### PR TITLE
Sync between clients

### DIFF
--- a/controllers/playbackMetrics.go
+++ b/controllers/playbackMetrics.go
@@ -20,6 +20,7 @@ func ReportPlaybackMetrics(w http.ResponseWriter, r *http.Request) {
 	type reportPlaybackMetricsRequest struct {
 		Bandwidth             float64 `json:"bandwidth"`
 		Latency               float64 `json:"latency"`
+		MaxLatency            float64 `json:"maxLatency"`
 		Errors                float64 `json:"errors"`
 		DownloadDuration      float64 `json:"downloadDuration"`
 		QualityVariantChanges float64 `json:"qualityVariantChanges"`
@@ -42,6 +43,10 @@ func ReportPlaybackMetrics(w http.ResponseWriter, r *http.Request) {
 
 	if request.Latency != 0.0 {
 		metrics.RegisterPlayerLatency(clientID, request.Latency)
+	}
+
+	if request.MaxLatency != 0.0 {
+		metrics.RegisterPlayerMaxLatency(clientID, request.MaxLatency)
 	}
 
 	if request.DownloadDuration != 0.0 {

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -1,0 +1,13 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/owncast/owncast/metrics"
+)
+
+func GetPlayInstructions(w http.ResponseWriter, r *http.Request) {
+	instructions := metrics.GetPlayInstructions()
+
+	WriteResponse(w, instructions)
+}

--- a/router/router.go
+++ b/router/router.go
@@ -88,6 +88,11 @@ func Start() error {
 	// save client video playback metrics
 	http.HandleFunc("/api/metrics/playback", controllers.ReportPlaybackMetrics)
 
+	// return play instructions, including
+	// what latency the client should be at, so that
+	// clients play at the same time
+	http.HandleFunc("/api/metrics/playinstructions", controllers.GetPlayInstructions)
+
 	// Register for notifications
 	http.HandleFunc("/api/notifications/register", middleware.RequireUserAccessToken(controllers.RegisterForLiveNotifications))
 

--- a/webroot/js/components/latencyCompensator.js
+++ b/webroot/js/components/latencyCompensator.js
@@ -27,6 +27,8 @@ How to help with this? The Owncast Latency Compensator will:
   - Completely give up on all compensation if too many buffering events occur.
 */
 
+import { getCurrentlyPlayingSegment } from "../utils/helpers.js";
+
 const REBUFFER_EVENT_LIMIT = 4; // Max number of buffering events before we stop compensating for latency.
 const MIN_BUFFER_DURATION = 200; // Min duration a buffer event must last to be counted.
 const MAX_SPEEDUP_RATE = 1.08; // The playback rate when compensating for latency.
@@ -485,28 +487,6 @@ class LatencyCompensator {
       this.countBufferingEvent();
     }, MIN_BUFFER_DURATION);
   }
-}
-
-function getCurrentlyPlayingSegment(tech) {
-  var target_media = tech.vhs.playlists.media();
-  var snapshot_time = tech.currentTime();
-
-  var segment;
-
-  // Iterate trough available segments and get first within which snapshot_time is
-  for (var i = 0, l = target_media.segments.length; i < l; i++) {
-    // Note: segment.end may be undefined or is not properly set
-    if (snapshot_time < target_media.segments[i].end) {
-      segment = target_media.segments[i];
-      break;
-    }
-  }
-
-  if (!segment) {
-    segment = target_media.segments[0];
-  }
-
-  return segment;
 }
 
 export default LatencyCompensator;

--- a/webroot/js/components/syncer.js
+++ b/webroot/js/components/syncer.js
@@ -1,0 +1,69 @@
+/*
+The Owncast Syncer.
+
+It will try to sync the play time between clients.
+
+Great for an LAN party.
+*/
+
+import { URL_PLAY_INSTRUCTIONS } from "../utils/constants.js";
+import { getCurrentlyPlayingSegment } from "../utils/helpers.js";
+
+export default class Syncer{
+    constructor(player){
+        this.player = player;
+        this.clockSkewMs = 0;
+        console.log("Syncer created")
+
+        setInterval(() => {
+            this.sync();
+        }, 2000);
+    }
+
+    setClockSkew(ms) {
+        this.clockSkewMs = ms;
+    }
+
+    async sync(){
+        const options={
+            method: 'GET'
+        };
+        const rawResponse = await fetch(URL_PLAY_INSTRUCTIONS,options);
+        const content = await rawResponse.json();
+        const expectedLatency = content.ExpectedLatency;
+
+        const tech = this.player.tech({ IWillNotUseThisInPlugins: true });
+        try {
+            const segment = getCurrentlyPlayingSegment(tech);
+            if (!segment || !segment.dateTimeObject) {
+              return;
+            }
+            const intoSegment = segment.duration - (segment.end - this.player.currentTime());
+            const segmentStartTime = segment.dateTimeObject.getTime();
+            const segmentTime = segmentStartTime + intoSegment * 1000;
+            const now = new Date().getTime() + this.clockSkewMs; //Server now
+            const latency = (now - segmentTime) / 1000;
+
+            // console.log("Current latency is",latency,", expected latency is",expectedLatency)
+
+            if (Math.abs(latency-expectedLatency)<0.1 || expectedLatency==0){
+                console.log("Current latency is",latency,", expected latency is",expectedLatency,", no need to sync")
+                return;
+            }else{
+                let targetPlayTime = this.player.currentTime() + (latency - expectedLatency)
+                if (targetPlayTime < 0) {
+                    targetPlayTime = 0;
+                }
+                // if (targetPlayTime > segment.end) {
+                //     targetPlayTime = segment.end;
+                // }
+
+                console.log("Current latency is",latency,", expected latency is",expectedLatency,", move ",targetPlayTime-this.player.currentTime(),"forward")
+                this.player.currentTime(targetPlayTime);
+            }
+          } catch (err) {
+            console.warn(err);
+          }
+
+    }
+}

--- a/webroot/js/components/syncer.js
+++ b/webroot/js/components/syncer.js
@@ -17,7 +17,7 @@ export default class Syncer{
 
         setInterval(() => {
             this.sync();
-        }, 2000);
+        }, 100);
     }
 
     setClockSkew(ms) {
@@ -44,19 +44,15 @@ export default class Syncer{
             const now = new Date().getTime() + this.clockSkewMs; //Server now
             const latency = (now - segmentTime) / 1000;
 
-            // console.log("Current latency is",latency,", expected latency is",expectedLatency)
-
             if (Math.abs(latency-expectedLatency)<0.1 || expectedLatency==0){
                 console.log("Current latency is",latency,", expected latency is",expectedLatency,", no need to sync")
                 return;
             }else{
-                let targetPlayTime = this.player.currentTime() + (latency - expectedLatency)
+                // + 0.1: It seems that the action of setting currentTime takes a little bit of time
+                let targetPlayTime = this.player.currentTime() + (latency - expectedLatency) + 0.1;
                 if (targetPlayTime < 0) {
                     targetPlayTime = 0;
                 }
-                // if (targetPlayTime > segment.end) {
-                //     targetPlayTime = segment.end;
-                // }
 
                 console.log("Current latency is",latency,", expected latency is",expectedLatency,", move ",targetPlayTime-this.player.currentTime(),"forward")
                 this.player.currentTime(targetPlayTime);

--- a/webroot/js/utils/constants.js
+++ b/webroot/js/utils/constants.js
@@ -18,6 +18,7 @@ export const URL_WEBSOCKET = `${
 export const URL_CHAT_REGISTRATION = `/api/chat/register`;
 export const URL_FOLLOWERS = `/api/followers`;
 export const URL_PLAYBACK_METRICS = `/api/metrics/playback`;
+export const URL_PLAY_INSTRUCTIONS = `/api/metrics/playinstructions`;
 
 export const URL_REGISTER_NOTIFICATION = `/api/notifications/register`;
 export const URL_REGISTER_EMAIL_NOTIFICATION = `/api/notifications/register/email`;

--- a/webroot/js/utils/helpers.js
+++ b/webroot/js/utils/helpers.js
@@ -212,3 +212,24 @@ export function paginateArray(items, page, perPage) {
     items: paginatedItems,
   };
 }
+
+export function getCurrentlyPlayingSegment(tech, old_segment = null) {
+  var target_media = tech.vhs.playlists.media();
+  var snapshot_time = tech.currentTime();
+  var segment;
+
+  // Iterate trough available segments and get first within which snapshot_time is
+  for (var i = 0, l = target_media.segments.length; i < l; i++) {
+    // Note: segment.end may be undefined or is not properly set
+    if (snapshot_time < target_media.segments[i].end) {
+      segment = target_media.segments[i];
+      break;
+    }
+  }
+
+  if (!segment) {
+    segment = target_media.segments[0];
+  }
+
+  return segment;
+}


### PR DESCRIPTION
- Clients now play at the same time, perfect for an LAN party. 
- Corrected latency measurement: considered how much the current segment has played, rather than using its start time. 
- Refactored code, putting all `getCurrentlyPlayingSegment(tech)` into `/js/utils/helper.js`