### PR TITLE
fix: #2957 Portrait Buttons Make Action Buttons Wrap

### DIFF
--- a/web/components/ui/Content/ActionButtons.tsx
+++ b/web/components/ui/Content/ActionButtons.tsx
@@ -10,7 +10,6 @@ import styles from './Content.module.scss';
 import { ActionButton } from '../../action-buttons/ActionButton/ActionButton';
 
 interface ActionButtonProps {
-  isMobile: boolean;
   supportFediverseFeatures: boolean;
   externalActions: ExternalAction[];
   supportsBrowserNotifications: boolean;
@@ -31,7 +30,6 @@ const NotifyReminderPopup = dynamic(
 );
 
 const ActionButtons: FC<ActionButtonProps> = ({
-  isMobile,
   supportFediverseFeatures,
   supportsBrowserNotifications,
   showNotifyReminder,
@@ -50,38 +48,37 @@ const ActionButtons: FC<ActionButtonProps> = ({
     />
   ));
 
-  if (!isMobile) {
-    return (
-      <ActionButtonRow>
-        {externalActionButtons}
-        {supportFediverseFeatures && (
-          <FollowButton size="small" onClick={() => setShowFollowModal(true)} />
-        )}
-        {supportsBrowserNotifications && (
-          <NotifyReminderPopup
-            open={showNotifyReminder}
-            notificationClicked={() => setShowNotifyModal(true)}
-            notificationClosed={() => disableNotifyReminderPopup()}
-          >
-            <NotifyButton onClick={() => setShowNotifyModal(true)} />
-          </NotifyReminderPopup>
-        )}
-      </ActionButtonRow>
-    );
-  }
-
   return (
-    <div className={styles.mobileActionButtonMenu}>
-      <ActionButtonMenu
-        className={styles.actionButtonMenu}
-        showFollowItem={supportFediverseFeatures}
-        showNotifyItem={supportsBrowserNotifications}
-        actions={externalActions}
-        externalActionSelected={setExternalActionToDisplay}
-        notifyItemSelected={() => setShowNotifyModal(true)}
-        followItemSelected={() => setShowFollowModal(true)}
-      />
-    </div>
+    <>
+      <div className={styles.desktopActionButtons}>
+        <ActionButtonRow>
+          {externalActionButtons}
+          {supportFediverseFeatures && (
+            <FollowButton size="small" onClick={() => setShowFollowModal(true)} />
+          )}
+          {supportsBrowserNotifications && (
+            <NotifyReminderPopup
+              open={showNotifyReminder}
+              notificationClicked={() => setShowNotifyModal(true)}
+              notificationClosed={() => disableNotifyReminderPopup()}
+            >
+              <NotifyButton onClick={() => setShowNotifyModal(true)} />
+            </NotifyReminderPopup>
+          )}
+        </ActionButtonRow>
+      </div>
+      <div className={styles.mobileActionButtonMenu}>
+        <ActionButtonMenu
+          className={styles.actionButtonMenu}
+          showFollowItem={supportFediverseFeatures}
+          showNotifyItem={supportsBrowserNotifications}
+          actions={externalActions}
+          externalActionSelected={setExternalActionToDisplay}
+          notifyItemSelected={() => setShowNotifyModal(true)}
+          followItemSelected={() => setShowFollowModal(true)}
+        />
+      </div>
+    </>
   );
 };
 

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -47,10 +47,24 @@
 }
 
 .mobileActionButtonMenu {
-  position: absolute;
-  top: 4px;
-  right: 10px;
-  z-index: 200;
+  display: none;
+
+  @include screen(tablet) {
+    display: block;
+    position: absolute;
+    top: 4px;
+    right: 10px;
+    z-index: 200;
+  }
+}
+
+.desktopActionButtons {
+  display: block;
+
+  @include screen(tablet) {
+    display: none;
+  }
+
 }
 
 //not sure if this is needed

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -233,7 +233,6 @@ export const Content: FC = () => {
         <Row>
           <Col span={24} style={{ paddingRight: dynamicPadding }}>
             <ActionButtons
-              isMobile={isMobile}
               supportFediverseFeatures={supportFediverseFeatures}
               supportsBrowserNotifications={supportsBrowserNotifications}
               showNotifyReminder={showNotifyReminder}

--- a/web/components/ui/Footer/Footer.module.scss
+++ b/web/components/ui/Footer/Footer.module.scss
@@ -15,12 +15,7 @@
   font-size: 0.75rem;
   font-weight: 400;
   border-top: 1px solid rgba(214, 211, 211, 0.5);
-
-  @include screen(mobile) {
-    position: fixed;
-    bottom: 0;
-  
-  }
+  width: 100%;
 
   @include screen(tablet) {
     font-size: 10px;
@@ -29,9 +24,12 @@
 
   }
 
-  @include screen(desktop) {
-    display: flex;
+  @include screen(mobile) {
+    position: fixed;
+    bottom: 0;
   }
+
+
 
   a {
     color: var(--theme-color-components-text-on-dark);


### PR DESCRIPTION
Action button experience is now a 100% CSS solution, media queries should govern the desktop and mobile experiences. 