### PR TITLE
fix: #2779 - strip trailing slash on s3 endpoint

### DIFF
--- a/web/components/admin/config/server/EditStorage.tsx
+++ b/web/components/admin/config/server/EditStorage.tsx
@@ -126,6 +126,9 @@ export default function EditStorage() {
   const handleSave = async () => {
     setSubmitStatus(createInputStatus(STATUS_PROCESSING));
     const postValue = formDataValues;
+    if (postValue?.servingEndpoint) {
+      postValue.servingEndpoint = postValue?.servingEndpoint?.replace(/\/+$/g, '');
+    }
 
     await postConfigUpdateToAPI({
       apiPath: API_S3_INFO,


### PR DESCRIPTION
Strips out any trailing / on admin s3 endpoint config form. 