### PR TITLE
username of repeat chat messages is display:none

### DIFF
--- a/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
@@ -20,6 +20,11 @@ $p-v-size: 2px;
     font-weight: 600;
   }
 
+  .repeatUser {
+    @extend .user;
+    display: none;
+  }
+
   .userBadges {
     margin-left: 3px;
   }

--- a/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.tsx
@@ -97,14 +97,12 @@ export const ChatUserMessage: FC<ChatUserMessageProps> = ({
       >
         <div className={styles.background} style={{ color }} />
 
-        {!sameUserAsLast && (
-          <UserTooltip user={user}>
-            <div className={styles.user} style={{ color }}>
-              <span className={styles.userName}>{displayName}</span>
-              <span className={styles.userBadges}>{badgeNodes}</span>
-            </div>
-          </UserTooltip>
-        )}
+        <UserTooltip user={user}>
+          <div className={sameUserAsLast ? styles.repeatUser : styles.user} style={{ color }}>
+            <span className={styles.userName}>{displayName}</span>
+            <span className={styles.userBadges}>{badgeNodes}</span>
+          </div>
+        </UserTooltip>
         <Tooltip title={formattedTimestamp} mouseEnterDelay={1}>
           <Interweave
             className={styles.message}


### PR DESCRIPTION
users who want to show repeat usernames can inject the following CSS: `[class^="ChatUserMessage_repeatUser"]{display:flex !important;}`

closes #3077