### PR TITLE
Fix video config admin modal layout

### DIFF
--- a/web/components/config/VideoVariantForm.tsx
+++ b/web/components/config/VideoVariantForm.tsx
@@ -1,6 +1,6 @@
 // This content populates the video variant modal, which is spawned from the variants table. This relies on the `dataState` prop fed in by the table.
 import React, { FC } from 'react';
-import { Popconfirm, Row, Col, Slider, Collapse, Typography } from 'antd';
+import { Popconfirm, Row, Col, Slider, Collapse, Typography, Alert, Button } from 'antd';
 import { ExclamationCircleFilled } from '@ant-design/icons';
 import classNames from 'classnames';
 import { FieldUpdaterFunc, VideoVariant, UpdateArgs } from '../../types/config-section';
@@ -108,7 +108,7 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
   });
   return (
     <div className={classes}>
-      <p className="description">
+      {/* <p className="description">
         <a
           href="https://owncast.online/docs/video?source=admin"
           target="_blank"
@@ -117,8 +117,24 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
           Learn more
         </a>{' '}
         about how each of these settings can impact the performance of your server.
-      </p>
-
+      </p> */}
+      <div style={{ marginBottom: '20px' }}>
+        <Alert
+          description="Learn more about how each of these settings can impact the performance of your server."
+          type="info"
+          action={
+            <a
+              href="https://owncast.online/docs/video?source=admin"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button size="small" type="text">
+                Visit the link
+              </Button>
+            </a>
+          }
+        />
+      </div>
       {videoPassthroughEnabled && (
         <p className="passthrough-warning">
           NOTE: Video Passthrough for this output stream variant is <em>enabled</em>, disabling the
@@ -127,12 +143,14 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
       )}
 
       <Row gutter={16}>
-        <TextField
-          maxLength="10"
-          {...VIDEO_NAME_DEFAULTS}
-          value={dataState.name}
-          onChange={handleNameChanged}
-        />
+        <div style={{ marginLeft: '-90px', marginBottom: '20px' }}>
+          <TextField
+            maxLength="10"
+            {...VIDEO_NAME_DEFAULTS}
+            value={dataState.name}
+            onChange={handleNameChanged}
+          />
+        </div>
         <Col sm={24} md={12}>
           <div className="form-module cpu-usage-container">
             <Typography.Title level={3}>CPU or GPU Utilization</Typography.Title>
@@ -153,7 +171,9 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
               <p className="selected-value-note">{cpuUsageNote()}</p>
             </div>
             <p className="read-more-subtext">
-              This could mean GPU or CPU usage depending on your server environment.{' '}
+              This could mean GPU or CPU usage depending on your server environment.
+              <br />
+              <br />
               <a
                 href="https://owncast.online/docs/video/?source=admin#cpu-usage"
                 target="_blank"
@@ -164,8 +184,7 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
             </p>
           </div>
         </Col>
-
-        <Col sm={24} md={12}>
+        <Col sm={24} md={11} offset={1}>
           {/* VIDEO BITRATE FIELD */}
           <div
             className={`form-module bitrate-container ${

--- a/web/components/config/VideoVariantForm.tsx
+++ b/web/components/config/VideoVariantForm.tsx
@@ -108,17 +108,7 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
   });
   return (
     <div className={classes}>
-      {/* <p className="description">
-        <a
-          href="https://owncast.online/docs/video?source=admin"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn more
-        </a>{' '}
-        about how each of these settings can impact the performance of your server.
-      </p> */}
-      <div style={{ marginBottom: '20px' }}>
+      <div className="video-varient-alert">
         <Alert
           description="Learn more about how each of these settings can impact the performance of your server."
           type="info"
@@ -143,14 +133,14 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
       )}
 
       <Row gutter={16}>
-        <div style={{ marginLeft: '-90px', marginBottom: '20px' }}>
+        <Col xs={24} lg={{ span: 24, pull: 3 }} className="video-text-field-container">
           <TextField
             maxLength="10"
             {...VIDEO_NAME_DEFAULTS}
             value={dataState.name}
             onChange={handleNameChanged}
           />
-        </div>
+        </Col>
         <Col sm={24} md={12}>
           <div className="form-module cpu-usage-container">
             <Typography.Title level={3}>CPU or GPU Utilization</Typography.Title>
@@ -228,7 +218,8 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
                 <p className="description">
                   Resizing your content will take additional resources on your server. If you wish
                   to optionally resize your content for this stream output then you should either
-                  set the width <strong>or</strong> the height to keep your aspect ratio.{' '}
+                  set the width <strong>or</strong> the height to keep your aspect ratio. <br />
+                  <br />
                   <a
                     href="https://owncast.online/docs/video/?source=admin"
                     target="_blank"
@@ -277,26 +268,33 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
                     </a>
                   </p>
                 </div>
-                <Popconfirm
-                  disabled={dataState.videoPassthrough === true}
-                  title="Did you read the documentation about video passthrough and understand the risks involved with enabling it?"
-                  icon={<ExclamationCircleFilled />}
-                  onConfirm={handleVideoPassConfirm}
-                  okText="Yes"
-                  cancelText="No"
-                >
-                  {/* adding an <a> tag to force Popcofirm to register click on toggle */}
-                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                  <a href="#">
-                    <ToggleSwitch
-                      label="Use Video Passthrough?"
-                      fieldName="video-passthrough"
-                      tip={VIDEO_VARIANT_SETTING_DEFAULTS.videoPassthrough.tip}
-                      checked={dataState.videoPassthrough}
-                      onChange={handleVideoPassthroughToggle}
-                    />
-                  </a>
-                </Popconfirm>
+                <div className="advanced-switch-container">
+                  <Popconfirm
+                    disabled={dataState.videoPassthrough === true}
+                    title="Did you read the documentation about video passthrough and understand the risks involved with enabling it?"
+                    icon={<ExclamationCircleFilled />}
+                    onConfirm={handleVideoPassConfirm}
+                    okText="Yes"
+                    cancelText="No"
+                  >
+                    {/* adding an <a> tag to force Popcofirm to register click on toggle */}
+                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                    <a href="#">
+                      <div className="advanced-description-switch-container">
+                        <div className="advanced-description-wrapper">
+                          <p>Use Video Passthrough?</p>
+                        </div>
+                        <ToggleSwitch
+                          label=""
+                          fieldName="video-passthrough"
+                          checked={dataState.videoPassthrough}
+                          onChange={handleVideoPassthroughToggle}
+                        />
+                      </div>
+                    </a>
+                    <p>*{VIDEO_VARIANT_SETTING_DEFAULTS.videoPassthrough.tip}</p>
+                  </Popconfirm>
+                </div>
               </div>
             </Col>
           </Row>

--- a/web/components/config/VideoVariantForm.tsx
+++ b/web/components/config/VideoVariantForm.tsx
@@ -110,7 +110,6 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
     <div className={classes}>
       <div className="video-varient-alert">
         <Alert
-          description="Learn more about how each of these settings can impact the performance of your server."
           type="info"
           action={
             <a
@@ -118,9 +117,12 @@ export const VideoVariantForm: FC<VideoVariantFormProps> = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <Button size="small" type="text">
-                Visit the link
-              </Button>
+              <div className="video-varient-alert-button-container">
+                <Button size="small" type="text" icon={<ExclamationCircleFilled />}>
+                  Read more about how each of these settings can impact the performance of your
+                  server.
+                </Button>
+              </div>
             </a>
           }
         />

--- a/web/public/styles/admin/config-video-variants.css
+++ b/web/public/styles/admin/config-video-variants.css
@@ -46,3 +46,23 @@
 .codec-module .ant-collapse-content-active {
   background-color: var(--white-15);
 }
+.video-text-field-container{
+  margin-left: 12px; 
+  margin-bottom: 30px; 
+}
+.video-varient-alert{
+  margin-bottom: 30px; 
+}
+.advanced-switch-container{
+  margin-left: 80px; 
+}
+.advanced-description-switch-container{
+  display: flex;
+  flex-direction: row; 
+}
+.advanced-description-wrapper{
+  color: black;
+  display: flex;
+  align-items: center;
+  margin-top: 16px;
+}

--- a/web/public/styles/admin/config-video-variants.css
+++ b/web/public/styles/admin/config-video-variants.css
@@ -66,3 +66,6 @@
   align-items: center;
   margin-top: 16px;
 }
+.video-varient-alert-button-container{
+  width: 100vh
+}

--- a/web/public/styles/admin/config-video-variants.css
+++ b/web/public/styles/admin/config-video-variants.css
@@ -46,21 +46,21 @@
 .codec-module .ant-collapse-content-active {
   background-color: var(--white-15);
 }
-.video-text-field-container{
-  margin-left: 12px; 
-  margin-bottom: 30px; 
+.video-text-field-container {
+  margin-left: 12px;
+  margin-bottom: 30px;
 }
-.video-varient-alert{
-  margin-bottom: 30px; 
+.video-varient-alert {
+  margin-bottom: 30px;
 }
-.advanced-switch-container{
-  margin-left: 80px; 
+.advanced-switch-container {
+  margin-left: 80px;
 }
-.advanced-description-switch-container{
+.advanced-description-switch-container {
   display: flex;
-  flex-direction: row; 
+  flex-direction: row;
 }
-.advanced-description-wrapper{
+.advanced-description-wrapper {
   color: black;
   display: flex;
   align-items: center;

--- a/web/public/styles/admin/config-video-variants.css
+++ b/web/public/styles/admin/config-video-variants.css
@@ -66,6 +66,6 @@
   align-items: center;
   margin-top: 16px;
 }
-.video-varient-alert-button-container{
-  width: 100vh
+.video-varient-alert-button-container {
+  width: 100vh;
 }

--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -405,19 +405,39 @@ export const VIDEO_NAME_DEFAULTS = {
 };
 
 export const VIDEO_BITRATE_SLIDER_MARKS = {
-  [VIDEO_BITRATE_DEFAULTS.min]: `${VIDEO_BITRATE_DEFAULTS.min} ${VIDEO_BITRATE_DEFAULTS.unit}`,
+  [VIDEO_BITRATE_DEFAULTS.min]: {
+    style: {
+      marginLeft: '24px',
+    },
+    label: `${VIDEO_BITRATE_DEFAULTS.min} ${VIDEO_BITRATE_DEFAULTS.unit}`,
+  },
   3000: 3000,
   4500: 4500,
-  [VIDEO_BITRATE_DEFAULTS.max]: `${VIDEO_BITRATE_DEFAULTS.max} ${VIDEO_BITRATE_DEFAULTS.unit}`,
+  [VIDEO_BITRATE_DEFAULTS.max]: {
+    style: {
+      marginLeft: '-10px',
+    },
+    label: `${VIDEO_BITRATE_DEFAULTS.max} ${VIDEO_BITRATE_DEFAULTS.unit}`,
+  },
 };
 // VIDEO VARIANT FORM - encoder preset
 // CPU
 export const ENCODER_PRESET_SLIDER_MARKS = {
-  1: 'lowest',
+  1: {
+    style: {
+      marginLeft: '15px',
+    },
+    label: <p>lowest</p>,
+  },
   2: '',
   3: '',
   4: '',
-  5: 'highest',
+  5: {
+    style: {
+      marginLeft: '-15px',
+    },
+    label: <p>highest</p>,
+  },
 };
 export const ENCODER_PRESET_TOOLTIPS = {
   1: 'Lowest hardware usage - lowest quality video',


### PR DESCRIPTION
Currently, the Video config modal layout is broken, and this PR fixes #2356. To fix this layout issue, I aligned components on the left side and added some padding between components to make it less cluttered. On the advanced settings component, I changed the toggle switch a little bit in order to make it more polished and consistent with the rest of the application UI. 

The Screenshot: 

![Screen Shot 2022-12-06 at 8 40 43 PM](https://user-images.githubusercontent.com/26856199/206006858-ac751a4e-3057-4fb0-82d2-1bd5aea34840.png)
