### PR TITLE
Address chat modal button issues

### DIFF
--- a/test/automated/browser/cypress/e2e/online/06_online_mobile_live.cy.js
+++ b/test/automated/browser/cypress/e2e/online/06_online_mobile_live.cy.js
@@ -29,6 +29,10 @@ filterTests(['mobile'], () => {
 			cy.get('#chat-input').should('be.visible');
 		});
 
+		it('Chat user menu should be visible', () => {
+			cy.get('#chat-modal-user-menu').should('be.visible');
+		});
+
 		it('Click on user menu', () => {
 			cy.get('#chat-modal-user-menu').click();
 		});

--- a/web/components/common/UserDropdown/UserDropdown.module.scss
+++ b/web/components/common/UserDropdown/UserDropdown.module.scss
@@ -27,7 +27,7 @@
 }
 
 .chatToggle {
-  @include screen(mobile) {
+  @include screen(tablet) {
     display: none;
   }
 }

--- a/web/components/ui/Content/Content.module.scss
+++ b/web/components/ui/Content/Content.module.scss
@@ -110,6 +110,11 @@
   width: 100px;
   height: 40px;
   bottom: 40px;
-  right: 10px;
+  right: var(--content-padding);
   font-weight: 600;
+	font-size: 1em;
+	z-index: 99;
+	background-color: var(--theme-color-components-chat-background);
+	border-width: 0;
+  box-shadow: 0px 1px 3px 1px rgb(0 0 0 / 20%);
 }

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -303,22 +303,21 @@ export const Content: FC = () => {
           handleClose={() => setShowFollowModal(false)}
         />
       </Modal>
-      {showChatModal && isChatVisible && (
+      {isMobile && showChatModal && isChatVisible && (
         <ChatModal
           messages={messages}
           currentUser={currentUser}
           handleClose={() => setShowChatModal(false)}
         />
       )}
-      {isChatVisible && (
+      {isMobile && isChatVisible && (
         <Button
           id="mobile-chat-button"
           type="primary"
           onClick={() => setShowChatModal(true)}
           className={styles.floatingMobileChatModalButton}
-          style={{ zIndex: 99 }}
         >
-          Chat <MessageFilled style={{ transform: 'translateX(-1px)' }} />
+          Chat <MessageFilled />
         </Button>
       )}
     </>

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -17,6 +17,7 @@ import {
   isOnlineSelector,
   isMobileAtom,
   serverStatusState,
+  isChatAvailableSelector,
 } from '../../stores/ClientConfigStore';
 import { ClientConfig } from '../../../interfaces/client-config.model';
 
@@ -97,6 +98,7 @@ export const Content: FC = () => {
   const [isMobile, setIsMobile] = useRecoilState<boolean | undefined>(isMobileAtom);
   const messages = useRecoilValue<ChatMessage[]>(chatMessagesAtom);
   const online = useRecoilValue<boolean>(isOnlineSelector);
+  const isChatAvailable = useRecoilValue<boolean>(isChatAvailableSelector);
 
   const { viewerCount, lastConnectTime, lastDisconnectTime, streamTitle } =
     useRecoilValue<ServerStatus>(serverStatusState);
@@ -180,7 +182,7 @@ export const Content: FC = () => {
     setSupportsBrowserNotifications(isPushNotificationSupported() && browserNotificationsEnabled);
   }, [browserNotificationsEnabled]);
 
-  const showChat = online && !chatDisabled && isChatVisible;
+  const showChat = isChatAvailable && !chatDisabled && isChatVisible;
 
   // accounts for sidebar width when online in desktop
   const dynamicPadding = showChat && !isMobile ? '320px' : '0px';
@@ -310,7 +312,7 @@ export const Content: FC = () => {
           handleClose={() => setShowChatModal(false)}
         />
       )}
-      {isMobile && showChat && (
+      {isMobile && isChatAvailable && (
         <Button
           id="mobile-chat-button"
           type="primary"

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -310,7 +310,7 @@ export const Content: FC = () => {
           handleClose={() => setShowChatModal(false)}
         />
       )}
-      {isMobile && isChatVisible && (
+      {isMobile && showChat && (
         <Button
           id="mobile-chat-button"
           type="primary"


### PR DESCRIPTION
Addresses https://github.com/owncast/owncast/issues/3041

- don't display chat button or modal if `isMobile` (768px) is true. 
- only display chat button if `online` is true. (mimics existing logic of showing the side bark on desktop when online is true.)
- don't display the show/hide chat option in the user dropdown for tablet sizes (768px) either. 
- tweak chat button styles and make chat button bg the same as the chat component bg color, to make it stand out.
