### PR TITLE
Handle error thrown in postConfigUpdateToAPI

### DIFF
--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -54,15 +54,22 @@ const TEXTFIELD_TYPE_URL = 'url';
 
 export async function postConfigUpdateToAPI(args: ApiPostArgs) {
   const { apiPath, data, onSuccess, onError } = args;
-  const result = await fetchData(`${SERVER_CONFIG_UPDATE_URL}${apiPath}`, {
-    data,
-    method: 'POST',
-    auth: true,
-  });
-  if (result.success && onSuccess) {
-    onSuccess(result.message);
-  } else if (onError) {
-    onError(result.message);
+  try {
+    const result = await fetchData(`${SERVER_CONFIG_UPDATE_URL}${apiPath}`, {
+      data,
+      method: 'POST',
+      auth: true,
+    });
+    if (result.success && onSuccess) {
+      onSuccess(result.message);
+    } else if (onError) {
+      onError(result.message);
+    }
+  }
+  catch (e) {
+    if (onError) {
+      onError(e.message);
+    }
   }
 }
 


### PR DESCRIPTION
**tldr**
This fix should resolve issue #3297 where the UI would display an uncaught error popup if the user tried to save an invalid url and received a non-2XX response from the server. The issue was broader than just this text field and affected all areas that called `postConfigUpdateToAPI()`.  

**More details**
1. `fetchData` will throw an Error when the `response.ok` is falsey
2. `postConfigUpdateToAPI` calls `await fetchData(...)` and does not handle the error being thrown. Instead it is checking `response.success && onSuccess` to handle success cases and anything else it will handle as error if there is an `onError` prop supplied (`web/utils/config-constants.tsx`)

Anywhere that uses `postConfigUpdateToAPI` will fail on error from server, not just this particular text field. I checked for direct `fetchData` calls throughout the code, most references will wrap it around a try/catch which is good but there are several instances where there is no try/catch so any server error will also most likely result in an uncaught error on the UI.

The two options that I considered and ultimately I went with option B.
A. Refactor `fetchData` to not throw an error when `response.ok` is falsey. CONS: You will need to refactor all `fetchData` calls.
B. Add try/catch in `postConfigUpdateToAPI` to handle errors thrown. PROs: We won't need to refactor any `fetchData` calls nor `postConfigUpdateToAPI` calls.