### PR TITLE
do not triger bundle web app on documentaion update

### DIFF
--- a/.github/workflows/bundle-web.yml
+++ b/.github/workflows/bundle-web.yml
@@ -5,7 +5,9 @@ on:
       - webv2
       - develop
     paths:
-      - web/**
+      - 'web/**'
+    paths-ignore:
+      - '**.md'  
 
 jobs:
   bundle:


### PR DESCRIPTION
next.js build is currently not reproducible. this patch prevents it from being triggered when markdown (documentation) files are changed.