### PR TITLE
highlighting: make case-insensitive, support unicode

### DIFF
--- a/web/components/chat/ChatUserMessage/customMatcher.ts
+++ b/web/components/chat/ChatUserMessage/customMatcher.ts
@@ -19,9 +19,18 @@ export class ChatMessageHighlightMatcher extends Matcher {
       return null;
     }
 
-    const highlightRegex = new RegExp(highlightString.replace(/\s/g, '\\s'), 'ui');
+    const escapedString = highlightString
+      .replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\s/g, '\\s');
 
-    const result = str.match(highlightRegex);
+    const normalizedString = escapedString.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+    let highlightRegex = escapedString;
+    if (escapedString !== normalizedString) {
+      highlightRegex = `(?:${escapedString})|(?:${normalizedString})`;
+    }
+
+    const result = str.match(new RegExp(highlightRegex, 'ui'));
 
     if (!result) {
       return null;

--- a/web/components/chat/ChatUserMessage/customMatcher.ts
+++ b/web/components/chat/ChatUserMessage/customMatcher.ts
@@ -19,7 +19,9 @@ export class ChatMessageHighlightMatcher extends Matcher {
       return null;
     }
 
-    const result = str.match(highlightString);
+    const highlightRegex = new RegExp(highlightString.replace(/\s/g, '\\s'), 'ui');
+
+    const result = str.match(highlightRegex);
 
     if (!result) {
       return null;

--- a/web/components/chat/ChatUserMessage/customMatcher.ts
+++ b/web/components/chat/ChatUserMessage/customMatcher.ts
@@ -20,7 +20,7 @@ export class ChatMessageHighlightMatcher extends Matcher {
     }
 
     const escapedString = highlightString
-      .replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
       .replace(/\s/g, '\\s');
 
     const normalizedString = escapedString.normalize('NFD').replace(/[\u0300-\u036f]/g, '');


### PR DESCRIPTION
Small change to make highlighting case-insensitive and to be unicode-aware for say, users with emoji or accented characters in their display name. Also allows matching any whitespace - I found it was pretty easy to say, accidentally insert a non-breaking-space when copying an emoji to use in my username. (alternatively it may be worth looking into normalizing usernames such that non-breaking-spaces are collapsed into a single regular space, I'll check that out, too).

Relies on the browser supprting unicode-aware RegExp, which is supported in all current browser versions: https://caniuse.com/mdn-javascript_builtins_regexp_unicode