### PR TITLE
fix TitleNotifier crash

### DIFF
--- a/web/components/TitleNotifier/TitleNotifier.tsx
+++ b/web/components/TitleNotifier/TitleNotifier.tsx
@@ -58,8 +58,8 @@ export const TitleNotifier: FC<TitleNotifierProps> = ({ name }) => {
     }
 
     // Only alert on real chat messages from people.
-    const lastMessage = chatMessages[chatMessages.length - 1];
-    if (lastMessage.type !== 'CHAT') {
+    const lastMessage = chatMessages.at(-1);
+    if (!lastMessage || lastMessage.type !== 'CHAT') {
       return;
     }
 


### PR DESCRIPTION
rare chance of crashing when using ReactRefresh with an empty chat