### PR TITLE
Stop Firefox from adding mysterious hash

### DIFF
--- a/web/components/stores/ClientConfigStore.tsx
+++ b/web/components/stores/ClientConfigStore.tsx
@@ -374,9 +374,7 @@ export const ClientConfigStore: FC = () => {
       const { socketHostOverride } = clientConfig;
 
       // Get a copy of the browser location without #fragments.
-      const l = window.location;
-      l.hash = '';
-      const location = l.toString().replaceAll('#', '');
+      const location = window.location.origin + window.location.pathname;
       const host = socketHostOverride || location;
 
       ws = new WebsocketService(accessToken, '/ws', host);


### PR DESCRIPTION
This resolves https://github.com/owncast/owncast/issues/3240

From the comments:
This was trickier than expected, but the root of the problem is Firefox will set `#` in the URL bar when `window.location.hash` is set to _any_ string, even a blank string. The morale of the story is, don't mutate base data if you just want to copy values. 😅

Sample of Firefox JavaScript console session that demonstrates the issue:
```javascript
>> window.location.href
"https://github.com/owncast/owncast/issues/3240"

>> const setBlankHash = () => { window.location.hash = ''; };
undefined

>> window.location.hash
""

>> window.location.href
"https://github.com/owncast/owncast/issues/3240"

>> setBlankHash()
undefined

>> // My browser just jumped to the top of the page
undefined

>> window.location.hash
""

>> window.location.href
"https://github.com/owncast/owncast/issues/3240#"
```

The main thing I'm uncertain about is, do we need to worry about query parameters? I don't think so since this is feeding the connection builder for websocket but let me know if it should be adjusted.
