### PR TITLE
Menu state in admin not saved after page refresh

### DIFF
--- a/web/components/admin/MainLayout.tsx
+++ b/web/components/admin/MainLayout.tsx
@@ -147,85 +147,85 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
   const integrationsMenu = [
     {
       label: <Link href="/admin/webhooks">Webhooks</Link>,
-      key: 'webhooks',
+      key: '/admin/webhooks',
     },
     {
       label: <Link href="/admin/access-tokens">Access Tokens</Link>,
-      key: 'access-tokens',
+      key: '/admin/access-tokens',
     },
     {
       label: <Link href="/admin/actions">External Actions</Link>,
-      key: 'actions',
+      key: '/admin/actions',
     },
   ];
 
   const chatMenu = [
     {
       label: <Link href="/admin/chat/messages">Messages</Link>,
-      key: 'messages',
+      key: '/admin/chat/messages',
     },
     {
       label: <Link href="/admin/chat/users">Users</Link>,
-      key: 'chat-users',
+      key: '/admin/chat/users',
     },
     {
       label: <Link href="/admin/chat/emojis">Emojis</Link>,
-      key: 'emojis',
+      key: '/admin/chat/emojis',
     },
   ];
 
   const utilitiesMenu = [
     {
       label: <Link href="/admin/hardware-info">Hardware</Link>,
-      key: 'hardware-info',
+      key: '/admin/hardware-info',
     },
     {
       label: <Link href="/admin/stream-health">Stream Health</Link>,
-      key: 'stream-health',
+      key: '/admin/stream-health',
     },
     {
       label: <Link href="/admin/logs">Logs</Link>,
-      key: 'logs',
+      key: '/admin/logs',
     },
     federationEnabled && {
       label: <Link href="/admin/federation/actions">Social Actions</Link>,
-      key: 'federation-activities',
+      key: '/admin/federation/actions',
     },
   ];
 
   const configurationMenu = [
     {
       label: <Link href="/admin/config/general">General</Link>,
-      key: 'config-public-details',
+      key: '/admin/config/general',
     },
     {
       label: <Link href="/admin/config/server">Server Setup</Link>,
-      key: 'config-server',
+      key: '/admin/config/server',
     },
     {
       label: <Link href="/admin/config-video">Video</Link>,
-      key: 'config-video',
+      key: '/admin/config-video',
     },
     {
       label: <Link href="/admin/config-chat">Chat</Link>,
-      key: 'config-chat',
+      key: '/admin/config-chat',
     },
     {
       label: <Link href="/admin/config-federation">Social</Link>,
-      key: 'config-federation',
+      key: '/admin/config-federation',
     },
     {
       label: <Link href="/admin/config-notify">Notifications</Link>,
-      key: 'config-notify',
+      key: '/admin/config-notify',
     },
   ];
 
   const menuItems = [
-    { label: <Link href="/admin">Home</Link>, icon: <HomeOutlined />, key: 'home' },
+    { label: <Link href="/admin">Home</Link>, icon: <HomeOutlined />, key: '/admin' },
     {
       label: <Link href="/admin/viewer-info">Viewers</Link>,
       icon: <LineChartOutlined />,
-      key: 'viewer-info',
+      key: '/admin/viewer-info',
     },
     !chatDisabled && {
       label: <span>Chat &amp; Users</span>,
@@ -234,7 +234,7 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
       key: 'chat-and-users',
     },
     federationEnabled && {
-      key: 'fediverse-followers',
+      key: '/admin/federation/followers',
       label: <Link href="/admin/federation/followers">Followers</Link>,
       icon: (
         <span
@@ -267,11 +267,11 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
       children: integrationsMenu,
     },
     upgradeVersion && {
-      key: 'upgrade',
+      key: '/admin/upgrade',
       label: <Link href="/admin/upgrade">{upgradeMessage}</Link>,
     },
     {
-      key: 'help',
+      key: '/admin/help',
       label: <Link href="/admin/help">Help</Link>,
       icon: <QuestionCircleOutlined />,
     },
@@ -295,11 +295,11 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
           <span className="title-label">Owncast Admin</span>
         </h1>
         <Menu
-          defaultSelectedKeys={[route.substring(1) || 'home']}
           defaultOpenKeys={openMenuItems}
           mode="inline"
           className="menu-container"
           items={menuItems}
+          selectedKeys={[route || '/admin']}
         />
       </Sider>
 

--- a/web/components/admin/MainLayout.tsx
+++ b/web/components/admin/MainLayout.tsx
@@ -129,7 +129,7 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
     <Alert message={alertMessage.message} afterClose={clearAlertMessage} banner closable />
   ) : null;
 
-  // status indicator items
+  // status indicator items.
   const streamDurationString = broadcaster
     ? parseSecondsToDurationString(differenceInSeconds(new Date(), new Date(broadcaster.time)))
     : '';

--- a/web/components/admin/MainLayout.tsx
+++ b/web/components/admin/MainLayout.tsx
@@ -129,7 +129,7 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
     <Alert message={alertMessage.message} afterClose={clearAlertMessage} banner closable />
   ) : null;
 
-  // status indicator items.
+  // status indicator items
   const streamDurationString = broadcaster
     ? parseSecondsToDurationString(differenceInSeconds(new Date(), new Date(broadcaster.time)))
     : '';

--- a/web/components/admin/MainLayout.tsx
+++ b/web/components/admin/MainLayout.tsx
@@ -276,6 +276,21 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
       icon: <QuestionCircleOutlined />,
     },
   ];
+
+  const [openKeys, setOpenKeys] = useState(openMenuItems);
+
+  const onOpenChange = (keys: string[]) => {
+    setOpenKeys(keys);
+  };
+
+  useEffect(() => {
+    menuItems.forEach(item =>
+      item?.children?.forEach(child => {
+        if (child?.key === route) setOpenKeys([...openMenuItems, item.key]);
+      }),
+    );
+  }, []);
+
   return (
     <Layout id="admin-page" className={appClass}>
       <Head>
@@ -295,11 +310,12 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
           <span className="title-label">Owncast Admin</span>
         </h1>
         <Menu
-          defaultOpenKeys={openMenuItems}
           mode="inline"
           className="menu-container"
           items={menuItems}
           selectedKeys={[route || '/admin']}
+          openKeys={openKeys}
+          onOpenChange={onOpenChange}
         />
       </Sider>
 


### PR DESCRIPTION
close #2807 

for highlight state, update menu keys to use route format so we can use it as reference
for collapse state, put the state in openKeys

[Screencast from 16-03-23 14:14:47.webm](https://user-images.githubusercontent.com/35093673/225542305-4ac0933b-69ea-455c-beea-bb238d1ad14d.webm)
