### PR TITLE
fix: Prevent color selector from closing on choosing a color

### DIFF
--- a/web/components/admin/config/general/AppearanceConfig.tsx
+++ b/web/components/admin/config/general/AppearanceConfig.tsx
@@ -70,18 +70,18 @@ const allAvailableValues = [...componentColorVariables, ...chatColorVariables, .
 );
 
 // eslint-disable-next-line react/function-component-definition
-function ColorPicker({
-  value,
-  name,
-  description,
-  onChange,
-}: {
-  value: string;
-  name: string;
-  description: string;
-  onChange: (name: string, value: string, description: string) => void;
-}) {
-  return (
+const ColorPicker = React.memo(
+  ({
+    value,
+    name,
+    description,
+    onChange,
+  }: {
+    value: string;
+    name: string;
+    description: string;
+    onChange: (name: string, value: string, description: string) => void;
+  }) => (
     <Col span={3} key={name}>
       <input
         type="color"
@@ -94,8 +94,8 @@ function ColorPicker({
       />
       <div style={{ padding: '2px' }}>{description}</div>
     </Col>
-  );
-}
+  ),
+);
 
 // eslint-disable-next-line react/function-component-definition
 export default function Appearance() {

--- a/web/components/admin/config/general/AppearanceConfig.tsx
+++ b/web/components/admin/config/general/AppearanceConfig.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useState } from 'react';
+import React, { FC, useContext, useCallback, useEffect, useState } from 'react';
 
 import { Button, Col, Collapse, Row, Slider, Space } from 'antd';
 import Paragraph from 'antd/lib/typography/Paragraph';
@@ -144,12 +144,12 @@ export default function Appearance() {
     setCustomValues(c);
   }, [appearanceVariables]);
 
-  const updateColor = (variable: string, color: string, description: string) => {
-    setCustomValues({
-      ...customValues,
+  const updateColor = useCallback((variable: string, color: string, description: string) => {
+    setCustomValues(oldCustomValues => ({
+      ...oldCustomValues,
       [variable]: { value: color, description },
-    });
-  };
+    }));
+  }, []);
 
   const reset = async () => {
     await postConfigUpdateToAPI({

--- a/web/components/admin/config/general/AppearanceConfig.tsx
+++ b/web/components/admin/config/general/AppearanceConfig.tsx
@@ -24,6 +24,11 @@ interface AppearanceVariable {
   description: string;
 }
 
+type ColorCollectionProps = {
+  variables: { name; description; value }[];
+  updateColor: (variable: string, color: string, description: string) => void;
+};
+
 const chatColorVariables = [
   { name: 'theme-color-users-0', description: '' },
   { name: 'theme-color-users-1', description: '' },
@@ -96,6 +101,24 @@ const ColorPicker = React.memo(
     </Col>
   ),
 );
+
+const ColorCollection: FC<ColorCollectionProps> = ({ variables, updateColor }) => {
+  const cc = variables.map(colorVar => {
+    const { name, description, value } = colorVar;
+
+    return (
+      <ColorPicker
+        key={name}
+        value={value}
+        name={name}
+        description={description}
+        onChange={updateColor}
+      />
+    );
+  });
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{cc}</>;
+};
 
 // eslint-disable-next-line react/function-component-definition
 export default function Appearance() {
@@ -193,33 +216,17 @@ export default function Appearance() {
     updateColor(variableName, `${value.toString()}px`, '');
   };
 
-  type ColorCollectionProps = {
-    variables: { name; description }[];
-  };
-  // eslint-disable-next-line react/no-unstable-nested-components
-  const ColorCollection: FC<ColorCollectionProps> = ({ variables }) => {
-    const cc = variables.map(colorVar => {
-      const source = customValues?.[colorVar.name] ? customValues : defaultValues;
-      const { name, description } = colorVar;
-      const { value } = source[name];
-
-      return (
-        <ColorPicker
-          key={name}
-          value={value}
-          name={name}
-          description={description}
-          onChange={updateColor}
-        />
-      );
-    });
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <>{cc}</>;
-  };
-
   if (!defaultValues) {
     return <div>Loading...</div>;
   }
+
+  const transformToColorMap = variables =>
+    variables.map(colorVar => {
+      const source = customValues?.[colorVar.name] ? customValues : defaultValues;
+      const { name, description } = colorVar;
+      const { value } = source[name];
+      return { name, description, value };
+    });
 
   return (
     <Space direction="vertical">
@@ -232,15 +239,20 @@ export default function Appearance() {
               Certain sections of the interface can be customized by selecting new colors for them.
             </p>
             <Row gutter={[16, 16]}>
-              <ColorCollection variables={componentColorVariables} />
+              <ColorCollection
+                variables={transformToColorMap(componentColorVariables)}
+                updateColor={updateColor}
+              />
             </Row>
           </Panel>
           <Panel header={<Title level={3}>Chat User Colors</Title>} key="2">
             <Row gutter={[16, 16]}>
-              <ColorCollection variables={chatColorVariables} />
+              <ColorCollection
+                variables={transformToColorMap(chatColorVariables)}
+                updateColor={updateColor}
+              />
             </Row>
           </Panel>
-
           <Panel header={<Title level={3}>Other Settings</Title>} key="4">
             How rounded should corners be?
             <Row gutter={[16, 16]}>


### PR DESCRIPTION
The bug was because on each click the state of the parent component was changing causing it to re-render. These re-renders then cascaded to its children recursively, resulting in the Color Picker component re-rendering which caused it to close. This PR uses useMemo & useCallback to ensure that there are no unnecessary re-renders which results in the color selector component staying open.

To make it easier to review, I've broken down the changes into smaller commits.

![Kapture 2023-03-08 at 20 44 32](https://user-images.githubusercontent.com/20909078/223751984-1feece8f-badb-43d6-8c0a-b83cfb59b883.gif)


Fixes #2782 