### PR TITLE
Chat name & color modal

### DIFF
--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -114,6 +114,10 @@ func (s *Server) userColorChanged(eventData chatClientEvent) {
 	if err := user.ChangeUserColor(eventData.client.User.ID, receivedEvent.NewColor); err != nil {
 		log.Errorln("error changing user display color", err)
 	}
+
+	// Resend client's user info with new color, otherwise the name change dialog would still show the old color
+	eventData.client.User.DisplayColor = receivedEvent.NewColor
+	eventData.client.sendConnectedClientInfo()
 }
 
 func (s *Server) userMessageSent(eventData chatClientEvent) {

--- a/web/components/modals/NameChangeModal/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.tsx
@@ -32,7 +32,8 @@ export const NameChangeModal: FC = () => {
 
   const { displayName, displayColor } = currentUser;
 
-  const saveEnabled = () => newName !== displayName && newName !== '' && websocketService?.isConnected();
+  const saveEnabled = () =>
+    newName !== displayName && newName !== '' && websocketService?.isConnected();
 
   const handleNameChange = () => {
     if (!saveEnabled()) return;
@@ -43,7 +44,6 @@ export const NameChangeModal: FC = () => {
     };
     websocketService.send(nameChange);
   };
-
 
   const handleColorChange = (color: string) => {
     const colorChange = {

--- a/web/components/modals/NameChangeModal/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.tsx
@@ -32,7 +32,11 @@ export const NameChangeModal: FC = () => {
 
   const { displayName, displayColor } = currentUser;
 
+  const saveEnabled = () => newName !== displayName && newName !== '' && websocketService?.isConnected();
+
   const handleNameChange = () => {
+    if (!saveEnabled()) return;
+
     const nameChange = {
       type: MessageType.NAME_CHANGE,
       newName,
@@ -40,7 +44,6 @@ export const NameChangeModal: FC = () => {
     websocketService.send(nameChange);
   };
 
-  const saveEnabled = newName !== displayName && newName !== '' && websocketService?.isConnected();
 
   const handleColorChange = (color: string) => {
     const colorChange = {
@@ -54,7 +57,7 @@ export const NameChangeModal: FC = () => {
   const colorOptions = [...Array(maxColor)].map((e, i) => i);
 
   const saveButton = (
-    <Button type="primary" onClick={handleNameChange} disabled={!saveEnabled}>
+    <Button type="primary" onClick={handleNameChange} disabled={!saveEnabled()}>
       Change name
     </Button>
   );

--- a/web/components/modals/NameChangeModal/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.tsx
@@ -74,12 +74,11 @@ export const NameChangeModal: FC = () => {
           defaultValue={displayName}
         />
       </Form>
-      <Form.Item label="Your Color" style={{ paddingTop: '8px' }}>
+      <Form.Item label="Your Color" style={{ paddingTop: '8px', zIndex: 1000, marginBottom: 0 }}>
         <Select
           style={{ width: 120 }}
           onChange={handleColorChange}
           defaultValue={displayColor.toString()}
-          getPopupContainer={triggerNode => triggerNode.parentElement}
         >
           {colorOptions.map(e => (
             <Option key={e.toString()} title={e}>

--- a/web/components/modals/NameChangeModal/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, FC, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { Input, Button, Select } from 'antd';
+import { Input, Button, Select, Form } from 'antd';
 import { MessageType } from '../../../interfaces/socket-events';
 import WebsocketService from '../../../services/websocket-service';
 import { websocketServiceAtom, currentUserAtom } from '../../stores/ClientConfigStore';
@@ -53,24 +53,28 @@ export const NameChangeModal: FC = () => {
   const maxColor = 8; // 0...n
   const colorOptions = [...Array(maxColor)].map((e, i) => i);
 
+  const saveButton = (
+    <Button type="primary" onClick={handleNameChange} disabled={!saveEnabled}>
+      Change name
+    </Button>
+  );
+
   return (
     <div>
-      Your chat display name is what people see when you send chat messages. Other information can
-      go here to mention auth, and stuff.
-      <Input
-        id="name-change-field"
-        value={newName}
-        onChange={e => setNewName(e.target.value)}
-        placeholder="Your chat display name"
-        maxLength={30}
-        showCount
-        defaultValue={displayName}
-      />
-      <Button id="name-change-submit" disabled={!saveEnabled} onClick={handleNameChange}>
-        Change name
-      </Button>
-      <div>
-        Your Color
+      Your chat display name is what people see when you send chat messages.
+      <Form onSubmitCapture={handleNameChange} style={{ paddingTop: '8px' }}>
+        <Input.Search
+          enterButton={saveButton}
+          id="name-change-field"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+          placeholder="Your chat display name"
+          maxLength={30}
+          showCount
+          defaultValue={displayName}
+        />
+      </Form>
+      <Form.Item label="Your Color" style={{ paddingTop: '8px' }}>
         <Select
           style={{ width: 120 }}
           onChange={handleColorChange}
@@ -83,7 +87,9 @@ export const NameChangeModal: FC = () => {
             </Option>
           ))}
         </Select>
-      </div>
+      </Form.Item>
+      You can also authenticate an IndieAuth or Fediverse account via the &quot;Authenticate&quot;
+      menu.
     </div>
   );
 };

--- a/web/components/ui/Modal/Modal.tsx
+++ b/web/components/ui/Modal/Modal.tsx
@@ -58,7 +58,7 @@ export const Modal: FC<ModalProps> = ({
       afterClose={afterClose}
       bodyStyle={modalStyle}
       width={width}
-      zIndex={9999}
+      zIndex={999}
       footer={null}
       centered
       destroyOnClose

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -130,7 +130,7 @@ DROPDOWN
 }
 
 .ant-input-affix-wrapper {
-  padding: 2px 5px;
+  padding: 4px 5px;
   background-color: var(--theme-color-components-form-field-background);
 }
 


### PR DESCRIPTION
Hi! This is a draft for the new chat name & color modal design discussed in #2205 

Current problems I'm still working on:
* The color selection menu overflows the modal and is hidden behind it, making it impossible to select some colors
* ~~The color is sent to the server, but reopening the modal still uses the initial color (a reload or rename after color changing solves this, as then user info is resent by the websocket). This is the same behavior as before, but I'd like to fix that :) Using useState with the `displayColor` similar to the displayName doesn't seem to persist the color either.~~  The backend now re-sends user info after a color change

I'm also not entirely sure how this dialog should look when logged in e.g. via FediAuth