### PR TITLE
fix chatuser test to handle mixed ipv4 & ipv6 bans

### DIFF
--- a/test/automated/api/chatusers.test.js
+++ b/test/automated/api/chatusers.test.js
@@ -154,17 +154,13 @@ test('ban an ip address', async (done) => {
   done();
 });
 
-// Note: This test expects the local address to be 127.0.0.1.
-// If it's running on an ipv6-only network, for example, things will
-// probably fail.
 test('verify IP address is blocked from the ban', async (done) => {
   const response = await request
     .get(`/api/admin/chat/users/ipbans`)
     .auth('admin', 'abc123')
     .expect(200);
 
-  expect(response.body).toHaveLength(1);
-  expect(response.body[0].ipAddress).toBe(localIPAddress);
+  expect(onlyLocalIPAddress(response.body)).toBe(true);
   done();
 });
 
@@ -196,3 +192,14 @@ test('verify access is again allowed', async (done) => {
   await request.get(`/api/chat?accessToken=${accessToken}`).expect(200);
   done();
 });
+
+
+// This function expects the local address to be 127.0.0.1 & ::1
+function onlyLocalIPAddress(banInfo) {
+  for (let i = 0; i < banInfo.length; i++) {
+    if ((banInfo[i].ipAddress != "127.0.0.1") && (banInfo[i].ipAddress != "::1")) {
+      return false
+    }
+  }
+  return true
+}


### PR DESCRIPTION
old test was randomly failing as:

```
 time="2022-12-06T20:19:40Z" level=trace msg="Adding client 0 total count: 1" func="github.com/owncast/owncast/core/chat.(*Server).Addclient" file="/build/core/chat/server.go:109"
 time="2022-12-06T20:19:40Z" level=trace msg="client closed: gifted-hugle 0 ::1" func="github.com/owncast/owncast/core/chat.(*Client).close" file="/build/core/chat/chatclient.go:189"
 time="2022-12-06T20:19:40Z" level=trace msg="client closed: gifted-hugle 0 ::1" func="github.com/owncast/owncast/core/chat.(*Client).close" file="/build/core/chat/chatclient.go:189"
 time="2022-12-06T20:19:40Z" level=debug msg="no connections for user found" func=github.com/owncast/owncast/controllers/admin.UpdateUserModerator file="/build/controllers/admin/chat.go:216"
 time="2022-12-06T20:19:40Z" level=trace msg="Adding client 1 total count: 1" func="github.com/owncast/owncast/core/chat.(*Server).Addclient" file="/build/core/chat/server.go:109"
 time="2022-12-06T20:19:40Z" level=trace msg="client closed: gifted-hugle 1 ::1" func="github.com/owncast/owncast/core/chat.(*Client).close" file="/build/core/chat/chatclient.go:189"
 time="2022-12-06T20:19:40Z" level=trace msg="client closed: gifted-hugle 1 ::1" func="github.com/owncast/owncast/core/chat.(*Client).close" file="/build/core/chat/chatclient.go:189"
 time="2022-12-06T20:19:42Z" level=trace msg="Adding client 2 total count: 1" func="github.com/owncast/owncast/core/chat.(*Server).Addclient" file="/build/core/chat/server.go:109"
 time="2022-12-06T20:19:42Z" level=trace msg="Disconnecting client 0-28DsF4R owned by gifted-hugle" func="github.com/owncast/owncast/core/chat.(*Server).DisconnectClients" file="/build/core/chat/server.go:271"
 time="2022-12-06T20:19:43Z" level=debug msg="Client ip address has been blocked. Rejecting." func=github.com/owncast/owncast/router/middleware.RequireUserAccessToken.func1 file="/build/router/middleware/auth.go:111"
 FAIL ./chatusers.test.js
   ● verify IP address is blocked from the ban

     expect(received).toHaveLength(expected)

     Expected length: 1
     Received length: 2
     Received array:  [{"createdAt": "2022-12-06T20:19:42Z", "ipAddress": "::1", "notes": "Banning of gifted-hugle"}, {"createdAt": "2022-12-06T20:19:43Z", "ipAddress": "127.0.0.1", "notes": "manually added"}]

       164 |     .expect(200);
       165 | 
     > 166 |   expect(response.body).toHaveLength(1);
           |                         ^
       167 |   expect(response.body[0].ipAddress).toBe(localIPAddress);
       168 |   done();
       169 | });

       at Object.<anonymous> (chatusers.test.js:166:25)
```