### PR TITLE
activitypub: ensure public messages are public

### DIFF
--- a/activitypub/outbox/outbox.go
+++ b/activitypub/outbox/outbox.go
@@ -173,6 +173,9 @@ func SendPublicMessage(textContent string) error {
 	activity, _, note, noteID := createBaseOutboundMessage(textContent)
 	note.SetActivityStreamsTag(tagProp)
 
+	note = apmodels.MakeNotePublic(note)
+	activity = apmodels.MakeActivityPublic(activity)
+
 	b, err := apmodels.Serialize(activity)
 	if err != nil {
 		log.Errorln("unable to serialize custom fediverse message activity", err)


### PR DESCRIPTION
Hi there! I noticed that the "compose a post to your followers" message wasn't working for users on my Pleroma instance. The note was being sent as a non-public announcement, which caused 2 issues:

1. Users can't re-toot/repeat/share etc.
2. Only one user on my instance would receive the update. On Pleroma, all the other posts to users inboxes would be discarded, since there was already an activity with the same ID value.

I'm unsure what the behavior was on Mastodon previously - but with this PR the public messages work as intended.