### PR TITLE
s3Storage: fix slice bounds out of range error

### DIFF
--- a/core/storageproviders/s3Storage.go
+++ b/core/storageproviders/s3Storage.go
@@ -200,7 +200,9 @@ func (s *S3Storage) Cleanup() error {
 		return err
 	}
 
-	s.deleteObjects(keys)
+	if len(keys) > 0 {
+		s.deleteObjects(keys)
+	}
 
 	return nil
 }
@@ -239,6 +241,10 @@ func (s *S3Storage) getDeletableVideoSegmentsWithOffset(offset int) ([]s3object,
 	objectsToDelete, err := s.retrieveAllVideoSegments()
 	if err != nil {
 		return nil, err
+	}
+
+	if offset > len(objectsToDelete)-1 {
+		offset = len(objectsToDelete) - 1
 	}
 
 	objectsToDelete = objectsToDelete[offset : len(objectsToDelete)-1]


### PR DESCRIPTION
Ran into this while testing out storage with a new, empty bucket - on the first iteration of trying to clean up segments, the offset was 30, but the number of segments only 19. This caused a panic when returning the slice `[30:18]`. The offset is now capped to return an empty slice in this case.

Additionally - now that an empty slice can be returned - the number of segments is checked before calling `deleteObjects` to prevent an s3 error about a malformed request.