### PR TITLE
Migrate to hashed password/key store (#2489)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ var BuildPlatform = "dev"
 var EnableAutoUpdate = false
 
 // A temporary stream key that can be set via the command line.
-var TemporaryStreamKey = ""
+var TemporaryStreamKey []byte = nil
 
 // GetCommit will return an identifier used for identifying the point in time this build took place.
 func GetCommit() string {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/owncast/owncast/models"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Defaults will hold default configuration values.
@@ -20,8 +21,6 @@ type Defaults struct {
 	WebServerPort    int
 	WebServerIP      string
 	RTMPServerPort   int
-	AdminPassword    string
-	StreamKeys       []models.StreamKey
 
 	YPEnabled bool
 	YPServer  string
@@ -37,16 +36,12 @@ type Defaults struct {
 }
 
 // GetDefaults will return default configuration values.
-func GetDefaults() Defaults {
-	return Defaults{
+func GetDefaults() *Defaults {
+	return &Defaults{
 		Name:                 "New Owncast Server",
 		Summary:              "This is a new live video streaming server powered by Owncast.",
 		ServerWelcomeMessage: "",
 		Logo:                 "logo.svg",
-		AdminPassword:        "abc123",
-		StreamKeys: []models.StreamKey{
-			{Key: "abc123", Comment: "Default stream key"},
-		},
 		Tags: []string{
 			"owncast",
 			"streaming",
@@ -91,4 +86,23 @@ func GetDefaults() Defaults {
 		FederationUsername:      "streamer",
 		FederationGoLiveMessage: "I've gone live!",
 	}
+}
+
+func (d *Defaults) GetAdminPasswordHash() ([]byte, error) {
+	return d.getDefaultPasswordHash()
+}
+
+func (d *Defaults) GetStreamKeysHashed() ([]models.StreamKeyHashed, error) {
+	hash, err := d.getDefaultPasswordHash()
+	if err != nil {
+		return nil, err
+	}
+	return []models.StreamKeyHashed{
+		{Key: hash, Comment: "default stream key"},
+	}, nil
+}
+
+func (d *Defaults) getDefaultPasswordHash() ([]byte, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte("abc123"), bcrypt.DefaultCost)
+	return hash, err
 }

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -208,7 +208,7 @@ func SetAdminPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := data.SetAdminPassword(configValue.Value.(string)); err != nil {
+	if err := data.SetAdminPasswordPlainText(configValue.Value.(string)); err != nil {
 		controllers.WriteSimpleResponse(w, false, err.Error())
 		return
 	}
@@ -775,7 +775,7 @@ func SetStreamKeys(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type streamKeysRequest struct {
-		Value []models.StreamKey `json:"value"`
+		Value []models.StreamKeyPlainText `json:"value"`
 	}
 
 	decoder := json.NewDecoder(r.Body)
@@ -785,7 +785,7 @@ func SetStreamKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := data.SetStreamKeys(streamKeys.Value); err != nil {
+	if err := data.SetStreamKeysPlainText(streamKeys.Value); err != nil {
 		controllers.WriteSimpleResponse(w, false, err.Error())
 		return
 	}

--- a/controllers/admin/serverConfig.go
+++ b/controllers/admin/serverConfig.go
@@ -49,8 +49,6 @@ func GetServerConfig(w http.ResponseWriter, r *http.Request) {
 			AppearanceVariables: data.GetCustomColorVariableValues(),
 		},
 		FFmpegPath:              ffmpeg,
-		AdminPassword:           data.GetAdminPassword(),
-		StreamKeys:              data.GetStreamKeys(),
 		WebServerPort:           config.WebServerPort,
 		WebServerIP:             config.WebServerIP,
 		RTMPServerPort:          data.GetRTMPPortNumber(),
@@ -99,8 +97,6 @@ func GetServerConfig(w http.ResponseWriter, r *http.Request) {
 type serverConfigAdminResponse struct {
 	InstanceDetails         webConfigResponse           `json:"instanceDetails"`
 	FFmpegPath              string                      `json:"ffmpegPath"`
-	AdminPassword           string                      `json:"adminPassword"`
-	StreamKeys              []models.StreamKey          `json:"streamKeys"`
 	WebServerPort           int                         `json:"webServerPort"`
 	WebServerIP             string                      `json:"webServerIP"`
 	RTMPServerPort          int                         `json:"rtmpServerPort"`

--- a/core/data/configEntry.go
+++ b/core/data/configEntry.go
@@ -33,6 +33,13 @@ func (c *ConfigEntry) getString() (string, error) {
 	return result, err
 }
 
+func (c *ConfigEntry) getByteSlice() ([]byte, error) {
+	decoder := c.getDecoder()
+	var result []byte
+	err := decoder.Decode(&result)
+	return result, err
+}
+
 func (c *ConfigEntry) getNumber() (float64, error) {
 	decoder := c.getDecoder()
 	var result float64

--- a/core/data/datastoreMigrations.go
+++ b/core/data/datastoreMigrations.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/owncast/owncast/models"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -56,8 +57,9 @@ func migrateToDatastoreValues1(datastore *Datastore) {
 
 func migrateToDatastoreValues2(datastore *Datastore) {
 	oldAdminPassword, _ := datastore.GetString("stream_key")
-	_ = SetAdminPassword(oldAdminPassword)
-	_ = SetStreamKeys([]models.StreamKey{
-		{Key: oldAdminPassword, Comment: "Default stream key"},
+	oldAdminPasswordHash, _ := bcrypt.GenerateFromPassword([]byte(oldAdminPassword), bcrypt.DefaultCost)
+	_ = SetAdminPasswordHashed(oldAdminPasswordHash)
+	_ = SetStreamKeysHashed([]models.StreamKeyHashed{
+		{Key: oldAdminPasswordHash, Comment: "Default stream key"},
 	})
 }

--- a/core/data/defaults.go
+++ b/core/data/defaults.go
@@ -23,17 +23,27 @@ func hasPopulatedFederationDefaults() bool {
 }
 
 // PopulateDefaults will set default values in the database.
-func PopulateDefaults() {
+func PopulateDefaults() error {
 	_datastore.warmCache()
 
 	defaults := config.GetDefaults()
 
 	if HasPopulatedDefaults() {
-		return
+		return nil
 	}
 
-	_ = SetAdminPassword(defaults.AdminPassword)
-	_ = SetStreamKeys(defaults.StreamKeys)
+	hashedAdminPassword, err := defaults.GetAdminPasswordHash()
+	if err != nil {
+		return err
+	}
+
+	streamKeys, err := defaults.GetStreamKeysHashed()
+	if err != nil {
+		return err
+	}
+
+	_ = SetAdminPasswordHashed(hashedAdminPassword)
+	_ = SetStreamKeysHashed(streamKeys)
 	_ = SetHTTPPortNumber(float64(defaults.WebServerPort))
 	_ = SetRTMPPortNumber(float64(defaults.RTMPServerPort))
 	_ = SetLogoPath(defaults.Logo)
@@ -51,4 +61,5 @@ func PopulateDefaults() {
 	})
 
 	_ = _datastore.SetBool("HAS_POPULATED_DEFAULTS", true)
+	return nil
 }

--- a/core/data/types.go
+++ b/core/data/types.go
@@ -30,6 +30,22 @@ func (ds *Datastore) SetString(key string, value string) error {
 	return ds.Save(configEntry)
 }
 
+// GetByteSlice will return the byte slice value for a key
+func (ds *Datastore) GetByteSlice(key string) ([]byte, error) {
+	configEntry, err := ds.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return configEntry.getByteSlice()
+}
+
+// SetByteSlice will set the byte slice value for a key
+func (ds *Datastore) SetByteSlice(key string, value []byte) error {
+	configEntry := ConfigEntry{key, value}
+	return ds.Save(configEntry)
+}
+
 // GetNumber will return the numeric value for a key.
 func (ds *Datastore) GetNumber(key string) (float64, error) {
 	configEntry, err := ds.Get(key)

--- a/core/rtmp/rtmp.go
+++ b/core/rtmp/rtmp.go
@@ -79,7 +79,7 @@ func HandleConn(c *rtmp.Conn, nc net.Conn) {
 	}
 
 	accessGranted := false
-	validStreamingKeys := data.GetStreamKeys()
+	validStreamingKeys := data.GetStreamKeysHashed()
 
 	for _, key := range validStreamingKeys {
 		if secretMatch(key.Key, c.URL.Path) {
@@ -89,7 +89,7 @@ func HandleConn(c *rtmp.Conn, nc net.Conn) {
 	}
 
 	// Test against the temporary key if it was set at runtime.
-	if config.TemporaryStreamKey != "" && secretMatch(config.TemporaryStreamKey, c.URL.Path) {
+	if config.TemporaryStreamKey != nil && secretMatch(config.TemporaryStreamKey, c.URL.Path) {
 		accessGranted = true
 	}
 

--- a/core/rtmp/utils.go
+++ b/core/rtmp/utils.go
@@ -1,7 +1,6 @@
 package rtmp
 
 import (
-	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"github.com/nareix/joy5/format/flv/flvio"
 	"github.com/owncast/owncast/models"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const unknownString = "Unknown"
@@ -81,7 +81,7 @@ func getVideoCodec(codec interface{}) string {
 	return unknownString
 }
 
-func secretMatch(configStreamKey string, path string) bool {
+func secretMatch(configStreamKeyHashed []byte, path string) bool {
 	prefix := "/live/"
 
 	if !strings.HasPrefix(path, prefix) {
@@ -91,6 +91,6 @@ func secretMatch(configStreamKey string, path string) bool {
 
 	streamingKey := path[len(prefix):] // Remove $prefix
 
-	matches := subtle.ConstantTimeCompare([]byte(streamingKey), []byte(configStreamKey)) == 1
-	return matches
+	cmpErr := bcrypt.CompareHashAndPassword(configStreamKeyHashed, []byte(streamingKey))
+	return cmpErr == nil
 }

--- a/core/rtmp/utils_test.go
+++ b/core/rtmp/utils_test.go
@@ -1,6 +1,10 @@
 package rtmp
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
 
 func Test_secretMatch(t *testing.T) {
 	tests := []struct {
@@ -26,8 +30,12 @@ func Test_secretMatch(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		hash, err := bcrypt.GenerateFromPassword([]byte(tt.streamKey), bcrypt.DefaultCost)
+		if err != nil {
+			t.Errorf("Failed to generate hash for streaming key: %s", err)
+		}
 		t.Run(tt.name, func(t *testing.T) {
-			if got := secretMatch(tt.streamKey, tt.path); got != tt.want {
+			if got := secretMatch(hash, tt.path); got != tt.want {
 				t.Errorf("secretMatch() = %v, want %v", got, tt.want)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/owncast/owncast/logging"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/core"
@@ -112,7 +113,7 @@ func main() {
 
 func handleCommandLineFlags() {
 	if *newAdminPassword != "" {
-		if err := data.SetAdminPassword(*newAdminPassword); err != nil {
+		if err := data.SetAdminPasswordPlainText(*newAdminPassword); err != nil {
 			log.Errorln("Error setting your admin password.", err)
 			log.Exit(1)
 		} else {
@@ -121,8 +122,13 @@ func handleCommandLineFlags() {
 	}
 
 	if *newStreamKey != "" {
+		hash, err := bcrypt.GenerateFromPassword([]byte(*newStreamKey), bcrypt.DefaultCost)
+		if err == nil {
+			log.Errorln("Error setting your temporary streaming key.", err)
+			log.Exit(1)
+		}
 		log.Println("Temporary stream key is set for this session.")
-		config.TemporaryStreamKey = *newStreamKey
+		config.TemporaryStreamKey = hash
 	}
 
 	// Set the web server port

--- a/models/streamKeyHashed.go
+++ b/models/streamKeyHashed.go
@@ -1,7 +1,7 @@
 package models
 
 // StreamKey represents a single stream key.
-type StreamKey struct {
-	Key     string `json:"key"`
+type StreamKeyHashed struct {
+	Key     []byte `json:"key"`
 	Comment string `json:"comment"`
 }

--- a/models/streamKeyPlainText.go
+++ b/models/streamKeyPlainText.go
@@ -1,0 +1,7 @@
+package models
+
+// StreamKey represents a single stream key.
+type StreamKeyPlainText struct {
+	Key     string `json:"key"`
+	Comment string `json:"comment"`
+}


### PR DESCRIPTION
In order to improve Owncast security, the admin password and stream keys are no longer being stored in plaintext, instead using a standard cryptographic hashing process to store them securely.

This commit not only moves the admin password to storage as a hash, but also splits the StreamKey model into StreamKeyPlainText and StreamKeyHashed to make it clear when, where, and how a stream key is being used in its plaintext and hashed forms.  Attempting to store a plaintext key to the database will automatically hash it.

Since it is no longer possible to send the plaintext admin password and streaming keys to the web UI, they have been removed from the relevant HTTP response objects.