### PR TITLE
add Github actions linter to Github actions

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - webv2
+    paths:
+      - '.github/workflows/*.yml'
+  pull_request:
+    branches:
+      - webv2
+    paths:
+      - '.github/workflows/*.yml'
+
+jobs:
+  actionlint:
+    name: GitHub actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker://rhysd/actionlint:latest
+        with:
+          args: -shellcheck= -color

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - webv2
     paths:
-      - '.github/workflows/*.yml'
+      - '.github/workflows/*'
   pull_request:
     branches:
       - webv2
     paths:
-      - '.github/workflows/*.yml'
+      - '.github/workflows/*'
 
 jobs:
   actionlint:

--- a/.github/workflows/javascript-formatting.yml
+++ b/.github/workflows/javascript-formatting.yml
@@ -61,7 +61,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
-          pull: --rebase --autostash
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
Actions linter [can detect](https://github.com/owncast/owncast/actions/runs/3795210886/jobs/6454100649) issues like [this](https://github.com/owncast/owncast/pull/2496#discussion_r1058041380). It also detects if any of the workflows are invalid (github does not report this in PR pages)