### PR TITLE
Use bcrypt hash comparisons for streaming key (#2495)

### DIFF
--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nareix/joy5/format/flv/flvio"
 	"github.com/owncast/owncast/models"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const unknownString = "Unknown"
@@ -80,7 +81,7 @@ func getVideoCodec(codec interface{}) string {
 	return unknownString
 }
 
-func secretMatch(configStreamKey string, path string) bool {
+func secretMatch(configStreamKeyHash []byte, path string) bool {
 	prefix := "/live/"
 
 	if !strings.HasPrefix(path, prefix) {
@@ -88,6 +89,11 @@ func secretMatch(configStreamKey string, path string) bool {
 		return false // We need the path to begin with $prefix
 	}
 
-	streamingKey := path[len(prefix):] // Remove $prefix
-	return streamingKey == configStreamKey
+	streamingKey := []byte(path[len(prefix):]) // Remove $prefix
+
+	result := bcrypt.CompareHashAndPassword(configStreamKeyHash, streamingKey)
+	if result != nil {
+		log.Debugf("Error comparing streaming key: %s", result)
+	}
+	return result == nil
 }

--- a/core/rtmp/utils_test.go
+++ b/core/rtmp/utils_test.go
@@ -1,6 +1,10 @@
 package rtmp
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
 
 func Test_secretMatch(t *testing.T) {
 	tests := []struct {
@@ -27,7 +31,11 @@ func Test_secretMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := secretMatch(tt.streamKey, tt.path); got != tt.want {
+			streamKeyHash, err := bcrypt.GenerateFromPassword([]byte(tt.streamKey), bcrypt.DefaultCost)
+			if err != nil {
+				t.Errorf("bcrypt.GenerateFromPassword returned err: %s", err)
+			}
+			if got := secretMatch(streamKeyHash, tt.path); got != tt.want {
 				t.Errorf("secretMatch() = %v, want %v", got, tt.want)
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/net v0.4.0
 	golang.org/x/sys v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+Wr
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
+golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
The streaming key comparison was previously using the `==` operator between a plaintext version of the streaming key and the one configured and stored.  This comparison exposes the possibility of a time-based attack for discovering the streaming key (see issue #2489).

Project contributor @MFTabriz noted that a better solution would be to use bcrypt and compare hashes.  This commit switches the comparison over to it.