### PR TITLE
wrap promise response in set timeout to keep local state in sync

### DIFF
--- a/web/components/config/EditLogo.tsx
+++ b/web/components/config/EditLogo.tsx
@@ -71,7 +71,7 @@ export const EditLogo: FC = () => {
 
       getBase64(file, (url: string) => {
         setlogoUrl(url);
-        return res();
+        setTimeout(() => res(), 100);
       });
     });
   };
@@ -80,7 +80,6 @@ export const EditLogo: FC = () => {
   const handleLogoUpdate = async () => {
     if (logoUrl !== currentLogo) {
       setSubmitStatus(createInputStatus(STATUS_PROCESSING));
-
       await postConfigUpdateToAPI({
         apiPath,
         data: { value: logoUrl },

--- a/web/utils/images.ts
+++ b/web/utils/images.ts
@@ -1,5 +1,3 @@
-import { RcFile } from 'antd/lib/upload';
-
 export const MAX_IMAGE_FILESIZE = 2097152;
 export const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif'];
 


### PR DESCRIPTION
This PR closes https://github.com/owncast/owncast/issues/2524

### Changes made
- wrap respone into a `setTimeout` in `beforeUpload` hook to keep local state in sync

It works every time now, but I'm not pleased with this solution. I couldn't figure out a better way to solve this. The root cause of the flakiness is that the local state (`const [logoUrl, setlogoUrl] = useState(null);`) is not updated at that time when the customRequest (`handleLogoUpdate`) function is fired.

Maybe we can find a better solution here. 🥲