### PR TITLE
Move enable save button logic to a use effect hook - 2546

### DIFF
--- a/web/components/config/notification/twitter.tsx
+++ b/web/components/config/notification/twitter.tsx
@@ -66,14 +66,16 @@ export const ConfigNotify = () => {
     );
   };
 
+  useEffect(() => {
+    setEnableSaveButton(canSave());
+  }, [formDataValues]);
+
   // update individual values in state
   const handleFieldChange = ({ fieldName, value }: UpdateArgs) => {
     setFormDataValues({
       ...formDataValues,
       [fieldName]: value,
     });
-
-    setEnableSaveButton(canSave());
   };
 
   // toggle switch.


### PR DESCRIPTION
Closes #2546

This moves the enable save button logic for twitter notifications into a use effect hook. This updates the state without delay and therefore fixes the issue.

Below is a recording of the fix.

https://user-images.githubusercontent.com/44574494/210586529-569d3d15-6efd-4016-a654-d072dacca290.mov
