### PR TITLE
Support using the custom video serving endpoint even if you don't use object storage

### DIFF
--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -771,6 +771,28 @@ func SetDisableSearchIndexing(w http.ResponseWriter, r *http.Request) {
 	controllers.WriteSimpleResponse(w, true, "search indexing support updated")
 }
 
+// SetVideoServingEndpoint will save the video serving endpoint.
+func SetVideoServingEndpoint(w http.ResponseWriter, r *http.Request) {
+	endpoint, success := getValueFromRequest(w, r)
+	if !success {
+		controllers.WriteSimpleResponse(w, false, "unable to update custom video serving endpoint")
+		return
+	}
+
+	value, ok := endpoint.Value.(string)
+	if !ok {
+		controllers.WriteSimpleResponse(w, false, "unable to update custom video serving endpoint")
+		return
+	}
+
+	if err := data.SetVideoServingEndpoint(value); err != nil {
+		controllers.WriteSimpleResponse(w, false, err.Error())
+		return
+	}
+
+	controllers.WriteSimpleResponse(w, true, "custom video serving endpoint updated")
+}
+
 func requirePOST(w http.ResponseWriter, r *http.Request) bool {
 	if r.Method != controllers.POST {
 		controllers.WriteSimpleResponse(w, false, r.Method+" not supported")

--- a/controllers/admin/serverConfig.go
+++ b/controllers/admin/serverConfig.go
@@ -59,6 +59,7 @@ func GetServerConfig(w http.ResponseWriter, r *http.Request) {
 		ChatDisabled:            data.GetChatDisabled(),
 		ChatJoinMessagesEnabled: data.GetChatJoinMessagesEnabled(),
 		SocketHostOverride:      data.GetWebsocketOverrideHost(),
+		VideoServingEndpoint:    data.GetVideoServingEndpoint(),
 		ChatEstablishedUserMode: data.GetChatEstbalishedUsersOnlyMode(),
 		HideViewerCount:         data.GetHideViewerCount(),
 		DisableSearchIndexing:   data.GetDisableSearchIndexing(),
@@ -107,6 +108,7 @@ type serverConfigAdminResponse struct {
 	SocketHostOverride      string                      `json:"socketHostOverride,omitempty"`
 	WebServerIP             string                      `json:"webServerIP"`
 	VideoCodec              string                      `json:"videoCodec"`
+	VideoServingEndpoint    string                      `json:"videoServingEndpoint"`
 	S3                      models.S3                   `json:"s3"`
 	Federation              federationConfigResponse    `json:"federation"`
 	SupportedCodecs         []string                    `json:"supportedCodecs"`
@@ -120,9 +122,9 @@ type serverConfigAdminResponse struct {
 	ChatDisabled            bool                        `json:"chatDisabled"`
 	ChatJoinMessagesEnabled bool                        `json:"chatJoinMessagesEnabled"`
 	ChatEstablishedUserMode bool                        `json:"chatEstablishedUserMode"`
+	DisableSearchIndexing   bool                        `json:"disableSearchIndexing"`
 	StreamKeyOverridden     bool                        `json:"streamKeyOverridden"`
 	HideViewerCount         bool                        `json:"hideViewerCount"`
-	DisableSearchIndexing   bool                        `json:"disableSearchIndexing"`
 }
 
 type videoSettings struct {

--- a/core/data/config.go
+++ b/core/data/config.go
@@ -70,6 +70,7 @@ const (
 	customColorVariableValuesKey         = "custom_color_variable_values"
 	streamKeysKey                        = "stream_keys"
 	disableSearchIndexingKey             = "disable_search_indexing"
+	videoServingEndpointKey              = "video_serving_endpoint"
 )
 
 // GetExtraPageBodyContent will return the user-supplied body content.
@@ -973,4 +974,15 @@ func GetDisableSearchIndexing() bool {
 		return false
 	}
 	return disableSearchIndexing
+}
+
+// GetVideoServingEndpoint returns the custom video endpont.
+func GetVideoServingEndpoint() string {
+	message, _ := _datastore.GetString(videoServingEndpointKey)
+	return message
+}
+
+// SetVideoServingEndpoint sets the custom video endpoint.
+func SetVideoServingEndpoint(message string) error {
+	return _datastore.SetString(videoServingEndpointKey, message)
 }

--- a/core/data/datastoreMigrations.go
+++ b/core/data/datastoreMigrations.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	datastoreValuesVersion   = 2
+	datastoreValuesVersion   = 3
 	datastoreValueVersionKey = "DATA_STORE_VERSION"
 )
 
@@ -25,6 +25,8 @@ func migrateDatastoreValues(datastore *Datastore) {
 			migrateToDatastoreValues1(datastore)
 		case 1:
 			migrateToDatastoreValues2(datastore)
+		case 2:
+			migrateToDatastoreValues3ServingEndpoint3(datastore)
 		default:
 			log.Fatalln("missing datastore values migration step")
 		}
@@ -60,4 +62,14 @@ func migrateToDatastoreValues2(datastore *Datastore) {
 	_ = SetStreamKeys([]models.StreamKey{
 		{Key: oldAdminPassword, Comment: "Default stream key"},
 	})
+}
+
+func migrateToDatastoreValues3ServingEndpoint3(_ *Datastore) {
+	s3Config := GetS3Config()
+
+	if !s3Config.Enabled {
+		return
+	}
+
+	_ = SetVideoServingEndpoint(s3Config.ServingEndpoint)
 }

--- a/core/storageproviders/rewriteLocalPlaylist.go
+++ b/core/storageproviders/rewriteLocalPlaylist.go
@@ -1,0 +1,36 @@
+package storageproviders
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+
+	"github.com/grafov/m3u8"
+	"github.com/owncast/owncast/config"
+	"github.com/owncast/owncast/core/playlist"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// rewriteRemotePlaylist will take a local playlist and rewrite it to have absolute URLs to remote locations.
+func rewriteRemotePlaylist(localFilePath, remoteServingEndpoint string) error {
+	f, err := os.Open(localFilePath) // nolint
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	p := m3u8.NewMasterPlaylist()
+	if err := p.DecodeFrom(bufio.NewReader(f), false); err != nil {
+		log.Warnln(err)
+	}
+
+	for _, item := range p.Variants {
+		item.URI = remoteServingEndpoint + filepath.Join("/hls", item.URI)
+	}
+
+	publicPath := filepath.Join(config.HLSStoragePath, filepath.Base(localFilePath))
+
+	newPlaylist := p.String()
+
+	return playlist.WritePlaylist(newPlaylist, publicPath)
+}

--- a/models/s3Storage.go
+++ b/models/s3Storage.go
@@ -2,13 +2,17 @@ package models
 
 // S3 is the storage configuration.
 type S3 struct {
-	Endpoint        string `json:"endpoint,omitempty"`
-	ServingEndpoint string `json:"servingEndpoint,omitempty"`
-	AccessKey       string `json:"accessKey,omitempty"`
-	Secret          string `json:"secret,omitempty"`
-	Bucket          string `json:"bucket,omitempty"`
-	Region          string `json:"region,omitempty"`
-	ACL             string `json:"acl,omitempty"`
-	Enabled         bool   `json:"enabled"`
-	ForcePathStyle  bool   `json:"forcePathStyle"`
+	Enabled        bool   `json:"enabled"`
+	Endpoint       string `json:"endpoint,omitempty"`
+	AccessKey      string `json:"accessKey,omitempty"`
+	Secret         string `json:"secret,omitempty"`
+	Bucket         string `json:"bucket,omitempty"`
+	Region         string `json:"region,omitempty"`
+	ACL            string `json:"acl,omitempty"`
+	ForcePathStyle bool   `json:"forcePathStyle"`
+
+	// This property is no longer used as of v0.1.1. See the standalone
+	// property that was pulled out of here instead. It's only left here
+	// to allow the migration to take place without data loss.
+	ServingEndpoint string `json:"-"`
 }

--- a/router/router.go
+++ b/router/router.go
@@ -291,6 +291,9 @@ func Start() error {
 	// Websocket host override
 	http.HandleFunc("/api/admin/config/sockethostoverride", middleware.RequireAdminAuth(admin.SetSocketHostOverride))
 
+	// Custom video serving endpoint
+	http.HandleFunc("/api/admin/config/videoservingendpoint", middleware.RequireAdminAuth(admin.SetVideoServingEndpoint))
+
 	// Is server marked as NSFW
 	http.HandleFunc("/api/admin/config/nsfw", middleware.RequireAdminAuth(admin.SetNSFW))
 

--- a/web/components/admin/EditInstanceDetails2.tsx
+++ b/web/components/admin/EditInstanceDetails2.tsx
@@ -10,6 +10,7 @@ import {
   TEXTFIELD_PROPS_SOCKET_HOST_OVERRIDE,
   TEXTFIELD_PROPS_ADMIN_PASSWORD,
   TEXTFIELD_PROPS_WEB_PORT,
+  TEXTFIELD_PROPS_VIDEO_SERVING_ENDPOINT,
 } from '../../utils/config-constants';
 import { UpdateArgs } from '../../types/config-section';
 import { ResetYP } from './ResetYP';
@@ -24,8 +25,15 @@ export default function EditInstanceDetails() {
 
   const { serverConfig } = serverStatusData || {};
 
-  const { adminPassword, ffmpegPath, rtmpServerPort, webServerPort, yp, socketHostOverride } =
-    serverConfig;
+  const {
+    adminPassword,
+    ffmpegPath,
+    rtmpServerPort,
+    webServerPort,
+    yp,
+    socketHostOverride,
+    videoServingEndpoint,
+  } = serverConfig;
 
   useEffect(() => {
     setFormDataValues({
@@ -34,6 +42,7 @@ export default function EditInstanceDetails() {
       rtmpServerPort,
       webServerPort,
       socketHostOverride,
+      videoServingEndpoint,
     });
   }, [serverConfig]);
 
@@ -42,6 +51,7 @@ export default function EditInstanceDetails() {
   }
 
   const handleFieldChange = ({ fieldName, value }: UpdateArgs) => {
+    console.log('handleFieldChange', fieldName, value);
     setFormDataValues({
       ...formDataValues,
       [fieldName]: value,
@@ -116,6 +126,15 @@ export default function EditInstanceDetails() {
             {...TEXTFIELD_PROPS_SOCKET_HOST_OVERRIDE}
             value={formDataValues.socketHostOverride}
             initialValue={socketHostOverride || ''}
+            type={TEXTFIELD_TYPE_URL}
+            onChange={handleFieldChange}
+          />
+
+          <TextFieldWithSubmit
+            fieldName="videoServingEndpoint"
+            {...TEXTFIELD_PROPS_VIDEO_SERVING_ENDPOINT}
+            value={formDataValues.videoServingEndpoint}
+            initialValue={videoServingEndpoint || ''}
             type={TEXTFIELD_TYPE_URL}
             onChange={handleFieldChange}
           />

--- a/web/components/admin/EditInstanceDetails2.tsx
+++ b/web/components/admin/EditInstanceDetails2.tsx
@@ -51,7 +51,6 @@ export default function EditInstanceDetails() {
   }
 
   const handleFieldChange = ({ fieldName, value }: UpdateArgs) => {
-    console.log('handleFieldChange', fieldName, value);
     setFormDataValues({
       ...formDataValues,
       [fieldName]: value,

--- a/web/components/admin/config/server/EditStorage.tsx
+++ b/web/components/admin/config/server/EditStorage.tsx
@@ -28,17 +28,7 @@ const { Panel } = Collapse;
 // we could probably add more detailed checks here
 // `currentValues` is what's currently in the global store and in the db
 function checkSaveable(formValues: any, currentValues: any) {
-  const {
-    endpoint,
-    accessKey,
-    secret,
-    bucket,
-    region,
-    enabled,
-    servingEndpoint,
-    acl,
-    forcePathStyle,
-  } = formValues;
+  const { endpoint, accessKey, secret, bucket, region, enabled, acl, forcePathStyle } = formValues;
   // if fields are filled out and different from what's in store, then return true
   if (enabled) {
     if (!!endpoint && isValidUrl(endpoint) && !!accessKey && !!secret && !!bucket && !!region) {
@@ -49,8 +39,6 @@ function checkSaveable(formValues: any, currentValues: any) {
         secret !== currentValues.secret ||
         bucket !== currentValues.bucket ||
         region !== currentValues.region ||
-        (!currentValues.servingEndpoint && servingEndpoint !== '') ||
-        (!!currentValues.servingEndpoint && servingEndpoint !== currentValues.servingEndpoint) ||
         (!currentValues.acl && acl !== '') ||
         (!!currentValues.acl && acl !== currentValues.acl) ||
         forcePathStyle !== currentValues.forcePathStyle
@@ -84,7 +72,6 @@ export default function EditStorage() {
     endpoint = '',
     region = '',
     secret = '',
-    servingEndpoint = '',
     forcePathStyle = false,
   } = s3;
 
@@ -97,7 +84,6 @@ export default function EditStorage() {
       endpoint,
       region,
       secret,
-      servingEndpoint,
       forcePathStyle,
     });
     setShouldDisplayForm(enabled);
@@ -232,13 +218,7 @@ export default function EditStorage() {
                 onChange={handleFieldChange}
               />
             </div>
-            <div className="field-container">
-              <TextField
-                {...S3_TEXT_FIELDS_INFO.servingEndpoint}
-                value={formDataValues.servingEndpoint}
-                onChange={handleFieldChange}
-              />
-            </div>
+
             <div className="enable-switch">
               <ToggleSwitch
                 {...S3_TEXT_FIELDS_INFO.forcePathStyle}

--- a/web/types/config-section.ts
+++ b/web/types/config-section.ts
@@ -81,7 +81,6 @@ export interface S3Field {
   endpoint: string;
   region: string;
   secret: string;
-  servingEndpoint?: string;
   forcePathStyle: boolean;
 }
 
@@ -145,6 +144,7 @@ export interface ConfigDetails {
   videoSettings: VideoSettingsFields;
   webServerPort: string;
   socketHostOverride: string;
+  videoServingEndpoint: string;
   yp: ConfigDirectoryFields;
   supportedCodecs: string[];
   videoCodec: string;

--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -40,6 +40,7 @@ const API_CHAT_JOIN_MESSAGES_ENABLED = '/chat/joinmessagesenabled';
 const API_CHAT_ESTABLISHED_MODE = '/chat/establishedusermode';
 const API_DISABLE_SEARCH_INDEXING = '/disablesearchindexing';
 const API_SOCKET_HOST_OVERRIDE = '/sockethostoverride';
+const API_VIDEO_SERVING_ENDPOINT = '/videoservingendpoint';
 
 // Federation
 const API_FEDERATION_ENABLED = '/federation/enable';
@@ -175,6 +176,18 @@ export const TEXTFIELD_PROPS_SOCKET_HOST_OVERRIDE = {
   placeholder: 'https://owncast.mysite.com',
   label: 'Websocket host override',
   tip: 'The direct URL of your Owncast server.',
+  type: TEXTFIELD_TYPE_URL,
+  pattern: DEFAULT_TEXTFIELD_URL_PATTERN,
+  useTrim: true,
+};
+
+export const TEXTFIELD_PROPS_VIDEO_SERVING_ENDPOINT = {
+  apiPath: API_VIDEO_SERVING_ENDPOINT,
+  fieldName: 'videoServingEndpoint',
+  label: 'Serving Endpoint',
+  maxLength: 255,
+  placeholder: 'http://cdn.provider.endpoint.com',
+  tip: 'Optional URL that video content should be accessed from instead of the default.  Used with CDNs and specific storage providers. Generally not required.',
   type: TEXTFIELD_TYPE_URL,
   pattern: DEFAULT_TEXTFIELD_URL_PATTERN,
   useTrim: true,
@@ -520,16 +533,6 @@ export const S3_TEXT_FIELDS_INFO = {
     maxLength: 255,
     placeholder: 'your secret key',
     tip: '',
-  },
-  servingEndpoint: {
-    fieldName: 'servingEndpoint',
-    label: 'Serving Endpoint',
-    maxLength: 255,
-    placeholder: 'http://cdn.ss3.provider.endpoint.com',
-    tip: 'Optional URL that content should be accessed from instead of the default.  Used with CDNs and specific storage providers. Generally not required.',
-    type: TEXTFIELD_TYPE_URL,
-    pattern: DEFAULT_TEXTFIELD_URL_PATTERN,
-    useTrim: true,
   },
   forcePathStyle: {
     fieldName: 'forcePathStyle',

--- a/web/utils/server-status-context.tsx
+++ b/web/utils/server-status-context.tsx
@@ -30,6 +30,7 @@ const initialServerConfigState: ConfigDetails = {
   rtmpServerPort: '',
   webServerPort: '',
   socketHostOverride: null,
+  videoServingEndpoint: '',
   s3: {
     accessKey: '',
     acl: '',
@@ -38,7 +39,6 @@ const initialServerConfigState: ConfigDetails = {
     endpoint: '',
     region: '',
     secret: '',
-    servingEndpoint: '',
     forcePathStyle: false,
   },
   yp: {


### PR DESCRIPTION
Mostly useful if you have a CDN you want to put in front of your video assets. Closes #2785