### PR TITLE
fix(mobile): toggle tablet content layout based on online state.

### DIFF
--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -14,8 +14,7 @@
   width: 100%;
 
   @include screen(tablet) {
-    //sets the position of tabbed content for online mode
-    top: 430px;
+    position: relative;
   }
 
   @include screen(mobile) {
@@ -27,6 +26,14 @@
     margin-bottom: 0px;
     padding-top: 0.5vh;
     padding-left: 1vw;
+  }
+}
+
+.online {
+  @include screen(tablet) {
+    //sets the position of tabbed content for online mode
+    position: absolute;
+    top: 430px;
   }
 }
 

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -268,6 +268,7 @@ export const Content: FC = () => {
               setShowFollowModal={setShowFollowModal}
               supportFediverseFeatures={supportFediverseFeatures}
               chatEnabled={isChatAvailable}
+              online={online}
             />
           ) : (
             <Col span={24} style={{ paddingRight: dynamicPadding }}>

--- a/web/components/ui/Content/MobileContent.tsx
+++ b/web/components/ui/Content/MobileContent.tsx
@@ -2,6 +2,7 @@ import React, { ComponentType, FC } from 'react';
 import dynamic from 'next/dynamic';
 import { Skeleton, TabsProps } from 'antd';
 import { ErrorBoundary } from 'react-error-boundary';
+import classNames from 'classnames';
 import { SocialLink } from '../../../interfaces/social-link.model';
 import styles from './Content.module.scss';
 import { CustomPageContent } from '../CustomPageContent/CustomPageContent';
@@ -22,6 +23,7 @@ export type MobileContentProps = {
   currentUser: CurrentUser;
   showChat: boolean;
   chatEnabled: boolean;
+  online: boolean;
 };
 
 // lazy loaded components
@@ -90,6 +92,7 @@ export const MobileContent: FC<MobileContentProps> = ({
   chatEnabled,
   setShowFollowModal,
   supportFediverseFeatures,
+  online,
 }) => {
   const aboutTabContent = (
     <>
@@ -134,7 +137,7 @@ export const MobileContent: FC<MobileContentProps> = ({
         <ComponentErrorFallback error={error} resetErrorBoundary={resetErrorBoundary} />
       )}
     >
-      <div className={styles.lowerSectionMobile}>
+      <div className={classNames([styles.lowerSectionMobile, online && styles.online])}>
         {items.length > 1 && <Tabs defaultActiveKey="0" items={items} />}
       </div>
       <div className={styles.mobileNoTabs}>{items.length <= 1 && aboutTabContent}</div>


### PR DESCRIPTION
Closes #3003

@thisprojects Curious if you could take a look and see if this is a good solution. The issue that I saw was the hard-coded 430px was being set even on tablet if the offline banner was not 430px. So instead I set it to relative positioning when offline, and then moved the hard coded 430px absolute positioning when online.

Offline:

![image](https://github.com/owncast/owncast/assets/414923/65e4d481-b93c-4649-8981-d2ddd8529a70)

Online:

![image](https://github.com/owncast/owncast/assets/414923/c71443c7-e0d7-4dc0-a88a-018cdddd6fc3)
