### PR TITLE
Fix twitter save button 2534

### DIFF
--- a/web/components/config/notification/twitter.tsx
+++ b/web/components/config/notification/twitter.tsx
@@ -53,18 +53,10 @@ export const ConfigNotify = () => {
   }, [twitter]);
 
   const canSave = (): boolean => {
-    const {
-      enabled,
-      apiKey,
-      apiSecret,
-      accessToken,
-      accessTokenSecret,
-      bearerToken,
-      goLiveMessage,
-    } = formDataValues;
+    const { apiKey, apiSecret, accessToken, accessTokenSecret, bearerToken, goLiveMessage } =
+      formDataValues;
 
     return (
-      enabled &&
       !!apiKey &&
       !!apiSecret &&
       !!accessToken &&


### PR DESCRIPTION
- [ ] Closes #2534

This updates the logic of the canSave method in twitter.tsx file to allow saving regardless of enabled's value.

https://user-images.githubusercontent.com/44574494/210133252-abf92113-c8c6-4a40-8c03-8d4fb9a968ae.mov

