### PR TITLE
fix: #2755 clicking more details on un-registered chat user throws ex…

### DIFF
--- a/web/components/chat/ChatModerationDetailsModal/ChatModerationDetailsModal.tsx
+++ b/web/components/chat/ChatModerationDetailsModal/ChatModerationDetailsModal.tsx
@@ -147,11 +147,10 @@ export const ChatModerationDetailsModal: FC<ChatModerationDetailsModalProps> = (
       ),
     },
   ];
-
   return (
     <Spin spinning={loading}>
       <UserColorBlock color={displayColor} />
-      {scopes.map(scope => (
+      {scopes?.map(scope => (
         <Tag key={scope}>{scope}</Tag>
       ))}
       {authenticated && <Tag>Authenticated</Tag>}


### PR DESCRIPTION
Fixes #2755 

Un-registered users have a `scope` of `undefined` - not sure if this should be the case or not. Fix checks validity of `scope` variable before applying map method. 