### PR TITLE
chat: check that a new username is different before sending out updates

### DIFF
--- a/core/chat/events.go
+++ b/core/chat/events.go
@@ -63,6 +63,12 @@ func (s *Server) userNameChanged(eventData chatClientEvent) {
 	savedUser := user.GetUserByToken(eventData.client.accessToken)
 	oldName := savedUser.DisplayName
 
+	// Check that the new name is different from old.
+	if proposedUsername == oldName {
+		eventData.client.sendConnectedClientInfo()
+		return
+	}
+
 	// Save the new name
 	if err := user.ChangeUsername(eventData.client.User.ID, proposedUsername); err != nil {
 		log.Errorln("error changing username", err)


### PR DESCRIPTION
Just prevents a case where a user say, updates their current name by adding a bunch of spaces at the end, so the resulting new name is the same as the old, and the "user updated their name" goes out with the same name as before.