### PR TITLE
Fix Owncast Avatar URL for discord webhooks

### DIFF
--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -112,7 +112,7 @@ func (n *Notifier) setupDiscord() error {
 	if discordConfig.Enabled && discordConfig.Webhook != "" {
 		var image string
 		if serverURL := data.GetServerURL(); serverURL != "" {
-			image = serverURL + "/images/owncast-logo.png"
+			image = serverURL + "/logo"
 		}
 		discordNotifier, err := discord.New(
 			data.GetServerName(),


### PR DESCRIPTION
Currently, discord webhook posts don't display any avatar for the bot user, only the default discord logo in a blue circle.
![image](https://user-images.githubusercontent.com/40394943/221570610-1bc6e462-3242-45d7-aec9-18a8c4d620f3.png)

When I was browsing the webhooks code recently, I realized that the default discord logo appears because Owncast links a nonexistant logo .png to discord. (Which discord can't display, so it falls back to a default discord logo.)

With this change, the discord webhook will display the /logo file instead.
![image](https://user-images.githubusercontent.com/40394943/221571265-4833d626-b428-45ef-a291-b02fd82f8368.png)
