### PR TITLE
fix: Prevent storybook from making websocket connections

### DIFF
--- a/web/components/layouts/Main/Main.stories.tsx
+++ b/web/components/layouts/Main/Main.stories.tsx
@@ -38,7 +38,7 @@ export default {
 
 // mock the Websocket to prevent ani webhook calls from being made in storybook
 // @ts-ignore
-window.WebSocket = () => {}
+window.WebSocket = () => {};
 
 type StateInitializer = (mutableState: MutableSnapshot) => void;
 

--- a/web/components/layouts/Main/Main.stories.tsx
+++ b/web/components/layouts/Main/Main.stories.tsx
@@ -36,6 +36,10 @@ export default {
   },
 } satisfies ComponentMeta<typeof Main>;
 
+// mock the Websocket to prevent ani webhook calls from being made in storybook
+// @ts-ignore
+window.WebSocket = () => {}
+
 type StateInitializer = (mutableState: MutableSnapshot) => void;
 
 const composeStateInitializers =


### PR DESCRIPTION
I've added another websocket config variable to the client config and then using that to determine whether to start the websocket connections or not. Let me know what you feel of this approach.
Fixes #2862 