### PR TITLE
contenteditable: remove warning about unknown property onContentChange

### DIFF
--- a/web/components/chat/ChatTextField/ContentEditable.tsx
+++ b/web/components/chat/ChatTextField/ContentEditable.tsx
@@ -53,6 +53,7 @@ export default class ContentEditable extends React.Component<ContentEditableProp
     const { tagName, html, ...newProps } = this.props;
 
     delete newProps.onRootRef;
+    delete newProps.onContentChange;
 
     return React.createElement(tagName || 'div', {
       ...newProps,


### PR DESCRIPTION
Noticed in the Javascript console there was a warning about onContentChange not being a react property, which is true - it just gets stored in props, and isn't needed by React to render.

So this just removes it from the call to create the div and keeps it in this.props.