### PR TITLE
Increase width of volume slider to 100px

### DIFF
--- a/web/components/video/VideoJS/VideoJS.scss
+++ b/web/components/video/VideoJS/VideoJS.scss
@@ -4,6 +4,11 @@
     color: var(--theme-color-components-text-on-light);
   }
 
+  .vjs-volume-bar.vjs-slider-horizontal {
+    width: 100px;
+    flex-shrink: 0;
+  }
+
   .vjs-menu li {
     color: var(--theme-color-components-text-on-dark);
   }


### PR DESCRIPTION
The 41px volume slider changed volume in 2.43% increments, making certain volume levels such as 1% impossible. A volume slider that's exactly 100px wide makes exact 1% increments possible.