### PR TITLE
FIX : Chat: words containing one or more dots are turned into links #2898

### DIFF
--- a/web/components/chat/ChatSystemMessage/ChatSystemMessage.tsx
+++ b/web/components/chat/ChatSystemMessage/ChatSystemMessage.tsx
@@ -26,7 +26,7 @@ export const ChatSystemMessage: FC<ChatSystemMessageProps> = ({
       className={styles.message}
       content={body}
       matchers={[
-        new UrlMatcher('url', { validateTLD: false }),
+        new UrlMatcher('url',{ customTLDs: ['online'] }),
         new ChatMessageHighlightMatcher('highlight', { highlightString }),
       ]}
     />

--- a/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from 'antd';
 import { useRecoilValue } from 'recoil';
 import dynamic from 'next/dynamic';
 import { Interweave } from 'interweave';
-import { UrlMatcher } from 'interweave-autolink';
+import { EmailMatcher, UrlMatcher } from 'interweave-autolink';
 import { ChatMessageHighlightMatcher } from './customMatcher';
 import styles from './ChatUserMessage.module.scss';
 import { formatTimestamp } from './messageFmt';
@@ -110,7 +110,7 @@ export const ChatUserMessage: FC<ChatUserMessageProps> = ({
             className={styles.message}
             content={body}
             matchers={[
-              new UrlMatcher('url', { validateTLD: false }),
+              new UrlMatcher('url',{ customTLDs: ['online'] }),
               new ChatMessageHighlightMatcher('highlight', { highlightString }),
             ]}
           />

--- a/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
@@ -110,7 +110,7 @@ export const ChatUserMessage: FC<ChatUserMessageProps> = ({
             className={styles.message}
             content={body}
             matchers={[
-              new UrlMatcher('url',{ customTLDs: ['online'] }),
+              new UrlMatcher('url', { customTLDs: ['online'] }),
               new ChatMessageHighlightMatcher('highlight', { highlightString }),
             ]}
           />

--- a/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from 'antd';
 import { useRecoilValue } from 'recoil';
 import dynamic from 'next/dynamic';
 import { Interweave } from 'interweave';
-import { EmailMatcher, UrlMatcher } from 'interweave-autolink';
+import { UrlMatcher } from 'interweave-autolink';
 import { ChatMessageHighlightMatcher } from './customMatcher';
 import styles from './ChatUserMessage.module.scss';
 import { formatTimestamp } from './messageFmt';


### PR DESCRIPTION
Fixes #2898 
Making validateTLD to true and also adding a parameter of customTLDs.
Using customTLDs we can add  domain names which will also be matched as a link