### PR TITLE
Edit external actions

### DIFF
--- a/web/pages/admin/actions.tsx
+++ b/web/pages/admin/actions.tsx
@@ -34,12 +34,21 @@ interface Props {
 const ActionModal = (props: Props) => {
   const { onOk, onCancel, open, action } = props;
 
-  const [actionUrl, setActionUrl] = useState(action?.url || '');
-  const [actionTitle, setActionTitle] = useState(action?.title || '');
-  const [actionDescription, setActionDescription] = useState(action?.description || '');
-  const [actionIcon, setActionIcon] = useState(action?.icon || '');
-  const [actionColor, setActionColor] = useState(action?.color || '');
-  const [openExternally, setOpenExternally] = useState(action?.openExternally || false);
+  const [actionUrl, setActionUrl] = useState('');
+  const [actionTitle, setActionTitle] = useState('');
+  const [actionDescription, setActionDescription] = useState('');
+  const [actionIcon, setActionIcon] = useState('');
+  const [actionColor, setActionColor] = useState('');
+  const [openExternally, setOpenExternally] = useState(false);
+
+  useEffect(() => {
+    setActionUrl(action?.url || '');
+    setActionTitle(action?.title || '');
+    setActionDescription(action?.description || '');
+    setActionIcon(action?.icon || '');
+    setActionColor(action?.color || '');
+    setOpenExternally(action?.openExternally || false);
+  }, [action]);
 
   function save() {
     onOk(
@@ -82,6 +91,7 @@ const ActionModal = (props: Props) => {
 
   return (
     <Modal
+      destroyOnClose
       title={action == null ? 'Create New Action' : 'Edit Action'}
       open={open}
       onOk={save}
@@ -112,7 +122,6 @@ const ActionModal = (props: Props) => {
         <Form.Item name="title">
           <Input
             value={actionTitle}
-            defaultValue={actionTitle}
             required
             placeholder="Your action title (required)"
             onChange={input => setActionTitle(input.currentTarget.value)}
@@ -121,7 +130,6 @@ const ActionModal = (props: Props) => {
         <Form.Item name="description">
           <Input
             value={actionDescription}
-            defaultValue={actionDescription}
             placeholder="Optional description"
             onChange={input => setActionDescription(input.currentTarget.value)}
           />
@@ -129,20 +137,20 @@ const ActionModal = (props: Props) => {
         <Form.Item name="icon">
           <Input
             value={actionIcon}
-            defaultValue={actionIcon}
             placeholder="https://myserver.com/action/icon.png (optional)"
             onChange={input => setActionIcon(input.currentTarget.value)}
           />
         </Form.Item>
-        <Form.Item name="color">
-          <Input
-            type="color"
-            value={actionColor}
-            defaultValue={actionColor}
-            onChange={input => setActionColor(input.currentTarget.value)}
-          />
+        <div>
+          <Form.Item name="color" style={{ marginBottom: '0px' }}>
+            <Input
+              type="color"
+              value={actionColor}
+              onChange={input => setActionColor(input.currentTarget.value)}
+            />
+          </Form.Item>
           Optional background color of the action button.
-        </Form.Item>
+        </div>
         <Form.Item name="openExternally">
           <Checkbox
             checked={openExternally}
@@ -161,7 +169,7 @@ const Actions = () => {
   const serverStatusData = useContext(ServerStatusContext);
   const { serverConfig, setFieldInConfigState } = serverStatusData || {};
   const { externalActions } = serverConfig;
-  const [actions, setActions] = useState<ExternalAction[]>([]);
+  const [actions, setActions] = useState<ExternalAction[]>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [submitStatus, setSubmitStatus] = useState(null);
   const [editAction, setEditAction] = useState<ExternalAction>(null);

--- a/web/pages/admin/actions.tsx
+++ b/web/pages/admin/actions.tsx
@@ -235,7 +235,7 @@ const Actions = () => {
         openExternally,
       };
 
-      // Replace old action if edited or the new action
+      // Replace old action if edited or append the new action
       const index = oldAction ? actions.findIndex(item => _.isEqual(item, oldAction)) : -1;
       if (index >= 0) {
         actionsData[index] = newAction;

--- a/web/pages/admin/actions.tsx
+++ b/web/pages/admin/actions.tsx
@@ -1,5 +1,5 @@
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
-import { Button, Checkbox, Input, Modal, Space, Table, Typography } from 'antd';
+import { Button, Checkbox, Form, Input, Modal, Space, Table, Typography } from 'antd';
 import _ from 'lodash';
 import React, { useContext, useEffect, useState } from 'react';
 import { FormStatusIndicator } from '../../components/config/FormStatusIndicator';
@@ -32,15 +32,14 @@ interface Props {
 }
 
 const ActionModal = (props: Props) => {
-  console.log('ActionModal', props);
   const { onOk, onCancel, open, action } = props;
 
-  const [actionUrl, setActionUrl] = useState(action?.url ?? '');
-  const [actionTitle, setActionTitle] = useState(action?.title ?? '');
-  const [actionDescription, setActionDescription] = useState(action?.description ?? '');
-  const [actionIcon, setActionIcon] = useState(action?.icon ?? '');
-  const [actionColor, setActionColor] = useState(action?.color ?? '');
-  const [openExternally, setOpenExternally] = useState(action?.openExternally ?? false);
+  const [actionUrl, setActionUrl] = useState(action?.url || '');
+  const [actionTitle, setActionTitle] = useState(action?.title || '');
+  const [actionDescription, setActionDescription] = useState(action?.description || '');
+  const [actionIcon, setActionIcon] = useState(action?.icon || '');
+  const [actionColor, setActionColor] = useState(action?.color || '');
+  const [openExternally, setOpenExternally] = useState(action?.openExternally || false);
 
   function save() {
     onOk(
@@ -83,13 +82,13 @@ const ActionModal = (props: Props) => {
 
   return (
     <Modal
-      title="Create New Action"
+      title={action == null ? 'Create New Action' : 'Edit Action'}
       open={open}
       onOk={save}
       onCancel={onCancel}
       okButtonProps={okButtonProps}
     >
-      <div>
+      <Form initialValues={action}>
         Add the URL for the external action you want to present.{' '}
         <strong>Only HTTPS urls are supported.</strong>
         <p>
@@ -101,54 +100,59 @@ const ActionModal = (props: Props) => {
             Read more about external actions.
           </a>
         </p>
-        <p>
+        <Form.Item name="url">
           <Input
-            value={actionUrl}
             required
             placeholder="https://myserver.com/action (required)"
             onChange={input => setActionUrl(input.currentTarget.value.trim())}
             type="url"
             pattern={DEFAULT_TEXTFIELD_URL_PATTERN}
           />
-        </p>
-        <p>
+        </Form.Item>
+        <Form.Item name="title">
           <Input
             value={actionTitle}
+            defaultValue={actionTitle}
             required
             placeholder="Your action title (required)"
             onChange={input => setActionTitle(input.currentTarget.value)}
           />
-        </p>
-        <p>
+        </Form.Item>
+        <Form.Item name="description">
           <Input
             value={actionDescription}
+            defaultValue={actionDescription}
             placeholder="Optional description"
             onChange={input => setActionDescription(input.currentTarget.value)}
           />
-        </p>
-        <p>
+        </Form.Item>
+        <Form.Item name="icon">
           <Input
             value={actionIcon}
+            defaultValue={actionIcon}
             placeholder="https://myserver.com/action/icon.png (optional)"
             onChange={input => setActionIcon(input.currentTarget.value)}
           />
-        </p>
-        <p>
+        </Form.Item>
+        <Form.Item name="color">
           <Input
             type="color"
             value={actionColor}
+            defaultValue={actionColor}
             onChange={input => setActionColor(input.currentTarget.value)}
           />
           Optional background color of the action button.
-        </p>
-        <Checkbox
-          checked={openExternally}
-          defaultChecked={openExternally}
-          onChange={onOpenExternallyChanged}
-        >
-          Open in a new tab instead of within your page.
-        </Checkbox>
-      </div>
+        </Form.Item>
+        <Form.Item name="openExternally">
+          <Checkbox
+            checked={openExternally}
+            defaultChecked={openExternally}
+            onChange={onOpenExternallyChanged}
+          >
+            Open in a new tab instead of within your page.
+          </Checkbox>
+        </Form.Item>
+      </Form>
     </Modal>
   );
 };
@@ -160,7 +164,7 @@ const Actions = () => {
   const [actions, setActions] = useState<ExternalAction[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [submitStatus, setSubmitStatus] = useState(null);
-  const [editAction, setEditAction] = useState<ExternalAction | null>(null);
+  const [editAction, setEditAction] = useState<ExternalAction>(null);
 
   const resetStates = () => {
     setSubmitStatus(null);
@@ -238,7 +242,7 @@ const Actions = () => {
     }
   }
 
-  async function handleEdit(action) {
+  async function handleEdit(action: ExternalAction) {
     setEditAction(action);
     setIsModalOpen(true);
   }


### PR DESCRIPTION
This PR fixes #1884 by adding the ability to edit existing external actions from the admin UI.

Before this, one would have to delete an action and add it again. Now one can just use the edit button.

Demo:

https://user-images.githubusercontent.com/32465636/204544312-7007b346-3eed-47a1-93b6-dfe1f6092cff.mp4



For this I edited (and renamed) the `NewActionModal` to also accept an optional old action for filling out default values. Upon saving changes, either the old action is replaced (if we were in edit mode) or a new action is added to the end of the array (as before).

Please feel free to point out any issues with the implementation. I'm not super familiar with React and the use of `useEffect` kind of feels weird to me (however, when using e.g. `const [actionUrl, setActionUrl] = useState(action?.url || '');` instead, the validation logic for the "OK" button didn't seem work correctly)