### PR TITLE
Block Private URLs at `serverurl` API endpoint

### DIFF
--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
-	"regexp"
 
 	"github.com/owncast/owncast/activitypub/outbox"
 	"github.com/owncast/owncast/controllers"
@@ -407,12 +407,11 @@ func SetServerURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Block private IPv4 URLs of the range 10.0.0.0/8 and 192.168.0.0/16 with regexp
-	matchPvtURL_10, _ := regexp.MatchString(`10\.\d{1,3}\.\d{1,3}\.\d{1,3}.*`, serverHostString)
-	matchPvtURL_192_168, _ := regexp.MatchString(`192\.168\.\d{1,3}\.\d{1,3}.*`, serverHostString)
+	// Block Private IP URLs
+	ipAddr, ipErr := netip.ParseAddr(utils.GetHostnameWithoutPortFromURLString(rawValue))
 
-	if matchPvtURL_10 || matchPvtURL_192_168 {
-		controllers.WriteSimpleResponse(w, false, "Server URL cannot be a private URL")
+	if ipErr == nil && ipAddr.IsPrivate() {
+		controllers.WriteSimpleResponse(w, false, "Server URL cannot be private")
 		return
 	}
 

--- a/controllers/admin/config.go
+++ b/controllers/admin/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"regexp"
 
 	"github.com/owncast/owncast/activitypub/outbox"
 	"github.com/owncast/owncast/controllers"
@@ -403,6 +404,15 @@ func SetServerURL(w http.ResponseWriter, r *http.Request) {
 	serverHostString := utils.GetHostnameFromURLString(rawValue)
 	if serverHostString == "" {
 		controllers.WriteSimpleResponse(w, false, "server url value invalid")
+		return
+	}
+
+	// Block private IPv4 URLs of the range 10.0.0.0/8 and 192.168.0.0/16 with regexp
+	matchPvtURL_10, _ := regexp.MatchString(`10\.\d{1,3}\.\d{1,3}\.\d{1,3}.*`, serverHostString)
+	matchPvtURL_192_168, _ := regexp.MatchString(`192\.168\.\d{1,3}\.\d{1,3}.*`, serverHostString)
+
+	if matchPvtURL_10 || matchPvtURL_192_168 {
+		controllers.WriteSimpleResponse(w, false, "Server URL cannot be a private URL")
 		return
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -379,6 +379,16 @@ func GetHostnameFromURLString(s string) string {
 	return u.Host
 }
 
+// GetHostnameWithoutPortFromURLString will return the hostname component without the port from a URL object.
+func GetHostnameWithoutPortFromURLString(s string) string {
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+
+	return u.Hostname()
+}
+
 // GetHashtagsFromText returns all the #Hashtags from a string.
 func GetHashtagsFromText(text string) []string {
 	re := regexp.MustCompile(`#[a-zA-Z0-9_]+`)


### PR DESCRIPTION
Solves #3268 by introducing a regex check for Private URLs of the range `10.0.0.0/8` and `192.168.0.0/16` at the `/api/admin/config/serverurl` API endpoint