### PR TITLE
Issue#2662: Make Followers Content Fit With overflow ending in ellipsis

### DIFF
--- a/web/components/ui/followers/SingleFollower/SingleFollower.module.scss
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.module.scss
@@ -27,7 +27,7 @@
   .account {
     color: var(--theme-color-components-text-on-light);
     word-break: break-all;
-    line-height: 0.9rem;
+    line-height: 1rem;
   }
 
   @include screen(mobile) {

--- a/web/components/ui/followers/SingleFollower/SingleFollower.tsx
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.tsx
@@ -19,10 +19,10 @@ export const SingleFollower: FC<SingleFollowerProps> = ({ follower }) => (
         </Col>
         <Col span={18}>
           <Row className={styles.name}>
-            <Typography.Text ellipsis={true}>{follower.name}</Typography.Text>
+            <Typography.Text ellipsis>{follower.name}</Typography.Text>
           </Row>
           <Row className={styles.account}>
-            <Typography.Text ellipsis={true}>{follower.username}</Typography.Text>
+            <Typography.Text ellipsis>{follower.username}</Typography.Text>
           </Row>
         </Col>
       </Row>

--- a/web/components/ui/followers/SingleFollower/SingleFollower.tsx
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.tsx
@@ -18,8 +18,12 @@ export const SingleFollower: FC<SingleFollowerProps> = ({ follower }) => (
           </Avatar>
         </Col>
         <Col span={18}>
-          <Row className={styles.name}><Typography.Text ellipsis={true}>{follower.name}</Typography.Text></Row>
-          <Row className={styles.account}><Typography.Text ellipsis={true}>{follower.username}</Typography.Text></Row>
+          <Row className={styles.name}>
+            <Typography.Text ellipsis={true}>{follower.name}</Typography.Text>
+          </Row>
+          <Row className={styles.account}>
+            <Typography.Text ellipsis={true}>{follower.username}</Typography.Text>
+          </Row>
         </Col>
       </Row>
     </a>

--- a/web/components/ui/followers/SingleFollower/SingleFollower.tsx
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Col, Row } from 'antd';
+import { Avatar, Col, Row, Typography } from 'antd';
 import React, { FC } from 'react';
 import cn from 'classnames';
 import { Follower } from '../../../../interfaces/follower';
@@ -17,9 +17,9 @@ export const SingleFollower: FC<SingleFollowerProps> = ({ follower }) => (
             <img src="/logo" alt="Logo" className={styles.placeholder} />
           </Avatar>
         </Col>
-        <Col>
-          <Row className={styles.name}>{follower.name}</Row>
-          <Row className={styles.account}>{follower.username}</Row>
+        <Col span={18}>
+          <Row className={styles.name}><Typography.Text ellipsis={true}>{follower.name}</Typography.Text></Row>
+          <Row className={styles.account}><Typography.Text ellipsis={true}>{follower.username}</Typography.Text></Row>
         </Col>
       </Row>
     </a>


### PR DESCRIPTION
Closes  #2662

After the change:
<img width="1149" alt="Screenshot 2023-02-05 at 8 51 31 AM" src="https://user-images.githubusercontent.com/43103185/216799859-0bd653b1-f127-4705-9eba-9f5c3569325e.png">
