### PR TITLE
fix webfinger responses according to the specs

### DIFF
--- a/activitypub/controllers/webfinger.go
+++ b/activitypub/controllers/webfinger.go
@@ -30,6 +30,7 @@ func WebfingerHandler(w http.ResponseWriter, r *http.Request) {
 
 	userComponents := strings.Split(account, "@")
 	if len(userComponents) < 2 {
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	host := userComponents[1]

--- a/activitypub/controllers/webfinger.go
+++ b/activitypub/controllers/webfinger.go
@@ -47,7 +47,7 @@ func WebfingerHandler(w http.ResponseWriter, r *http.Request) {
 	// should be rejected.
 	instanceHostString := data.GetServerURL()
 	if instanceHostString == "" {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -59,7 +59,7 @@ test('enable federation', async (done) => {
 });
 
 test('verify responses of /.well-known/webfinger when federation is enabled', async (done) => {
-	const res = request.get('/.well-known/webfinger').expect(200);
+	const res = request.get('/.well-known/webfinger').expect(400);
 	done();
 });
 

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -77,6 +77,9 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 	const resBadServer = request.get(
 		'/.well-known/webfinger?resource=acct:' + fediUsername + '@not.my.server.lol'
 	).expect(404);
+	const resBadUser = request.get(
+		'/.well-known/webfinger?resource=acct:not' + fediUsername + '@' + serverURL
+	).expect(404);
 	const res = request.get(
 		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverURL
 	).expect(200);

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -72,6 +72,12 @@ test('enable federation, set params', async (done) => {
 test('verify responses of /.well-known/webfinger when federation is enabled', async (done) => {
 	const resNoResource = request.get('/.well-known/webfinger').expect(400);
 	const resBadResource = request.get(
+		'/.well-known/webfinger?resource=' + fediUsername + '@' + serverURL
+	).expect(400);
+	const resBadServer = request.get(
+		'/.well-known/webfinger?resource=acct:' + fediUsername + '@not.my.server.lol'
+	).expect(404);
+	const res = request.get(
 		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverURL
 	).expect(200);
 	done();

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -8,6 +8,9 @@ request = request('http://127.0.0.1:8080');
 var ajv = new Ajv();
 var nodeInfoSchema = jsonfile.readFileSync('schema/nodeinfo_2.0.json');
 
+const serverURL = 'owncast.server.test'
+const fediUsername = 'streamer'
+
 test('disable federation', async (done) => {
 	const res = await sendConfigChangeRequest('federation/enable', false);
 	done();
@@ -53,13 +56,24 @@ test('verify responses of /federation/ when federation is disabled', async (done
 	done();
 });
 
-test('enable federation', async (done) => {
-	const res = await sendConfigChangeRequest('federation/enable', true);
+test('enable federation, set params', async (done) => {
+	const res1 = await sendConfigChangeRequest(
+		'serverurl',
+		serverURL
+	);
+	const res2 = await sendConfigChangeRequest('federation/enable', true);
+	const res3 = await sendConfigChangeRequest(
+		'federation/username',
+		fediUsername
+	);
 	done();
 });
 
 test('verify responses of /.well-known/webfinger when federation is enabled', async (done) => {
-	const res = request.get('/.well-known/webfinger').expect(400);
+	const resNoResource = request.get('/.well-known/webfinger').expect(400);
+	const resBadResource = request.get(
+		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverURL
+	).expect(200);
 	done();
 });
 

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -56,16 +56,16 @@ test('verify responses of /federation/ when federation is disabled', async (done
 	done();
 });
 
-test('enable federation, set params', async (done) => {
+test('set required parameters and enable federation', async (done) => {
 	const res1 = await sendConfigChangeRequest(
 		'serverurl',
 		serverURL
 	);
-	const res2 = await sendConfigChangeRequest('federation/enable', true);
-	const res3 = await sendConfigChangeRequest(
+	const res2 = await sendConfigChangeRequest(
 		'federation/username',
 		fediUsername
 	);
+	const res3 = await sendConfigChangeRequest('federation/enable', true);
 	done();
 });
 


### PR DESCRIPTION
according to [RFC 7033](https://www.rfc-editor.org/rfc/rfc7033): 

> If the "resource" parameter is absent or malformed, the WebFinger resource MUST indicate that the request is bad as per Section 10.4.1 of RFC 2616 

> If the "resource" parameter is a value for which the server has no information, the server MUST indicate that it was unable to match the request as per Section 10.4.5 of RFC 2616.
