### PR TITLE
validate response of federation APIs

### DIFF
--- a/activitypub/controllers/webfinger.go
+++ b/activitypub/controllers/webfinger.go
@@ -22,7 +22,7 @@ func WebfingerHandler(w http.ResponseWriter, r *http.Request) {
 	instanceHostString := utils.GetHostnameFromURLString(data.GetServerURL())
 	if instanceHostString == "" {
 		w.WriteHeader(http.StatusNotFound)
-		log.Warnln("webfinger request rejected! Federation is enabled but server URL is not set. data.GetServerURL(): " + data.GetServerURL())
+		log.Warnln("webfinger request rejected! Federation is enabled but server URL is not set properly. data.GetServerURL(): " + data.GetServerURL())
 		return
 	}
 

--- a/activitypub/controllers/webfinger.go
+++ b/activitypub/controllers/webfinger.go
@@ -19,7 +19,14 @@ func WebfingerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instanceHostString := utils.GetHostnameFromURLString(data.GetServerURL())
+	instanceHostURL := data.GetServerURL()
+	if instanceHostURL == "" {
+		w.WriteHeader(http.StatusNotFound)
+		log.Warnln("webfinger request rejected! Federation is enabled but server URL is empty.")
+		return
+	}
+
+	instanceHostString := utils.GetHostnameFromURLString(instanceHostURL)
 	if instanceHostString == "" {
 		w.WriteHeader(http.StatusNotFound)
 		log.Warnln("webfinger request rejected! Federation is enabled but server URL is not set properly. data.GetServerURL(): " + data.GetServerURL())

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -416,7 +416,8 @@ func SetServerURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawValue, ok := configValue.Value.(string)
-	if !ok {
+	serverHostString := utils.GetHostnameFromURLString(rawValue)
+	if !ok || serverHostString == "" {
 		controllers.WriteSimpleResponse(w, false, "server url value invalid")
 		return
 	}

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -416,8 +416,13 @@ func SetServerURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rawValue, ok := configValue.Value.(string)
+	if !ok {
+		controllers.WriteSimpleResponse(w, false, "could not read server url")
+		return
+	}
+
 	serverHostString := utils.GetHostnameFromURLString(rawValue)
-	if !ok || serverHostString == "" {
+	if serverHostString == "" {
 		controllers.WriteSimpleResponse(w, false, "server url value invalid")
 		return
 	}

--- a/test/automated/api/chatusers.test.js
+++ b/test/automated/api/chatusers.test.js
@@ -76,7 +76,7 @@ test('verify user list is populated', async (done) => {
   });
 });
 
-test('disable a user', async (done) => {
+test('disable a user by admin', async (done) => {
   // To allow for visually being able to see the test hiding the
   // message add a short delay.
   await new Promise((r) => setTimeout(r, 1500));
@@ -110,7 +110,7 @@ test('verify messages from user are hidden', async (done) => {
   done();
 });
 
-test('re-enable a user', async (done) => {
+test('re-enable a user by admin', async (done) => {
   const res = await sendAdminPayload('chat/users/setenabled', { userId: userId, enabled: true });
   done();
 });
@@ -123,7 +123,7 @@ test('verify user is enabled', async (done) => {
   done();
 });
 
-test('ban an ip address', async (done) => {
+test('ban an ip address by admin', async (done) => {
   const resIPv4 = await sendAdminRequest('chat/users/ipbans/create', localIPAddressV4);
   const resIPv6 = await sendAdminRequest('chat/users/ipbans/create', localIPAddressV6);
   done();
@@ -142,7 +142,7 @@ test('verify access is denied', async (done) => {
   done();
 });
 
-test('remove an ip address ban', async (done) => {
+test('remove an ip address ban by admin', async (done) => {
   const resIPv4 = await sendAdminRequest('chat/users/ipbans/remove', localIPAddressV4);
   const resIPv6 = await sendAdminRequest('chat/users/ipbans/remove', localIPAddressV6);
   done();

--- a/test/automated/api/configmanagement.test.js
+++ b/test/automated/api/configmanagement.test.js
@@ -3,6 +3,7 @@ var request = require('supertest');
 const Random = require('crypto-random');
 
 const sendAdminRequest = require('./lib/admin').sendAdminRequest;
+const failAdminRequest = require('./lib/admin').failAdminRequest;
 const getAdminResponse = require('./lib/admin').getAdminResponse;
 
 request = request('http://127.0.0.1:8080');
@@ -245,6 +246,10 @@ test('set forbidden usernames', async (done) => {
 });
 
 test('set server url', async (done) => {
+	const resBadURL = await failAdminRequest(
+		'config/serverurl',
+		'not.valid.url'
+	);
 	const res = await sendAdminRequest(
 		'config/serverurl',
 		newYPConfig.instanceUrl

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -1,4 +1,5 @@
 var request = require('supertest');
+const parseJson = require('parse-json');
 const jsonfile = require('jsonfile');
 const Ajv = require('ajv-draft-04');
 const sendAdminRequest = require('./lib/admin').sendAdminRequest;
@@ -82,8 +83,13 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 	).expect(404);
 	const res = request.get(
 		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverURL
-	).expect(200);
-	done();
+	).set('Accept', 'application/json')
+		.expect('Content-Type', "application/jrd+json")
+		.expect(200)
+		.then((res) => {
+			expect(parseJson(res.body)).toBe(true);
+			done();
+		});
 });
 
 test('verify responses of /.well-known/host-meta when federation is enabled', async (done) => {

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -90,7 +90,9 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 	).expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(parseJson(res.body)).toBe(true);
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();;
 			done();
 		});
 });

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -81,11 +81,10 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 	const resBadUser = request.get(
 		'/.well-known/webfinger?resource=acct:not' + fediUsername + '@' + serverURL
 	).expect(404);
-	const res = request.get(
+	const resNoAccept = request.get(
 		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverURL
-	).set('Accept', 'application/json')
-		.expect('Content-Type', "application/jrd+json")
-		.expect(200)
+	).expect(200)
+		.expect('Content-Type', /json/)
 		.then((res) => {
 			expect(parseJson(res.body)).toBe(true);
 			done();

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -90,9 +90,7 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 	).expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 		});
 	const resWithAccept = request.get(
 		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverName
@@ -100,9 +98,7 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 		.set('Accept', 'application/json')
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 			done();
 		});
 });
@@ -119,9 +115,7 @@ test('verify responses of /.well-known/nodeinfo when federation is enabled', asy
 		.expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 			done();
 		});
 });
@@ -131,9 +125,7 @@ test('verify responses of /.well-known/x-nodeinfo2 when federation is enabled', 
 		.expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 			done();
 		});
 });
@@ -144,9 +136,7 @@ test('verify responses of /nodeinfo/2.0 when federation is enabled', async (done
 		.expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 			expect(ajv.validate(nodeInfoSchema, res.body)).toBe(true);
 			done();
 		});
@@ -157,9 +147,7 @@ test('verify responses of /api/v1/instance when federation is enabled', async (d
 		.expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 			done();
 		});
 });
