### PR TITLE
fix Notify Reminder Popup Design

### DIFF
--- a/web/components/ui/NotifyReminderPopup/NotifyReminderPopup.tsx
+++ b/web/components/ui/NotifyReminderPopup/NotifyReminderPopup.tsx
@@ -33,7 +33,7 @@ export const NotifyReminderPopup: FC<NotifyReminderPopupProps> = ({
     cursor: 'pointer',
     paddingTop: '10px',
     paddingRight: '10px',
-    fontSize: '16px',
+    fontSize: '14px',
   };
 
   const popupClicked = e => {
@@ -63,7 +63,7 @@ export const NotifyReminderPopup: FC<NotifyReminderPopupProps> = ({
   return (
     mounted && (
       <Popover
-        placement="topLeft"
+        placement="topRight"
         defaultOpen={openPopup}
         open={openPopup}
         destroyTooltipOnHide


### PR DESCRIPTION
This PR fixes the Notify Reminder Popup design issue (the issue #2358 ), which occurred after the inner scrolling problem fix. To solve this issue, I changed the text font size inside the popup from 16 px to 14 px because "getPopupContainer={node => node}" increased the font size somehow. Also, I changed the placement of this popup from "topLeft" to "topRight" because occasionally this popup shows up behind the chat window and causes the overflow issue.  

this screenshot demonstrates the overflow and increased font size issues:

![Screen Shot 2022-12-29 at 12 33 42 PM](https://user-images.githubusercontent.com/26856199/209951918-dee30b09-13b2-49ed-a7de-aa0f4631647e.png)

this screenshot demonstrates how they have been fixed:

![Screen Shot 2022-12-29 at 1 39 45 PM](https://user-images.githubusercontent.com/26856199/209952369-e79f8d96-edf9-4064-830b-f482d587aca6.png)




 
