### PR TITLE
activitypub: ensure Undo request has valid type

### DIFF
--- a/activitypub/inbox/undo.go
+++ b/activitypub/inbox/undo.go
@@ -18,7 +18,12 @@ func handleUndoInboxRequest(c context.Context, activity vocab.ActivityStreamsUnd
 				return err
 			}
 		} else {
-			log.Traceln("Undo", iter.GetType().GetTypeName(), "ignored")
+			t := iter.GetType()
+			if t != nil {
+				log.Traceln("Undo", t.GetTypeName(), "ignored")
+			} else {
+				log.Traceln("Undo (no type) ignored")
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
Hi there - I discovered this potential segfault.

I manually patched my local Pleroma instance to handle Owncast live notifications. In Pleroma, if I remove a Like (or other react) for a post, Owncast crashes with a segfault.

It appears the issue is - when logging the request, the call to `GetType` can return `nil`, causing the segfault when logging.

So, this patch just checks that `GetType` returns a non-nil value before logging. I'm unsure if Pleroma is in the wrong here or not (I haven't checked what the full, original JSON payload is, whether an upstream library is removing data, etc) - but this seems like a straightforward way to prevent a crash.