### PR TITLE
Fix URL Modal scrolling and size

### DIFF
--- a/web/components/ui/Modal/Modal.tsx
+++ b/web/components/ui/Modal/Modal.tsx
@@ -42,6 +42,7 @@ export const Modal: FC<ModalProps> = ({
       sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
       frameBorder="0"
       allowFullScreen
+      style={{ display: 'block' }}
       // eslint-disable-next-line react/no-unknown-property
       onLoad={() => setLoading(false)}
     />

--- a/web/components/ui/Modal/Modal.tsx
+++ b/web/components/ui/Modal/Modal.tsx
@@ -27,10 +27,17 @@ export const Modal: FC<ModalProps> = ({
 }) => {
   const [loading, setLoading] = useState(!!url);
 
+  let defaultHeight = '100%';
+  let defaultWidth = '520px';
+  if (url) {
+    defaultHeight = '70vh';
+    defaultWidth = '900px';
+  }
+
   const modalStyle = {
     padding: '0px',
     minHeight: height,
-    height: height ?? '100%',
+    height: height ?? defaultHeight,
   };
 
   const iframe = url && (
@@ -58,7 +65,7 @@ export const Modal: FC<ModalProps> = ({
       onCancel={handleCancel}
       afterClose={afterClose}
       bodyStyle={modalStyle}
-      width={width}
+      width={width ?? defaultWidth}
       zIndex={999}
       footer={null}
       centered


### PR DESCRIPTION
# Description

Fixes #2395 (Default modal width is too narrow)

Fixes the double scrollbar issue when using the Modal with an `iframe` inside. The double scrollbar was caused because `display` types were not working too well with each other. Setting the display of the `iframe` to `block` instead of the default `inline-block` does the trick.

 Also set a larger default size for the modal when the modal contains an iframe. From `width:520px` and no defined height, to `width:900px` and `height:70vh`. Width still has a `max-width:100vw-16px` as set by Ant Modal.

Changes were made based on [comments on the original issue](https://github.com/owncast/owncast/issues/2395#issuecomment-1338289951).
