### PR TITLE
replace grapheme-splitter with graphemer (updated fork)

### DIFF
--- a/web/components/chat/ChatTextField/ChatTextField.tsx
+++ b/web/components/chat/ChatTextField/ChatTextField.tsx
@@ -2,7 +2,7 @@ import { Popover } from 'antd';
 import React, { FC, useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import sanitizeHtml from 'sanitize-html';
-import GraphemeSplitter from 'grapheme-splitter';
+import Graphemer from 'graphemer';
 
 import dynamic from 'next/dynamic';
 import classNames from 'classnames';
@@ -34,7 +34,7 @@ export type ChatTextFieldProps = {
 
 const characterLimit = 300;
 const maxNodeDepth = 10;
-const graphemeSplitter = new GraphemeSplitter();
+const graphemer = new Graphemer();
 
 const getNodeTextContent = (node, depth) => {
   let text = '';
@@ -131,7 +131,7 @@ export const ChatTextField: FC<ChatTextFieldProps> = ({ defaultText, enabled, fo
 
   const getCharacterCount = () => {
     const message = getTextContent(contentEditable);
-    return graphemeSplitter.countGraphemes(message);
+    return graphemer.countGraphemes(message);
   };
 
   const sendMessage = () => {
@@ -141,7 +141,7 @@ export const ChatTextField: FC<ChatTextFieldProps> = ({ defaultText, enabled, fo
     }
 
     const message = getTextContent(contentEditable);
-    const count = graphemeSplitter.countGraphemes(message);
+    const count = graphemer.countGraphemes(message);
     if (count === 0 || count > characterLimit) return;
 
     websocketService.send({ type: MessageType.CHAT, body: message });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,7 @@
 				"chart.js": "^4.2.0",
 				"classnames": "2.3.2",
 				"date-fns": "^2.29.3",
-				"grapheme-splitter": "^1.0.4",
+				"graphemer": "^1.4.0",
 				"interweave": "^13.0.0",
 				"interweave-autolink": "^5.1.0",
 				"lodash": "4.17.21",
@@ -23546,16 +23546,10 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
 		"node_modules/gzip-size": {
 			"version": "6.0.0",
@@ -63525,16 +63519,10 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-		},
 		"graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
 		"gzip-size": {
 			"version": "6.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,7 @@
 		"chart.js": "^4.2.0",
 		"classnames": "2.3.2",
 		"date-fns": "^2.29.3",
-		"grapheme-splitter": "^1.0.4",
+		"graphemer": "^1.4.0",
 		"interweave": "^13.0.0",
 		"interweave-autolink": "^5.1.0",
 		"lodash": "4.17.21",


### PR DESCRIPTION
While doing some testing I discovered grapheme-splitter would not correctly split out some grapheme clusters. Turns out it hasn't been updated in a while, it looks like [graphemer](https://github.com/flmnt/graphemer) is the preferred fork.

It provides a drop-in compatible module, this should provide more accurate character counts in the chat.