### PR TITLE
Larger text box font to prevent iOS Safari's auto zoom.

### DIFF
--- a/web/components/chat/ChatTextField/ChatTextField.module.scss
+++ b/web/components/chat/ChatTextField/ChatTextField.module.scss
@@ -33,7 +33,7 @@
   }
 
   div[role='textbox'] {
-    font-size: 0.9rem;
+    font-size: 16px;
     padding: 0.3rem;
     background-color: inherit;
     border-color: var(--theme-color-components-form-field-border);

--- a/web/components/chat/ChatTextField/ChatTextField.tsx
+++ b/web/components/chat/ChatTextField/ChatTextField.tsx
@@ -253,7 +253,7 @@ export const ChatTextField: FC<ChatTextFieldProps> = ({ defaultText }) => {
             onKeyDown={onKeyDown}
             onPaste={onPaste}
             renderElement={renderElement}
-            placeholder="Chat message goes here..."
+            placeholder="Send a message to chat"
             style={{ width: '100%' }}
             autoFocus
           />


### PR DESCRIPTION
Use 16px font size to prevent auto zoom on iOS Safari. Shorten the 'type here' message so it doesn't wrap to a second line when the chat pane becomes a column on the right side of larger screens. Re #2276.