### PR TITLE
cleanup automated tests for public dir

### DIFF
--- a/test/automated/api/publicstatic.test.js
+++ b/test/automated/api/publicstatic.test.js
@@ -3,29 +3,60 @@ request = request('http://127.0.0.1:8080');
 const fs = require('fs');
 const path = require('path');
 
+const publicPath = path.resolve(__dirname, '../../../public');
+const filename = randomString(20) + '.txt';
+const fileContent = randomString(8);
+
+
+test('random public static file does not exist', async (done) => {
+	request.get('/public/' + filename).expect(404);
+
+	done();
+});
+
+test('public directory is writable', async (done) => {
+
+	try {
+		writeFileToPublic();
+	} catch (err) {
+		if (err) {
+			if (err.code === "ENOENT") { // path does not exist
+				fs.mkdirSync(publicPath);
+				writeFileToPublic();
+			} else {
+				throw err;
+			}
+		}
+	}
+
+	done();
+});
+
+test('public static file is accessible', async (done) => {
+
+	request.get('/public/' + filename).expect(200).then((res) => {
+		expect(res.text).toEqual(fileContent);
+		done();
+	});
+
+});
+
+test('public static file is persistent and not locked', async (done) => {
+
+	fs.unlink(path.join(publicPath, filename), (err) => {
+		if (err) { throw err; }
+	});
+	done();
+});
+
+
 function randomString(length) {
-	return Math.random().toString(36).substring(length);
+	return Math.random().toString(36).substr(2, length);
 }
 
-const filename = `${randomString(20)}.txt`;
-
-test('public static file should not exist', async (done) => {
-	await request.get(`/public/${filename}`).expect(404);
-
-	done();
-});
-
-test('public static file should exist', async (done) => {
-	// make public static files directory
-	try {
-		fs.mkdirSync(path.join(__dirname, '../../../public/'));
-		fs.writeFileSync(
-			path.join(__dirname, `../../../public/${filename}`),
-			'hello world'
-		);
-	} catch (e) {}
-
-	await request.get(`/public/${filename}`).expect(200);
-
-	done();
-});
+function writeFileToPublic() {
+	fs.writeFileSync(
+		path.join(publicPath, filename),
+		fileContent
+	);
+  }


### PR DESCRIPTION
- fix `randomString()`
- do not suppress unhandled errors
- create public directory if it does not exist
- validate content of server response
- remove the temporary file after the tests