### PR TITLE
hide user name in user dropdown on mobile

### DIFF
--- a/web/components/common/UserDropdown/UserDropdown.module.scss
+++ b/web/components/common/UserDropdown/UserDropdown.module.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/mixins.scss';
+
 .root {
   button {
     border: none;
@@ -7,4 +9,18 @@
 			}
 		}
   }
+  .userIcon {
+	@include screen(desktop) {
+		margin-right: .5rem;
+	}
+  }
+
+  .username {
+	  display: none;
+  
+	  @include screen(desktop) {
+		  display: inline;
+	  }
+  }
 }
+

--- a/web/components/common/UserDropdown/UserDropdown.tsx
+++ b/web/components/common/UserDropdown/UserDropdown.tsx
@@ -1,4 +1,4 @@
-import { Menu, Dropdown, Button, Space } from 'antd';
+import { Menu, Dropdown, Button } from 'antd';
 import {
   CaretDownOutlined,
   EditOutlined,
@@ -83,11 +83,11 @@ export const UserDropdown: FC<UserDropdownProps> = ({ username: defaultUsername 
   return (
     <div id="user-menu" className={`${styles.root}`}>
       <Dropdown overlay={menu} trigger={['click']}>
-        <Button type="primary" icon={<UserOutlined style={{ marginRight: '.5rem' }} />}>
-          <Space>
+        <Button type="primary" icon={<UserOutlined className={styles.userIcon} />}>
+          <span className={styles.username}>
             {username}
-            <CaretDownOutlined />
-          </Space>
+          </span>
+          <CaretDownOutlined />
         </Button>
       </Dropdown>
       <Modal

--- a/web/components/common/UserDropdown/UserDropdown.tsx
+++ b/web/components/common/UserDropdown/UserDropdown.tsx
@@ -84,9 +84,7 @@ export const UserDropdown: FC<UserDropdownProps> = ({ username: defaultUsername 
     <div id="user-menu" className={`${styles.root}`}>
       <Dropdown overlay={menu} trigger={['click']}>
         <Button type="primary" icon={<UserOutlined className={styles.userIcon} />}>
-          <span className={styles.username}>
-            {username}
-          </span>
+          <span className={styles.username}>{username}</span>
           <CaretDownOutlined />
         </Button>
       </Dropdown>

--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -35,6 +35,7 @@
       text-overflow: ellipsis;
       width: 70vw;
       overflow: hidden;
+      line-height: 1.4;
     }
   }
 }

--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -33,7 +33,8 @@
       font-weight: 600;
       white-space: nowrap;
       text-overflow: ellipsis;
-      max-width: 90%;
+      width: 70vw;
+      overflow: hidden;
     }
   }
 }

--- a/web/components/ui/Header/Header.tsx
+++ b/web/components/ui/Header/Header.tsx
@@ -23,7 +23,7 @@ export const Header: FC<HeaderComponentProps> = ({
       <div id="header-logo" className={styles.logoImage}>
         <OwncastLogo variant="contrast" />
       </div>
-      <h1 className={styles.title} id="global-header-text">
+      <h1 className={styles.title} id="global-header-text" title={name}>
         {name}
       </h1>
     </div>


### PR DESCRIPTION
### This PR closes the following issue:

closes https://github.com/owncast/owncast/issues/2497

### Changes made:

- hide user name label on mobile
- apply styles for user icon only on desktop

### Storybook
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13103896/209582763-9724f150-338a-43ca-ad3b-e01e4356d469.png">

### App
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13103896/209582909-b9c24e9a-dd85-4bfb-9d57-24bf852dcf1e.png">

