### PR TITLE
Add `initiallyMuted` query parameter to embed player

### DIFF
--- a/web/components/video/OwncastPlayer/OwncastPlayer.tsx
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.tsx
@@ -24,6 +24,7 @@ let latencyCompensatorEnabled = false;
 export type OwncastPlayerProps = {
   source: string;
   online: boolean;
+  initiallyMuted?: boolean;
 };
 
 async function getVideoSettings() {
@@ -38,7 +39,11 @@ async function getVideoSettings() {
   return qualities;
 }
 
-export const OwncastPlayer: FC<OwncastPlayerProps> = ({ source, online }) => {
+export const OwncastPlayer: FC<OwncastPlayerProps> = ({
+  source,
+  online,
+  initiallyMuted = false,
+}) => {
   const playerRef = React.useRef(null);
   const [videoPlaying, setVideoPlaying] = useRecoilState<boolean>(isVideoPlayingAtom);
   const clockSkew = useRecoilValue<Number>(clockSkewAtom);
@@ -215,6 +220,7 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({ source, online }) => {
     playsinline: true,
     liveui: true,
     preload: 'auto',
+    muted: initiallyMuted,
     controlBar: {
       progressControl: {
         seekBar: false,

--- a/web/components/video/OwncastPlayer/OwncastPlayer.tsx
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { useHotkeys } from 'react-hotkeys-hook';
+import { VideoJsPlayerOptions } from 'video.js';
 import { VideoJS } from '../VideoJS/VideoJS';
 import ViewerPing from '../viewer-ping';
 import { VideoPoster } from '../VideoPoster/VideoPoster';
@@ -245,7 +246,7 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
         type: 'application/x-mpegURL',
       },
     ],
-  };
+  } satisfies VideoJsPlayerOptions;
 
   const handlePlayerReady = (player, videojs) => {
     playerRef.current = player;

--- a/web/components/video/VideoJS/VideoJS.tsx
+++ b/web/components/video/VideoJS/VideoJS.tsx
@@ -1,17 +1,17 @@
 import React, { FC } from 'react';
-import videojs from 'video.js';
+import videojs, { VideoJsPlayer, VideoJsPlayerOptions } from 'video.js';
 import styles from './VideoJS.module.scss';
 
 require('video.js/dist/video-js.css');
 
 export type VideoJSProps = {
-  options: any;
-  onReady: (player: videojs.Player, vjsInstance: videojs) => void;
+  options: VideoJsPlayerOptions;
+  onReady: (player: videojs.Player, vjsInstance: typeof videojs) => void;
 };
 
 export const VideoJS: FC<VideoJSProps> = ({ options, onReady }) => {
-  const videoRef = React.useRef(null);
-  const playerRef = React.useRef(null);
+  const videoRef = React.useRef<HTMLVideoElement | null>(null);
+  const playerRef = React.useRef<VideoJsPlayer | null>(null);
 
   React.useEffect(() => {
     // Make sure Video.js player is only initialized once
@@ -19,7 +19,7 @@ export const VideoJS: FC<VideoJSProps> = ({ options, onReady }) => {
       const videoElement = videoRef.current;
 
       // eslint-disable-next-line no-multi-assign
-      const player = (playerRef.current = videojs(videoElement, options, () => {
+      const player: VideoJsPlayer = (playerRef.current = videojs(videoElement, options, () => {
         console.debug('player is ready');
         return onReady && onReady(player, videojs);
       }));

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -79,6 +79,7 @@
 				"@types/react": "18.0.26",
 				"@types/react-linkify": "1.0.1",
 				"@types/ua-parser-js": "0.7.36",
+				"@types/video.js": "^7.3.50",
 				"@typescript-eslint/eslint-plugin": "5.47.1",
 				"@typescript-eslint/parser": "5.47.1",
 				"babel-loader": "9.1.0",
@@ -11972,6 +11973,12 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
 			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+		},
+		"node_modules/@types/video.js": {
+			"version": "7.3.50",
+			"resolved": "https://registry.npmjs.org/@types/video.js/-/video.js-7.3.50.tgz",
+			"integrity": "sha512-xG0xoeyLGuWhtWMBBLRVhTEOfT2n6AjhNoWhFWVbpa6A8hSMi4eNvttuHYXsn6NslITu7IUdKPDRQ2bAWgXKDA==",
+			"dev": true
 		},
 		"node_modules/@types/webpack": {
 			"version": "4.41.33",

--- a/web/package.json
+++ b/web/package.json
@@ -83,6 +83,7 @@
 		"@types/react": "18.0.26",
 		"@types/react-linkify": "1.0.1",
 		"@types/ua-parser-js": "0.7.36",
+		"@types/video.js": "^7.3.50",
 		"@typescript-eslint/eslint-plugin": "5.47.1",
 		"@typescript-eslint/parser": "5.47.1",
 		"babel-loader": "9.1.0",

--- a/web/stories/VideoEmbed.stories.tsx
+++ b/web/stories/VideoEmbed.stories.tsx
@@ -1,0 +1,69 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+const Template = ({
+  origin,
+  query,
+  title,
+  width,
+  height,
+}: {
+  origin: string;
+  query: string;
+  title: string;
+  width: number;
+  height: number;
+}) => (
+  <iframe
+    src={`${origin}/embed/video?${query}`}
+    title={title}
+    height={`${height}px`}
+    width={`${width}px`}
+    referrerPolicy="origin"
+    scrolling="no"
+    allowFullScreen
+  />
+);
+
+const origins = {
+  DemoServer: `https://watch.owncast.online`,
+  RetroStrangeTV: `https://live.retrostrange.com`,
+  localhost: `http://localhost:3000`,
+};
+
+export default {
+  title: 'owncast/Player/Embeds',
+  component: Template,
+  argTypes: {
+    origin: {
+      options: Object.keys(origins),
+      mapping: origins,
+      control: {
+        type: 'select',
+      },
+      defaultValue: origins.DemoServer,
+    },
+    query: {
+      type: 'string',
+    },
+    title: {
+      defaultValue: 'My Title',
+      type: 'string',
+    },
+    height: {
+      defaultValue: 350,
+      type: 'number',
+    },
+    width: {
+      defaultValue: 550,
+      type: 'number',
+    },
+  },
+} satisfies ComponentMeta<typeof Template>;
+
+export const Default: ComponentStory<typeof Template> = Template.bind({});
+Default.args = {};
+
+export const InitiallyMuted: ComponentStory<typeof Template> = Template.bind({});
+InitiallyMuted.args = {
+  query: 'initiallyMuted=true',
+};


### PR DESCRIPTION
This PR introduces a new `initiallyMuted` query parameter that can be added to the embed URL. If set to exactly `true`, the video will be muted once it is played. It can still be unmuted manually.

This behavior can be observed in the newly added `Player/Embeds` stories. Please note that video.js caches whether a certain video has been muted or not, so the default player may continue to be muted if it was muted manually before a reload. The `initiallyMuted` query parameter overrides this cache.

As a fan of the boy scout rule, I also improved the typings of the `<VideoJS>` component. Please let me know if you would prefer this to happen in another commit or perhaps even not at all. While I was hoping to add some tests for the new behavior, I was only able to find existing cypress tests and I didn't fully understand how the embed tests work so I decided against it for the moment. If you would like me to add tests, I'd appreciate a pointer what type of tests to add, where to add them and where I can find examples and perhaps shared setup code that I could use.

Fixes #2420