### PR TITLE
address doublescroll #3028

### DIFF
--- a/web/components/layouts/Main/Main.module.scss
+++ b/web/components/layouts/Main/Main.module.scss
@@ -4,7 +4,8 @@
   // this margin is for fixed header
   padding-top: var(--header-height);
   background-color: var(--theme-color-main-background);
-  min-height: 100vh;
+  min-height: 100dvh;
+
   position: relative;
 
   // add some spacing between the last row of content and the footer

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -21,7 +21,8 @@
 			position: absolute;
 			top: calc(var(--player-container-height) + var(--status-bar-height) + var(--header-height));
 
-
+			// As we want content in the tabs to scroll within itself, force the tabs to display max height at all times.
+			// (We don't have to do this when not-online because we're having the entire layout scroll.
 			:global(.ant-tabs-content) {
 				 height: 100% !important;
 			}

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -55,7 +55,7 @@
     position: absolute;
     top: 4px;
     right: 10px;
-    z-index: 200;
+    z-index: 199;
   }
 }
 

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -20,6 +20,11 @@
 		&.online {
 			position: absolute;
 			top: calc(var(--player-container-height) + var(--status-bar-height) + var(--header-height));
+
+
+			:global(.ant-tabs-content) {
+				 height: 100% !important;
+			}
 		}
   }
 

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -162,7 +162,6 @@ DROPDOWN
     height: 100%;
   }
   .ant-tabs-content {
-    // height: 100% !important;
     overflow: auto;
     .ant-tabs-tabpane-active {
       height: 100%;

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -162,7 +162,7 @@ DROPDOWN
     height: 100%;
   }
   .ant-tabs-content {
-    height: 100% !important;
+    // height: 100% !important;
     overflow: auto;
     .ant-tabs-tabpane-active {
       height: 100%;


### PR DESCRIPTION
- A fix for https://github.com/owncast/owncast/issues/3028.
  - give main layout a height of `100dvh` to accommodate for iOS Safari not dealing well with 100vh. -- NOTE: this value is only supported in [very modern browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/length#browser_compatibility).
  - only force 100% height on tabs when online.
  

- A fix for this issue as well - where the mobile menu item overlaps the header.

  <img width="465" alt="image" src="https://github.com/owncast/owncast/assets/9563255/e472f979-cd1d-4227-a2a7-88759ad9771f">