@@ -175,9 +163,7 @@ test('verify responses of /federation/user/ when federation is enabled', async (
 		.expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {
-			expect(() => {
-				parseJson(res.text);
-			}).not.toThrow();
+			parseJson(res.text);
 			done();
 		});
 });

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -158,6 +158,9 @@ test('verify responses of /federation/user/ when federation is enabled', async (
 	const resWithAccept = request.get('/federation/user/')
 		.set('Accept', 'application/json')
 		.expect(404);
+	const resWithAcceptWrongUsername = request.get('/federation/user/not' + fediUsername)
+		.set('Accept', 'application/json')
+		.expect(404);
 	const resWithAcceptUsername = request.get('/federation/user/' + fediUsername)
 		.set('Accept', 'application/json')
 		.expect(200)

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -75,8 +75,11 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 	const resBadResource = request.get(
 		'/.well-known/webfinger?resource=' + fediUsername + '@' + serverURL
 	).expect(400);
+	const resBadResource2 = request.get(
+		'/.well-known/webfinger?resource=notacct:' + fediUsername + '@' + serverURL
+	).expect(400);
 	const resBadServer = request.get(
-		'/.well-known/webfinger?resource=acct:' + fediUsername + '@not.my.server.lol'
+		'/.well-known/webfinger?resource=acct:' + fediUsername + '@not' + serverURL
 	).expect(404);
 	const resBadUser = request.get(
 		'/.well-known/webfinger?resource=acct:not' + fediUsername + '@' + serverURL

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -9,8 +9,8 @@ request = request('http://127.0.0.1:8080');
 var ajv = new Ajv();
 var nodeInfoSchema = jsonfile.readFileSync('schema/nodeinfo_2.0.json');
 
-const serverURL = 'http://owncast.server.test'
 const serverName = 'owncast.server.test'
+const serverURL = 'http://' + serverName
 const fediUsername = 'streamer'
 
 test('disable federation', async (done) => {
@@ -92,47 +92,101 @@ test('verify responses of /.well-known/webfinger when federation is enabled', as
 		.then((res) => {
 			expect(() => {
 				parseJson(res.text);
-			}).not.toThrow();;
+			}).not.toThrow();
+		});
+	const resWithAccept = request.get(
+		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverName
+	).expect(200)
+		.set('Accept', 'application/json')
+		.expect('Content-Type', /json/)
+		.then((res) => {
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();
 			done();
 		});
 });
 
 test('verify responses of /.well-known/host-meta when federation is enabled', async (done) => {
-	const res = request.get('/.well-known/host-meta').expect(200);
+	const res = request.get('/.well-known/host-meta')
+		.expect(200)
+		.expect('Content-Type', /xml/);
 	done();
 });
 
 test('verify responses of /.well-known/nodeinfo when federation is enabled', async (done) => {
-	const res = request.get('/.well-known/nodeinfo').expect(200);
-	done();
+	const res = request.get('/.well-known/nodeinfo')
+		.expect(200)
+		.expect('Content-Type', /json/)
+		.then((res) => {
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();
+			done();
+		});
 });
 
 test('verify responses of /.well-known/x-nodeinfo2 when federation is enabled', async (done) => {
-	const res = request.get('/.well-known/x-nodeinfo2').expect(200);
-	done();
+	const res = request.get('/.well-known/x-nodeinfo2')
+		.expect(200)
+		.expect('Content-Type', /json/)
+		.then((res) => {
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();
+			done();
+		});
 });
 
 test('verify responses of /nodeinfo/2.0 when federation is enabled', async (done) => {
 	const res = request
 		.get('/nodeinfo/2.0')
 		.expect(200)
+		.expect('Content-Type', /json/)
 		.then((res) => {
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();
 			expect(ajv.validate(nodeInfoSchema, res.body)).toBe(true);
 			done();
 		});
 });
 
 test('verify responses of /api/v1/instance when federation is enabled', async (done) => {
-	const res = request.get('/api/v1/instance').expect(200);
-	done();
+	const res = request.get('/api/v1/instance')
+		.expect(200)
+		.expect('Content-Type', /json/)
+		.then((res) => {
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();
+			done();
+		});
 });
 
 test('verify responses of /federation/user/ when federation is enabled', async (done) => {
-	const res = request.get('/federation/user/').expect(200);
-	done();
+	const resNoAccept = request.get('/federation/user/')
+		.expect(307);
+	const resWithAccept = request.get('/federation/user/')
+		.set('Accept', 'application/json')
+		.expect(404);
+	const resWithAcceptUsername = request.get('/federation/user/' + fediUsername)
+		.set('Accept', 'application/json')
+		.expect(200)
+		.expect('Content-Type', /json/)
+		.then((res) => {
+			expect(() => {
+				parseJson(res.text);
+			}).not.toThrow();
+			done();
+		});
 });
 
 test('verify responses of /federation/ when federation is enabled', async (done) => {
-	const res = request.get('/federation/').expect(200);
+	const resNoAccept = request.get('/federation/')
+		.expect(307);
+	const resWithAccept = request.get('/federation/')
+		.set('Accept', 'application/json')
+		.expect(404);
 	done();
 });

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -9,7 +9,8 @@ request = request('http://127.0.0.1:8080');
 var ajv = new Ajv();
 var nodeInfoSchema = jsonfile.readFileSync('schema/nodeinfo_2.0.json');
 
-const serverURL = 'owncast.server.test'
+const serverURL = 'http://owncast.server.test'
+const serverName = 'owncast.server.test'
 const fediUsername = 'streamer'
 
 test('disable federation', async (done) => {
@@ -73,19 +74,19 @@ test('set required parameters and enable federation', async (done) => {
 test('verify responses of /.well-known/webfinger when federation is enabled', async (done) => {
 	const resNoResource = request.get('/.well-known/webfinger').expect(400);
 	const resBadResource = request.get(
-		'/.well-known/webfinger?resource=' + fediUsername + '@' + serverURL
+		'/.well-known/webfinger?resource=' + fediUsername + '@' + serverName
 	).expect(400);
 	const resBadResource2 = request.get(
-		'/.well-known/webfinger?resource=notacct:' + fediUsername + '@' + serverURL
+		'/.well-known/webfinger?resource=notacct:' + fediUsername + '@' + serverName
 	).expect(400);
 	const resBadServer = request.get(
-		'/.well-known/webfinger?resource=acct:' + fediUsername + '@not' + serverURL
+		'/.well-known/webfinger?resource=acct:' + fediUsername + '@not' + serverName
 	).expect(404);
 	const resBadUser = request.get(
-		'/.well-known/webfinger?resource=acct:not' + fediUsername + '@' + serverURL
+		'/.well-known/webfinger?resource=acct:not' + fediUsername + '@' + serverName
 	).expect(404);
 	const resNoAccept = request.get(
-		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverURL
+		'/.well-known/webfinger?resource=acct:' + fediUsername + '@' + serverName
 	).expect(200)
 		.expect('Content-Type', /json/)
 		.then((res) => {

--- a/test/automated/api/lib/admin.js
+++ b/test/automated/api/lib/admin.js
@@ -52,7 +52,7 @@ async function failAdminRequest(
 	adminPassword = defaultAdminPassword,
 	responseCode = 400
 ) {
-	const url = '/api/admin/config/' + endpoint;
+	const url = '/api/admin/' + endpoint;
 	const res = await request
 		.post(url)
 		.auth('admin', adminPassword)

--- a/test/automated/api/lib/admin.js
+++ b/test/automated/api/lib/admin.js
@@ -46,6 +46,25 @@ async function sendAdminPayload(
 	return res;
 }
 
+async function failAdminRequest(
+	endpoint,
+	value,
+	adminPassword = defaultAdminPassword,
+	responseCode = 400
+) {
+	const url = '/api/admin/config/' + endpoint;
+	const res = await request
+		.post(url)
+		.auth('admin', adminPassword)
+		.send({ value: value })
+		.expect(responseCode);
+
+	expect(res.body.success).toBe(false);
+	return res;
+}
+
 module.exports.getAdminResponse = getAdminResponse;
 module.exports.sendAdminRequest = sendAdminRequest;
 module.exports.sendAdminPayload = sendAdminPayload;
+module.exports.failAdminRequest = failAdminRequest;
+

--- a/test/automated/api/package-lock.json
+++ b/test/automated/api/package-lock.json
@@ -9,7 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "supertest": "^6.0.1",
+        "ajv": "^8.11.0",
+        "ajv-draft-04": "^1.0.0",
+        "crypto-random": "^2.0.1",
+        "jsonfile": "^6.1.0",
+        "supertest": "^6.3.2",
         "websocket": "^1.0.32"
       },
       "devDependencies": {
@@ -972,6 +976,34 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -1071,6 +1103,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -1327,6 +1364,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1503,9 +1552,9 @@
       "dev": true
     },
     "node_modules/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
@@ -1551,6 +1600,14 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/crypto-random": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/crypto-random/-/crypto-random-2.0.1.tgz",
+      "integrity": "sha512-MTag9YM+VySFM+eEitCBQy6aCBxlhIeFnQZAm6e6Rnfnn3dEXG2G0xbPyV/YQI0MmW1AgG0JfG/urp7nwbyDEg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/cssom": {
@@ -1601,14 +1658,19 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -1716,6 +1778,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2083,6 +2154,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2096,9 +2172,9 @@
       "dev": true
     },
     "node_modules/fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fb-watchman": {
       "version": "2.0.1",
@@ -2134,6 +2210,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
       "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2144,9 +2221,18 @@
       }
     },
     "node_modules/formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
@@ -2182,8 +2268,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2201,6 +2286,19 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -2263,7 +2361,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -2276,7 +2374,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2291,6 +2388,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-value": {
@@ -2354,6 +2462,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hosted-git-info": {
@@ -2466,7 +2582,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3782,6 +3899,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -3795,6 +3917,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/kind-of": {
@@ -3848,6 +3989,17 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -3909,7 +4061,7 @@
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3928,9 +4080,9 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "bin": {
         "mime": "cli.js"
       },
@@ -4179,6 +4331,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4207,7 +4367,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4479,17 +4638,22 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react-is": {
@@ -4585,19 +4749,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4640,6 +4791,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4716,11 +4875,6 @@
       "engines": {
         "node": "6.* || >= 7.*"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -4916,9 +5070,12 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4986,6 +5143,19 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/signal-exit": {
       "version": "3.0.3",
@@ -5297,14 +5467,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
@@ -5358,36 +5520,48 @@
       }
     },
     "node_modules/superagent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.5.tgz",
+      "integrity": "sha512-lQVE0Praz7nHiSaJLKBM/cZyi7J0E4io8tWnGSBdBrqAzhzrjQ/F5iGP9Zr29CJC8N5zYdhG2kKaNcB6dKxp7g==",
       "dependencies": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
         "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">= 7.0.0"
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/supertest": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.0.1.tgz",
-      "integrity": "sha512-8yDNdm+bbAN/jeDdXsRipbq9qMpVF7wRsbwLgsANHqdjPsCoecmlTuqEcLQMGpmojFBhxayZ0ckXmLXYq7e+0g==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.2.tgz",
+      "integrity": "sha512-mSmbW/sPpBU6K8w8189ZiHdc62zMe7dCHpC2ktS9tc0/d2DN0FaxNbDJJNFknZD4jCrGJpxkiFoVyemvKgOdwA==",
       "dependencies": {
-        "methods": "1.1.2",
-        "superagent": "6.1.0"
+        "methods": "^1.1.2",
+        "superagent": "^8.0.3"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {
@@ -5661,6 +5835,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -5684,11 +5866,6 @@
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uuid": {
       "version": "8.3.1",
@@ -5863,8 +6040,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -5912,6 +6088,11 @@
       "engines": {
         "node": ">=0.10.32"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -6771,6 +6952,23 @@
         "debug": "4"
       }
     },
+    "ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "requires": {}
+    },
     "ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -6845,6 +7043,11 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -7060,6 +7263,15 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -7206,9 +7418,9 @@
       }
     },
     "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -7245,6 +7457,11 @@
           }
         }
       }
+    },
+    "crypto-random": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/crypto-random/-/crypto-random-2.0.1.tgz",
+      "integrity": "sha512-MTag9YM+VySFM+eEitCBQy6aCBxlhIeFnQZAm6e6Rnfnn3dEXG2G0xbPyV/YQI0MmW1AgG0JfG/urp7nwbyDEg=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -7290,9 +7507,9 @@
       }
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -7378,6 +7595,15 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -7678,6 +7904,11 @@
         }
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7691,9 +7922,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -7723,6 +7954,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
       "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7730,9 +7962,15 @@
       }
     },
     "formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "requires": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -7759,8 +7997,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -7773,6 +8010,16 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -7819,7 +8066,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "devOptional": true
     },
     "growly": {
       "version": "1.3.0",
@@ -7832,7 +8079,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7842,6 +8088,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -7894,6 +8145,11 @@
           }
         }
       }
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -7981,7 +8237,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -9038,6 +9295,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -9045,6 +9307,22 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
       }
     },
     "kind-of": {
@@ -9086,6 +9364,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -9137,7 +9423,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
     "micromatch": {
       "version": "4.0.2",
@@ -9150,9 +9436,9 @@
       }
     },
     "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -9354,6 +9640,11 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -9376,7 +9667,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -9586,13 +9876,15 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "react-is": {
       "version": "17.0.1",
