### PR TITLE
fix(chat): fix chat not using the correct messages selector. 

### DIFF
--- a/web/components/stores/ClientConfigStore.tsx
+++ b/web/components/stores/ClientConfigStore.tsx
@@ -174,7 +174,7 @@ export const ClientConfigStore: FC = () => {
   const setAppState = useSetRecoilState<AppStateOptions>(appStateAtom);
   const setGlobalFatalErrorMessage = useSetRecoilState<DisplayableError>(fatalErrorStateAtom);
   const setWebsocketService = useSetRecoilState<WebsocketService>(websocketServiceAtom);
-  const [hiddenMessageIds, setHiddenMessageIds] = useRecoilState<string[]>(removedMessageIdsAtom);
+  const setHiddenMessageIds = useSetRecoilState<string[]>(removedMessageIdsAtom);
   const [hasLoadedConfig, setHasLoadedConfig] = useState(false);
 
   let ws: WebsocketService;
@@ -279,11 +279,9 @@ export const ClientConfigStore: FC = () => {
   const handleMessageVisibilityChange = (message: MessageVisibilityEvent) => {
     const { ids, visible } = message;
     if (visible) {
-      const updatedIds = hiddenMessageIds.filter(id => !ids.includes(id));
-      setHiddenMessageIds(updatedIds);
+      setHiddenMessageIds(currentState => currentState.filter(id => !ids.includes(id)));
     } else {
-      const updatedIds = [...hiddenMessageIds, ...ids];
-      setHiddenMessageIds(updatedIds);
+      setHiddenMessageIds(currentState => [...currentState, ...ids]);
     }
   };
 

--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -10,7 +10,6 @@ import { canPushNotificationsBeSupported } from '../../../utils/browserPushNotif
 
 import {
   clientConfigStateAtom,
-  chatMessagesAtom,
   currentUserAtom,
   ChatState,
   chatStateAtom,
@@ -19,6 +18,7 @@ import {
   isMobileAtom,
   serverStatusState,
   isChatAvailableSelector,
+  visibleChatMessagesSelector,
 } from '../../stores/ClientConfigStore';
 import { ClientConfig } from '../../../interfaces/client-config.model';
 
@@ -103,7 +103,7 @@ export const Content: FC = () => {
   const currentUser = useRecoilValue(currentUserAtom);
   const serverStatus = useRecoilValue<ServerStatus>(serverStatusState);
   const [isMobile, setIsMobile] = useRecoilState<boolean | undefined>(isMobileAtom);
-  const messages = useRecoilValue<ChatMessage[]>(chatMessagesAtom);
+  const messages = useRecoilValue<ChatMessage[]>(visibleChatMessagesSelector);
   const online = useRecoilValue<boolean>(isOnlineSelector);
   const isChatAvailable = useRecoilValue<boolean>(isChatAvailableSelector);
 


### PR DESCRIPTION
Looks like at some point the wrong array of messages was changed to getting passed to chat. The two embed chat views are still correct, though.

Closes #3166