### PR TITLE
Fix highlight in video quality selection menu

### DIFF
--- a/web/components/video/OwncastPlayer/OwncastPlayer.tsx
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.tsx
@@ -81,15 +81,6 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
     }
   };
 
-  const setLatencyCompensatorItemTitle = t => {
-    const item = document.querySelector('.latency-toggle-item > .vjs-menu-item-text');
-    if (!item) {
-      return;
-    }
-
-    item.innerHTML = t;
-  };
-
   const startLatencyCompensator = () => {
     if (latencyCompensator) {
       latencyCompensator.stop();
@@ -101,8 +92,6 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
     latencyCompensator.setClockSkew(clockSkew);
     latencyCompensator.enable();
     setLocalStorage(LATENCY_COMPENSATION_ENABLED, true);
-
-    setLatencyCompensatorItemTitle('disable minimized latency');
   };
 
   const stopLatencyCompensator = () => {
@@ -112,17 +101,16 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
     latencyCompensator = null;
     latencyCompensatorEnabled = false;
     setLocalStorage(LATENCY_COMPENSATION_ENABLED, false);
-    setLatencyCompensatorItemTitle(
-      '<span style="font-size: 0.8em">enable minimized latency (experimental)</span>',
-    );
   };
 
+  // Toggle minimized latency mode. Return the new state.
   const toggleLatencyCompensator = () => {
     if (latencyCompensatorEnabled) {
       stopLatencyCompensator();
     } else {
       startLatencyCompensator();
     }
+    return latencyCompensatorEnabled;
   };
 
   const setupLatencyCompensator = player => {


### PR DESCRIPTION
Also removed dead code in video quality selection menu. Also 'minimize latency (experimental)' button is no longer renamed when pressed (it is now highlighted when enabled).

Closes #2760