### PR TITLE
Fix empty query in video embed story

### DIFF
--- a/web/stories/VideoEmbed.stories.tsx
+++ b/web/stories/VideoEmbed.stories.tsx
@@ -12,17 +12,20 @@ const Template = ({
   title: string;
   width: number;
   height: number;
-}) => (
-  <iframe
-    src={`${origin}/embed/video?${query}`}
-    title={title}
-    height={`${height}px`}
-    width={`${width}px`}
-    referrerPolicy="origin"
-    scrolling="no"
-    allowFullScreen
-  />
-);
+}) => {
+  const queryString = query ? `?${query}` : '';
+  return (
+    <iframe
+      src={`${origin}/embed/video${queryString}`}
+      title={title}
+      height={`${height}px`}
+      width={`${width}px`}
+      referrerPolicy="origin"
+      scrolling="no"
+      allowFullScreen
+    />
+  );
+};
 
 const origins = {
   DemoServer: `https://watch.owncast.online`,


### PR DESCRIPTION
Fixes @MFTabriz's comment in #2539 about the unmuted embed player being loaded with a `?undefined` query.