### PR TITLE
feat: close modal after name change

### DIFF
--- a/web/components/common/UserDropdown/UserDropdown.tsx
+++ b/web/components/common/UserDropdown/UserDropdown.tsx
@@ -86,6 +86,10 @@ export const UserDropdown: FC<UserDropdownProps> = ({
     setShowNameChangeModal(true);
   };
 
+  const closeChangeNameModal = () => {
+    setShowNameChangeModal(false);
+  };
+
   // Register keyboard shortcut for the space bar to toggle playback
   useHotkeys(
     'c',
@@ -153,9 +157,9 @@ export const UserDropdown: FC<UserDropdownProps> = ({
         <Modal
           title="Change Chat Display Name"
           open={showNameChangeModal}
-          handleCancel={() => setShowNameChangeModal(false)}
+          handleCancel={closeChangeNameModal}
         >
-          <NameChangeModal />
+          <NameChangeModal closeChangeNameModal={closeChangeNameModal} />
         </Modal>
         <Modal
           title="Authenticate"

--- a/web/components/common/UserDropdown/UserDropdown.tsx
+++ b/web/components/common/UserDropdown/UserDropdown.tsx
@@ -159,7 +159,7 @@ export const UserDropdown: FC<UserDropdownProps> = ({
           open={showNameChangeModal}
           handleCancel={closeChangeNameModal}
         >
-          <NameChangeModal closeChangeNameModal={closeChangeNameModal} />
+          <NameChangeModal closeModal={closeChangeNameModal} />
         </Modal>
         <Modal
           title="Authenticate"

--- a/web/components/modals/NameChangeModal/NameChangeModal.stories.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.stories.tsx
@@ -27,7 +27,7 @@ const Example = () => {
 
   return (
     <div>
-      <NameChangeModal />
+      <NameChangeModal closeModal={() => {}} />
     </div>
   );
 };

--- a/web/components/modals/NameChangeModal/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.tsx
@@ -22,7 +22,11 @@ const UserColor: FC<UserColorProps> = ({ color }) => {
   return <div style={style} />;
 };
 
-export const NameChangeModal: FC = () => {
+type NameChangeModalProps = {
+  closeChangeNameModal: () => void;
+};
+
+export const NameChangeModal: FC<NameChangeModalProps> = ({ closeChangeNameModal }) => {
   const currentUser = useRecoilValue(currentUserAtom);
   const websocketService = useRecoilValue<WebsocketService>(websocketServiceAtom);
   const [newName, setNewName] = useState<string>(currentUser?.displayName);
@@ -44,6 +48,7 @@ export const NameChangeModal: FC = () => {
       newName,
     };
     websocketService.send(nameChange);
+    closeChangeNameModal();
   };
 
   const handleColorChange = (color: string) => {

--- a/web/components/modals/NameChangeModal/NameChangeModal.tsx
+++ b/web/components/modals/NameChangeModal/NameChangeModal.tsx
@@ -23,10 +23,10 @@ const UserColor: FC<UserColorProps> = ({ color }) => {
 };
 
 type NameChangeModalProps = {
-  closeChangeNameModal: () => void;
+  closeModal: () => void;
 };
 
-export const NameChangeModal: FC<NameChangeModalProps> = ({ closeChangeNameModal }) => {
+export const NameChangeModal: FC<NameChangeModalProps> = ({ closeModal }) => {
   const currentUser = useRecoilValue(currentUserAtom);
   const websocketService = useRecoilValue<WebsocketService>(websocketServiceAtom);
   const [newName, setNewName] = useState<string>(currentUser?.displayName);
@@ -48,7 +48,7 @@ export const NameChangeModal: FC<NameChangeModalProps> = ({ closeChangeNameModal
       newName,
     };
     websocketService.send(nameChange);
-    closeChangeNameModal();
+    closeModal();
   };
 
   const handleColorChange = (color: string) => {


### PR DESCRIPTION
# What does this PR do?
Fixes #3083

### Added auto close name change modal after changing name
https://github.com/owncast/owncast/assets/66241121/f4fe3631-a0fb-4a66-9362-57a16165bd7d



## Type of Change
- Feature (non-breaking change)

## How should this be tested?
- Start your broadcast, click on your username on the top-right, click on "Change name"
- A pop-up will open, change your username, then click on the "Change name" button
- The pop-up will auto close
