### PR TITLE
Moved global modifier to fix cascading

### DIFF
--- a/web/components/ui/Modal/Modal.module.scss
+++ b/web/components/ui/Modal/Modal.module.scss
@@ -19,34 +19,34 @@
   }
 }
 
-.modal {
-	:global(.ant-modal-header) {
+:global .modal {
+	.ant-modal-header {
 		color: var(--theme-color-components-modal-header-text);
 		font-family: var(--theme-text-display-font-family);
 		padding: 1rem 1.25rem;
 	}
 
-	:global(.ant-modal-title) {
+	.ant-modal-title {
 		color: var(--theme-color-components-modal-header-text);
 		font-size: 17px;
 		font-weight: 600;
 	}
 
-	:global(.ant-modal-body) {
+	.ant-modal-body {
 		overflow: auto;
 		border-radius: 0 0 var(--theme-rounded-corners) var(--theme-rounded-corners);
 	}
-	:global(.ant-modal-close-x) {
+	.ant-modal-close-x {
 		font-size: 12px;
 	}
-	:global(.ant-modal) {
+	.ant-modal {
 		color: var(--theme-color-components-text-on-light);
 		h1 {
 			color: var(--theme-color-components-text-on-light);
 		}
 	}
 
-	:global(.ant-modal-content) {
+	.ant-modal-content {
 		box-shadow: 3px 15px 15px -3px rgba(0, 0, 0, 0.15), 0px 4px 6px -2px rgba(0, 0, 0, 0.08);
 	}
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -107,7 +107,7 @@
 				"mermaid": "^10.0.0",
 				"npm": "^9.4.0",
 				"prettier": "2.8.8",
-				"sass": "1.62.0",
+				"sass": "^1.62.0",
 				"sass-loader": "13.2.2",
 				"sb": "6.5.16",
 				"storybook-addon-designs": "6.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -112,7 +112,7 @@
 		"mermaid": "^10.0.0",
 		"npm": "^9.4.0",
 		"prettier": "2.8.8",
-		"sass": "1.62.0",
+		"sass": "^1.62.0",
 		"sass-loader": "13.2.2",
 		"sb": "6.5.16",
 		"storybook-addon-designs": "6.3.1",


### PR DESCRIPTION
moved :global from child .ant-modal selectors up to .modal to ensure access from  admin modals. Let me know if there's a better way to do this and I'll fix it! 

fixes #2964 :)