### PR TITLE
Fix/issue 2649/status bar time info

### DIFF
--- a/web/components/ui/Statusbar/Statusbar.tsx
+++ b/web/components/ui/Statusbar/Statusbar.tsx
@@ -3,6 +3,7 @@ import intervalToDuration from 'date-fns/intervalToDuration';
 import { FC, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import styles from './Statusbar.module.scss';
+import { pluralize } from '../../../utils/helpers';
 
 // Lazy loaded components
 
@@ -18,15 +19,23 @@ export type StatusbarProps = {
 };
 
 function makeDurationString(lastConnectTime: Date): string {
+  const DAY_LABEL = 'day';
+  const HOUR_LABEL = 'hour';
+  const MINUTE_LABEL = 'minute';
+  const SECOND_LABEL = 'second';
   const diff = intervalToDuration({ start: lastConnectTime, end: new Date() });
+
   if (diff.days > 1) {
-    return `${diff.days} days ${diff.hours} hours`;
+    return `${diff.days} ${pluralize(DAY_LABEL, diff.days)}
+			${diff.hours} ${pluralize(HOUR_LABEL, diff.hours)}`;
   }
   if (diff.hours >= 1) {
-    return `${diff.hours} hours ${diff.minutes} minutes`;
+    return `${diff.hours} ${pluralize(HOUR_LABEL, diff.hours)} ${diff.minutes}
+			${pluralize(MINUTE_LABEL, diff.minutes)}`;
   }
 
-  return `${diff.minutes} minutes ${diff.seconds} seconds`;
+  return `${diff.minutes} ${pluralize(MINUTE_LABEL, diff.minutes)}
+		${diff.seconds} ${pluralize(SECOND_LABEL, diff.seconds)}`;
 }
 
 export const Statusbar: FC<StatusbarProps> = ({

--- a/web/components/ui/Statusbar/Statusbar.tsx
+++ b/web/components/ui/Statusbar/Statusbar.tsx
@@ -25,7 +25,7 @@ function makeDurationString(lastConnectTime: Date): string {
   const SECOND_LABEL = 'second';
   const diff = intervalToDuration({ start: lastConnectTime, end: new Date() });
 
-  if (diff.days > 1) {
+  if (diff.days >= 1) {
     return `${diff.days} ${pluralize(DAY_LABEL, diff.days)}
 			${diff.hours} ${pluralize(HOUR_LABEL, diff.hours)}`;
   }


### PR DESCRIPTION
#### Reference issues/PRs
Status bar time info: #2649 

#### What does this implementation/fix?
Using a helper function (already present in the codebase), I managed the singular values for the time units.
With this commit [fix: manage singular day visibility](https://github.com/owncast/owncast/commit/564bcaa1411dd78e0ba49c3cd9057f11255614fa), I modified the condition to `>=` otherwise, if the `lastConnectTime` value has only 1 day before _now_, `1 day` was not shown.

<img width="1005" alt="Screenshot 2023-01-31 at 21 24 26" src="https://user-images.githubusercontent.com/123890236/215874582-b41b5b03-545e-4162-9ed5-4333d1f9752f.png">

#### Any other comments?
I tested the implementation on Storybook and seems to work fine. Let me know if I made some mistakes, thx!