### PR TITLE
Un-squish logo

### DIFF
--- a/web/components/ui/Logo/Logo.module.scss
+++ b/web/components/ui/Logo/Logo.module.scss
@@ -24,7 +24,7 @@
 .image {
   width: 100%;
   height: 100%;
-  background-size: cover;
-  background-position: center;
+  object-fit: cover;
+  object-position: center;
   overflow: hidden;
 }


### PR DESCRIPTION
Fixes #2667 by applying the correct styling for the `img` tag (`background-*` only works if the image is being rendered as a `background` or `background-image`).