### PR TITLE
refactor chatuser api tests

### DIFF
--- a/test/automated/api/chatusers.test.js
+++ b/test/automated/api/chatusers.test.js
@@ -38,10 +38,7 @@ test('can set the user as moderator', async (done) => {
 });
 
 test('verify user is a moderator', async (done) => {
-  const response = await request
-    .get('/api/admin/chat/users/moderators')
-    .auth('admin', 'abc123')
-    .expect(200);
+  const response = await getAdminResponse('chat/users/moderators');
   const tokenCheck = response.body.filter((user) => user.id === userId);
   expect(tokenCheck).toHaveLength(1);
 

--- a/test/automated/api/chatusers.test.js
+++ b/test/automated/api/chatusers.test.js
@@ -8,8 +8,8 @@ const registerChat = require('./lib/chat').registerChat;
 const sendChatMessage = require('./lib/chat').sendChatMessage;
 const sendAdminRequest = require('./lib/admin').sendAdminRequest;
 const sendAdminPayload = require('./lib/admin').sendAdminPayload;
-const getAdminDisabledChatUsers = require('./lib/admin').getAdminDisabledChatUsers;
-const getAdminBlockedChatIPs = require('./lib/admin').getAdminBlockedChatIPs;
+const getAdminResponse= require('./lib/admin').getAdminResponse;
+
 
 const localIPAddressV4 = '127.0.0.1';
 const localIPAddressV6 = '::1';
@@ -101,7 +101,7 @@ test('can disable a user', async (done) => {
 });
 
 test('verify user is disabled', async (done) => {
-  const response = await getAdminDisabledChatUsers();
+  const response = await getAdminResponse('chat/users/disabled');
   const tokenCheck = response.body.filter((user) => user.id === userId);
   expect(tokenCheck).toHaveLength(1);
   done();
@@ -125,7 +125,7 @@ test('can re-enable a user', async (done) => {
 });
 
 test('verify user is enabled', async (done) => {
-  const response = await getAdminDisabledChatUsers();
+  const response = await getAdminResponse('chat/users/disabled');
   const tokenCheck = response.body.filter((user) => user.id === userId);
   expect(tokenCheck).toHaveLength(0);
 
@@ -139,7 +139,7 @@ test('ban an ip address', async (done) => {
 });
 
 test('verify IP address is blocked from the ban', async (done) => {
-  const response = await getAdminBlockedChatIPs();
+  const response = await getAdminResponse('chat/users/ipbans');
 
   expect(response.body).toHaveLength(2);
   expect(onlyLocalIPAddress(response.body)).toBe(true);
@@ -158,7 +158,7 @@ test('remove an ip address ban', async (done) => {
 });
 
 test('verify IP address is no longer banned', async (done) => {
-  const response = await getAdminBlockedChatIPs();
+  const response = await getAdminResponse('chat/users/ipbans');
 
   expect(response.body).toHaveLength(0);
   done();

--- a/test/automated/api/chatusers.test.js
+++ b/test/automated/api/chatusers.test.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const registerChat = require('./lib/chat').registerChat;
 const sendChatMessage = require('./lib/chat').sendChatMessage;
 const sendAdminRequest = require('./lib/admin').sendAdminRequest;
+const sendAdminPayload = require('./lib/admin').sendAdminPayload;
 const getAdminDisabledChatUsers = require('./lib/admin').getAdminDisabledChatUsers;
 const getAdminBlockedChatIPs = require('./lib/admin').getAdminBlockedChatIPs;
 
@@ -32,11 +33,7 @@ test('can send a chat message', async (done) => {
 });
 
 test('can set the user as moderator', async (done) => {
-  await request
-    .post('/api/admin/chat/users/setmoderator')
-    .send({ userId: userId, isModerator: true })
-    .auth('admin', 'abc123')
-    .expect(200);
+  const res = await sendAdminPayload('chat/users/setmoderator', { userId: userId, isModerator: true });
   done();
 });
 
@@ -97,11 +94,7 @@ test('can disable a user', async (done) => {
     }
   );
 
-  await request
-    .post('/api/admin/chat/users/setenabled')
-    .send({ userId: userId, enabled: false })
-    .auth('admin', 'abc123')
-    .expect(200);
+  const res = await sendAdminPayload('chat/users/setenabled', { userId: userId, enabled: false });
 
   await new Promise((r) => setTimeout(r, 1500));
   done();
@@ -127,11 +120,7 @@ test('verify messages from user are hidden', async (done) => {
 });
 
 test('can re-enable a user', async (done) => {
-  await request
-    .post('/api/admin/chat/users/setenabled')
-    .send({ userId: userId, enabled: true })
-    .auth('admin', 'abc123')
-    .expect(200);
+  const res = await sendAdminPayload('chat/users/setenabled', { userId: userId, enabled: true });
   done();
 });
 

--- a/test/automated/api/chatusers.test.js
+++ b/test/automated/api/chatusers.test.js
@@ -8,7 +8,7 @@ const registerChat = require('./lib/chat').registerChat;
 const sendChatMessage = require('./lib/chat').sendChatMessage;
 const sendAdminRequest = require('./lib/admin').sendAdminRequest;
 const sendAdminPayload = require('./lib/admin').sendAdminPayload;
-const getAdminResponse= require('./lib/admin').getAdminResponse;
+const getAdminResponse = require('./lib/admin').getAdminResponse;
 
 
 const localIPAddressV4 = '127.0.0.1';
@@ -21,18 +21,18 @@ const testVisibilityMessage = {
 
 var userId;
 var accessToken;
-test('can register a user', async (done) => {
+test('register a user', async (done) => {
   const registration = await registerChat();
   userId = registration.id;
   accessToken = registration.accessToken;
   done();
 });
 
-test('can send a chat message', async (done) => {
+test('send a chat message', async (done) => {
   sendChatMessage(testVisibilityMessage, accessToken, done);
 });
 
-test('can set the user as moderator', async (done) => {
+test('set the user as moderator', async (done) => {
   const res = await sendAdminPayload('chat/users/setmoderator', { userId: userId, isModerator: true });
   done();
 });
@@ -54,10 +54,7 @@ test('verify user list is populated', async (done) => {
   );
 
   ws.on('open', async function open() {
-    const response = await request
-      .get('/api/admin/chat/clients')
-      .auth('admin', 'abc123')
-      .expect(200);
+    const response = await getAdminResponse('chat/clients');
 
     expect(response.body.length).toBeGreaterThan(0);
 
@@ -79,7 +76,7 @@ test('verify user list is populated', async (done) => {
   });
 });
 
-test('can disable a user', async (done) => {
+test('disable a user', async (done) => {
   // To allow for visually being able to see the test hiding the
   // message add a short delay.
   await new Promise((r) => setTimeout(r, 1500));
@@ -105,10 +102,7 @@ test('verify user is disabled', async (done) => {
 });
 
 test('verify messages from user are hidden', async (done) => {
-  const response = await request
-    .get('/api/admin/chat/messages')
-    .auth('admin', 'abc123')
-    .expect(200);
+  const response = await getAdminResponse('chat/messages');
   const message = response.body.filter((obj) => {
     return obj.user.id === userId;
   });
@@ -116,7 +110,7 @@ test('verify messages from user are hidden', async (done) => {
   done();
 });
 
-test('can re-enable a user', async (done) => {
+test('re-enable a user', async (done) => {
   const res = await sendAdminPayload('chat/users/setenabled', { userId: userId, enabled: true });
   done();
 });
@@ -161,7 +155,7 @@ test('verify IP address is no longer banned', async (done) => {
   done();
 });
 
-test('verify access is again allowed', async (done) => {
+test('verify access is allowed after unban', async (done) => {
   await request.get(`/api/chat?accessToken=${accessToken}`).expect(200);
   done();
 });

--- a/test/automated/api/configmanagement.test.js
+++ b/test/automated/api/configmanagement.test.js
@@ -3,8 +3,7 @@ var request = require('supertest');
 const Random = require('crypto-random');
 
 const sendAdminRequest = require('./lib/admin').sendAdminRequest;
-const getAdminConfig = require('./lib/admin').getAdminConfig;
-const getAdminStatus = require('./lib/admin').getAdminStatus;
+const getAdminResponse = require('./lib/admin').getAdminResponse;
 
 request = request('http://127.0.0.1:8080');
 
@@ -144,7 +143,7 @@ test('verify default config values', async (done) => {
 });
 
 test('verify default admin configuration', async (done) => {
-	const res = await getAdminConfig();
+	const res = await getAdminResponse('serverconfig');
 
 	expect(res.body.instanceDetails.name).toBe(defaultServerName);
 	expect(res.body.instanceDetails.summary).toBe(defaultServerSummary);
@@ -331,7 +330,7 @@ test('change admin password', async (done) => {
 });
 
 test('verify admin password change', async (done) => {
-	const res = await getAdminConfig((adminPassword = newAdminPassword));
+	const res = await getAdminResponse('serverconfig', (adminPassword = newAdminPassword));
 
 	expect(res.body.adminPassword).toBe(newAdminPassword);
 	done();
@@ -360,7 +359,7 @@ test('verify updated config values', async (done) => {
 
 // Test that the raw video details being broadcasted are coming through
 test('verify admin stream details', async (done) => {
-	const res = await getAdminStatus();
+	const res = await getAdminResponse('status');
 
 	expect(res.body.broadcaster.streamDetails.width).toBe(320);
 	expect(res.body.broadcaster.streamDetails.height).toBe(180);
@@ -373,7 +372,7 @@ test('verify admin stream details', async (done) => {
 });
 
 test('verify updated admin configuration', async (done) => {
-	const res = await getAdminConfig();
+	const res = await getAdminResponse('serverconfig');
 
 	expect(res.body.instanceDetails.name).toBe(newServerName);
 	expect(res.body.instanceDetails.summary).toBe(newServerSummary);

--- a/test/automated/api/configmanagement.test.js
+++ b/test/automated/api/configmanagement.test.js
@@ -2,7 +2,7 @@ var request = require('supertest');
 
 const Random = require('crypto-random');
 
-const sendConfigChangeRequest = require('./lib/admin').sendConfigChangeRequest;
+const sendAdminRequest = require('./lib/admin').sendAdminRequest;
 const getAdminConfig = require('./lib/admin').getAdminConfig;
 const getAdminStatus = require('./lib/admin').getAdminStatus;
 
@@ -181,37 +181,37 @@ test('verify default admin configuration', async (done) => {
 });
 
 test('set server name', async (done) => {
-	const res = await sendConfigChangeRequest('name', newServerName);
+	const res = await sendAdminRequest('config/name', newServerName);
 	done();
 });
 
 test('set stream title', async (done) => {
-	const res = await sendConfigChangeRequest('streamtitle', newStreamTitle);
+	const res = await sendAdminRequest('config/streamtitle', newStreamTitle);
 	done();
 });
 
 test('set server summary', async (done) => {
-	const res = await sendConfigChangeRequest('serversummary', newServerSummary);
+	const res = await sendAdminRequest('config/serversummary', newServerSummary);
 	done();
 });
 
 test('set extra page content', async (done) => {
-	const res = await sendConfigChangeRequest('pagecontent', newPageContent);
+	const res = await sendAdminRequest('config/pagecontent', newPageContent);
 	done();
 });
 
 test('set tags', async (done) => {
-	const res = await sendConfigChangeRequest('tags', newTags);
+	const res = await sendAdminRequest('config/tags', newTags);
 	done();
 });
 
 test('set stream keys', async (done) => {
-	const res = await sendConfigChangeRequest('streamkeys', newStreamKeys);
+	const res = await sendAdminRequest('config/streamkeys', newStreamKeys);
 	done();
 });
 
 test('set latency level', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'video/streamlatencylevel',
 		latencyLevel
 	);
@@ -219,24 +219,24 @@ test('set latency level', async (done) => {
 });
 
 test('set video stream output variants', async (done) => {
-	const res = await sendConfigChangeRequest('video/streamoutputvariants', [
+	const res = await sendAdminRequest('config/video/streamoutputvariants', [
 		streamOutputVariants,
 	]);
 	done();
 });
 
 test('set social handles', async (done) => {
-	const res = await sendConfigChangeRequest('socialhandles', newSocialHandles);
+	const res = await sendAdminRequest('config/socialhandles', newSocialHandles);
 	done();
 });
 
 test('set s3 configuration', async (done) => {
-	const res = await sendConfigChangeRequest('s3', newS3Config);
+	const res = await sendAdminRequest('config/s3', newS3Config);
 	done();
 });
 
 test('set forbidden usernames', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'chat/forbiddenusernames',
 		newForbiddenUsernames
 	);
@@ -244,7 +244,7 @@ test('set forbidden usernames', async (done) => {
 });
 
 test('set server url', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'serverurl',
 		newYPConfig.instanceUrl
 	);
@@ -252,7 +252,7 @@ test('set server url', async (done) => {
 });
 
 test('set federation username', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'federation/username',
 		newFederationConfig.username
 	);
@@ -260,7 +260,7 @@ test('set federation username', async (done) => {
 });
 
 test('set federation goLiveMessage', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'federation/livemessage',
 		newFederationConfig.goLiveMessage
 	);
@@ -268,7 +268,7 @@ test('set federation goLiveMessage', async (done) => {
 });
 
 test('toggle private federation mode', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'federation/private',
 		newFederationConfig.isPrivate
 	);
@@ -276,7 +276,7 @@ test('toggle private federation mode', async (done) => {
 });
 
 test('toggle federation engagement', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'federation/showengagement',
 		newFederationConfig.showEngagement
 	);
@@ -284,7 +284,7 @@ test('toggle federation engagement', async (done) => {
 });
 
 test('set federation blocked domains', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'federation/blockdomains',
 		newFederationConfig.blockedDomains
 	);
@@ -292,7 +292,7 @@ test('set federation blocked domains', async (done) => {
 });
 
 test('set offline message', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'offlinemessage',
 		newOfflineMessage
 	);
@@ -300,7 +300,7 @@ test('set offline message', async (done) => {
 });
 
 test('set hide viewer count', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'hideviewercount',
 		newHideViewerCount
 	);
@@ -308,17 +308,17 @@ test('set hide viewer count', async (done) => {
 });
 
 test('set custom style values', async (done) => {
-	const res = await sendConfigChangeRequest('appearance', appearanceValues);
+	const res = await sendAdminRequest('config/appearance', appearanceValues);
 	done();
 });
 
 test('enable directory', async (done) => {
-	const res = await sendConfigChangeRequest('directoryenabled', true);
+	const res = await sendAdminRequest('config/directoryenabled', true);
 	done();
 });
 
 test('enable federation', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'federation/enable',
 		newFederationConfig.enabled
 	);
@@ -326,7 +326,7 @@ test('enable federation', async (done) => {
 });
 
 test('change admin password', async (done) => {
-	const res = await sendConfigChangeRequest('adminpass', newAdminPassword);
+	const res = await sendAdminRequest('config/adminpass', newAdminPassword);
 	done();
 });
 
@@ -338,7 +338,7 @@ test('verify admin password change', async (done) => {
 });
 
 test('reset admin password', async (done) => {
-	const res = await sendConfigChangeRequest(
+	const res = await sendAdminRequest(
 		'adminpass',
 		defaultAdminPassword,
 		(adminPassword = newAdminPassword)

--- a/test/automated/api/configmanagement.test.js
+++ b/test/automated/api/configmanagement.test.js
@@ -212,7 +212,7 @@ test('set stream keys', async (done) => {
 
 test('set latency level', async (done) => {
 	const res = await sendAdminRequest(
-		'video/streamlatencylevel',
+		'config/video/streamlatencylevel',
 		latencyLevel
 	);
 	done();
@@ -237,7 +237,7 @@ test('set s3 configuration', async (done) => {
 
 test('set forbidden usernames', async (done) => {
 	const res = await sendAdminRequest(
-		'chat/forbiddenusernames',
+		'config/chat/forbiddenusernames',
 		newForbiddenUsernames
 	);
 	done();
@@ -245,7 +245,7 @@ test('set forbidden usernames', async (done) => {
 
 test('set server url', async (done) => {
 	const res = await sendAdminRequest(
-		'serverurl',
+		'config/serverurl',
 		newYPConfig.instanceUrl
 	);
 	done();
@@ -253,7 +253,7 @@ test('set server url', async (done) => {
 
 test('set federation username', async (done) => {
 	const res = await sendAdminRequest(
-		'federation/username',
+		'config/federation/username',
 		newFederationConfig.username
 	);
 	done();
@@ -261,7 +261,7 @@ test('set federation username', async (done) => {
 
 test('set federation goLiveMessage', async (done) => {
 	const res = await sendAdminRequest(
-		'federation/livemessage',
+		'config/federation/livemessage',
 		newFederationConfig.goLiveMessage
 	);
 	done();
@@ -269,7 +269,7 @@ test('set federation goLiveMessage', async (done) => {
 
 test('toggle private federation mode', async (done) => {
 	const res = await sendAdminRequest(
-		'federation/private',
+		'config/federation/private',
 		newFederationConfig.isPrivate
 	);
 	done();
@@ -277,7 +277,7 @@ test('toggle private federation mode', async (done) => {
 
 test('toggle federation engagement', async (done) => {
 	const res = await sendAdminRequest(
-		'federation/showengagement',
+		'config/federation/showengagement',
 		newFederationConfig.showEngagement
 	);
 	done();
@@ -285,7 +285,7 @@ test('toggle federation engagement', async (done) => {
 
 test('set federation blocked domains', async (done) => {
 	const res = await sendAdminRequest(
-		'federation/blockdomains',
+		'config/federation/blockdomains',
 		newFederationConfig.blockedDomains
 	);
 	done();
@@ -293,7 +293,7 @@ test('set federation blocked domains', async (done) => {
 
 test('set offline message', async (done) => {
 	const res = await sendAdminRequest(
-		'offlinemessage',
+		'config/offlinemessage',
 		newOfflineMessage
 	);
 	done();
@@ -301,7 +301,7 @@ test('set offline message', async (done) => {
 
 test('set hide viewer count', async (done) => {
 	const res = await sendAdminRequest(
-		'hideviewercount',
+		'config/hideviewercount',
 		newHideViewerCount
 	);
 	done();
@@ -319,7 +319,7 @@ test('enable directory', async (done) => {
 
 test('enable federation', async (done) => {
 	const res = await sendAdminRequest(
-		'federation/enable',
+		'config/federation/enable',
 		newFederationConfig.enabled
 	);
 	done();
@@ -339,7 +339,7 @@ test('verify admin password change', async (done) => {
 
 test('reset admin password', async (done) => {
 	const res = await sendAdminRequest(
-		'adminpass',
+		'config/adminpass',
 		defaultAdminPassword,
 		(adminPassword = newAdminPassword)
 	);

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -1,7 +1,7 @@
 var request = require('supertest');
 const jsonfile = require('jsonfile');
 const Ajv = require('ajv-draft-04');
-const sendConfigChangeRequest = require('./lib/admin').sendConfigChangeRequest;
+const sendAdminRequest = require('./lib/admin').sendAdminRequest;
 
 request = request('http://127.0.0.1:8080');
 
@@ -12,7 +12,7 @@ const serverURL = 'owncast.server.test'
 const fediUsername = 'streamer'
 
 test('disable federation', async (done) => {
-	const res = await sendConfigChangeRequest('federation/enable', false);
+	const res = await sendAdminRequest('config/federation/enable', false);
 	done();
 });
 
@@ -57,15 +57,15 @@ test('verify responses of /federation/ when federation is disabled', async (done
 });
 
 test('set required parameters and enable federation', async (done) => {
-	const res1 = await sendConfigChangeRequest(
+	const res1 = await sendAdminRequest(
 		'serverurl',
 		serverURL
 	);
-	const res2 = await sendConfigChangeRequest(
+	const res2 = await sendAdminRequest(
 		'federation/username',
 		fediUsername
 	);
-	const res3 = await sendConfigChangeRequest('federation/enable', true);
+	const res3 = await sendAdminRequest('config/federation/enable', true);
 	done();
 });
 

--- a/test/automated/api/federation.test.js
+++ b/test/automated/api/federation.test.js
@@ -58,11 +58,11 @@ test('verify responses of /federation/ when federation is disabled', async (done
 
 test('set required parameters and enable federation', async (done) => {
 	const res1 = await sendAdminRequest(
-		'serverurl',
+		'config/serverurl',
 		serverURL
 	);
 	const res2 = await sendAdminRequest(
-		'federation/username',
+		'config/federation/username',
 		fediUsername
 	);
 	const res3 = await sendAdminRequest('config/federation/enable', true);

--- a/test/automated/api/lib/admin.js
+++ b/test/automated/api/lib/admin.js
@@ -41,7 +41,7 @@ async function sendAdminPayload(
 		.send(payload)
 		.expect(200);
 
-	expect(res.body.success).toBe(true);
+	expect(res.body.success).not.toBe(false);
 
 	return res;
 }

--- a/test/automated/api/lib/admin.js
+++ b/test/automated/api/lib/admin.js
@@ -3,36 +3,10 @@ request = request('http://127.0.0.1:8080');
 
 const defaultAdminPassword = 'abc123';
 
-async function getAdminConfig(adminPassword = defaultAdminPassword) {
+async function getAdminResponse(endpoint, adminPassword = defaultAdminPassword) {
+	const url = '/api/admin/' + endpoint;
 	const res = request
-		.get('/api/admin/serverconfig')
-		.auth('admin', adminPassword)
-		.expect(200);
-
-	return res;
-}
-
-async function getAdminDisabledChatUsers(adminPassword = defaultAdminPassword) {
-	const res = request
-		.get('/api/admin/chat/users/disabled')
-		.auth('admin', adminPassword)
-		.expect(200);
-
-	return res;
-}
-
-async function getAdminBlockedChatIPs(adminPassword = defaultAdminPassword) {
-	const res = request
-		.get('/api/admin/chat/users/ipbans')
-		.auth('admin', adminPassword)
-		.expect(200);
-
-	return res;
-}
-
-async function getAdminStatus(adminPassword = defaultAdminPassword) {
-	const res = request
-		.get('/api/admin/status')
+		.get(url)
 		.auth('admin', adminPassword)
 		.expect(200);
 
@@ -72,9 +46,6 @@ async function sendAdminPayload(
 	return res;
 }
 
-module.exports.getAdminConfig = getAdminConfig;
-module.exports.getAdminStatus = getAdminStatus;
-module.exports.getAdminDisabledChatUsers = getAdminDisabledChatUsers;
-module.exports.getAdminBlockedChatIPs = getAdminBlockedChatIPs;
+module.exports.getAdminResponse = getAdminResponse;
 module.exports.sendAdminRequest = sendAdminRequest;
 module.exports.sendAdminPayload = sendAdminPayload;

--- a/test/automated/api/lib/admin.js
+++ b/test/automated/api/lib/admin.js
@@ -12,6 +12,24 @@ async function getAdminConfig(adminPassword = defaultAdminPassword) {
 	return res;
 }
 
+async function getAdminDisabledChatUsers(adminPassword = defaultAdminPassword) {
+	const res = request
+		.get('/api/admin/chat/users/disabled')
+		.auth('admin', adminPassword)
+		.expect(200);
+
+	return res;
+}
+
+async function getAdminBlockedChatIPs(adminPassword = defaultAdminPassword) {
+	const res = request
+		.get('/api/admin/chat/users/ipbans')
+		.auth('admin', adminPassword)
+		.expect(200);
+
+	return res;
+}
+
 async function getAdminStatus(adminPassword = defaultAdminPassword) {
 	const res = request
 		.get('/api/admin/status')
@@ -21,12 +39,12 @@ async function getAdminStatus(adminPassword = defaultAdminPassword) {
 	return res;
 }
 
-async function sendConfigChangeRequest(
+async function sendAdminRequest(
 	endpoint,
 	value,
 	adminPassword = defaultAdminPassword
 ) {
-	const url = '/api/admin/config/' + endpoint;
+	const url = '/api/admin/' + endpoint;
 	const res = await request
 		.post(url)
 		.auth('admin', adminPassword)
@@ -37,12 +55,12 @@ async function sendConfigChangeRequest(
 	return res;
 }
 
-async function sendConfigChangePayload(
+async function sendAdminPayload(
 	endpoint,
 	payload,
 	adminPassword = defaultAdminPassword
 ) {
-	const url = '/api/admin/config/' + endpoint;
+	const url = '/api/admin/' + endpoint;
 	const res = await request
 		.post(url)
 		.auth('admin', adminPassword)
@@ -56,5 +74,7 @@ async function sendConfigChangePayload(
 
 module.exports.getAdminConfig = getAdminConfig;
 module.exports.getAdminStatus = getAdminStatus;
-module.exports.sendConfigChangeRequest = sendConfigChangeRequest;
-module.exports.sendConfigChangePayload = sendConfigChangePayload;
+module.exports.getAdminDisabledChatUsers = getAdminDisabledChatUsers;
+module.exports.getAdminBlockedChatIPs = getAdminBlockedChatIPs;
+module.exports.sendAdminRequest = sendAdminRequest;
+module.exports.sendAdminPayload = sendAdminPayload;


### PR DESCRIPTION
- ban and un-ban both ipv4 and ipv6 of localhost (without explicit un-banning the ipv6 loopback, some tests afterwards may fail) [see #2415]
- cleanup the tests and use `test/automated/api/lib/admin.js` functions for admin API requests