@@ -9670,16 +9962,6 @@
         }
       }
     },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -9713,6 +9995,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -9771,11 +10058,6 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -9943,9 +10225,12 @@
       }
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -9997,6 +10282,16 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -10264,14 +10559,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "string-length": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
@@ -10312,30 +10599,41 @@
       "dev": true
     },
     "superagent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.5.tgz",
+      "integrity": "sha512-lQVE0Praz7nHiSaJLKBM/cZyi7J0E4io8tWnGSBdBrqAzhzrjQ/F5iGP9Zr29CJC8N5zYdhG2kKaNcB6dKxp7g==",
       "requires": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
         "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "supertest": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.0.1.tgz",
-      "integrity": "sha512-8yDNdm+bbAN/jeDdXsRipbq9qMpVF7wRsbwLgsANHqdjPsCoecmlTuqEcLQMGpmojFBhxayZ0ckXmLXYq7e+0g==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.2.tgz",
+      "integrity": "sha512-mSmbW/sPpBU6K8w8189ZiHdc62zMe7dCHpC2ktS9tc0/d2DN0FaxNbDJJNFknZD4jCrGJpxkiFoVyemvKgOdwA==",
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "6.1.0"
+        "methods": "^1.1.2",
+        "superagent": "^8.0.3"
       }
     },
     "supports-color": {
@@ -10555,6 +10853,14 @@
         }
       }
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -10574,11 +10880,6 @@
       "requires": {
         "node-gyp-build": "^4.2.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "8.3.1",
@@ -10727,8 +11028,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -10770,6 +11070,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/test/automated/api/package.json
+++ b/test/automated/api/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "supertest": "^6.0.1",
+    "supertest": "^6.3.2",
     "websocket": "^1.0.32",
     "ajv": "^8.11.0",
     "ajv-draft-04" : "^1.0.0",


### PR DESCRIPTION
- verify json responses are parsable
- set `Accept` request header and check `Content-Type` in response headers
- refuse empty and invalid webfinger queries more strictly (+tests)
- log the reasons for webfinger query rejections in debug mode
- validate server URL before setting it through API (+test failed validations with `failAdminRequest()`)
- bump supertest minor version
- update `test/automated/api/package-lock.json`