### PR TITLE
Fix NotifyReminderPopup warning #3034.

### DIFF
--- a/web/components/action-buttons/NotifyButton.tsx
+++ b/web/components/action-buttons/NotifyButton.tsx
@@ -15,15 +15,13 @@ export type NotifyButtonProps = {
 };
 
 export const NotifyButton: FC<NotifyButtonProps> = ({ onClick, text }) => (
-  <div>
-    <Button
-      type="primary"
-      className={`${styles.button}`}
-      icon={<BellFilled />}
-      onClick={onClick}
-      id="notify-button"
-    >
-      {text || 'Notify'}
-    </Button>
-  </div>
+  <Button
+    type="primary"
+    className={`${styles.button}`}
+    icon={<BellFilled />}
+    onClick={onClick}
+    id="notify-button"
+  >
+    {text || 'Notify'}
+  </Button>
 );

--- a/web/components/action-buttons/NotifyButton.tsx
+++ b/web/components/action-buttons/NotifyButton.tsx
@@ -15,13 +15,15 @@ export type NotifyButtonProps = {
 };
 
 export const NotifyButton: FC<NotifyButtonProps> = ({ onClick, text }) => (
-  <Button
-    type="primary"
-    className={`${styles.button}`}
-    icon={<BellFilled />}
-    onClick={onClick}
-    id="notify-button"
-  >
-    {text || 'Notify'}
-  </Button>
+  <div>
+    <Button
+      type="primary"
+      className={`${styles.button}`}
+      icon={<BellFilled />}
+      onClick={onClick}
+      id="notify-button"
+    >
+      {text || 'Notify'}
+    </Button>
+  </div>
 );

--- a/web/components/ui/NotifyReminderPopup/NotifyReminderPopup.tsx
+++ b/web/components/ui/NotifyReminderPopup/NotifyReminderPopup.tsx
@@ -78,7 +78,7 @@ export const NotifyReminderPopup: FC<NotifyReminderPopupProps> = ({
         overlayInnerStyle={popupStyle}
         color={styles.popupBackgroundColor}
       >
-        {children}
+        <div>{children}</div>
       </Popover>
     )
   );


### PR DESCRIPTION
Looks like the warning is caused by the `Button` components from the library, `antd`.

Using ref as suggested didn't work, the warning is supposedly fixed on the library side.

• Solution 
   wrap the `antd`'s component with `div` tag without braking the original css style.

• Output
<img width="1427" alt="Screenshot 2023-06-03 at 6 54 10 PM" src="https://github.com/owncast/owncast/assets/69574727/b8ae35d7-3303-4383-899c-9b9a5d526697">

TT:#3034