### PR TITLE
Fix embedded status bar being cut off

### DIFF
--- a/web/components/video/OwncastPlayer/OwncastPlayer.module.scss
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.module.scss
@@ -30,8 +30,3 @@
     grid-row: 1;
   }
 }
-
-.embedded {
-  height: 96vh; // Leave room for the status bar
-  max-height: unset;
-}

--- a/web/components/video/OwncastPlayer/OwncastPlayer.tsx
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.tsx
@@ -29,7 +29,6 @@ export type OwncastPlayerProps = {
   initiallyMuted?: boolean;
   title: string;
   className?: string;
-  embedded?: boolean;
 };
 
 export const OwncastPlayer: FC<OwncastPlayerProps> = ({
@@ -38,7 +37,6 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
   initiallyMuted = false,
   title,
   className,
-  embedded = false,
 }) => {
   const VideoSettingsService = useContext(VideoSettingsServiceContext);
   const playerRef = React.useRef(null);
@@ -302,7 +300,7 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
       )}
     >
       <div
-        className={classNames(styles.container, className, embedded && styles.embedded)}
+        className={classNames(styles.container, className)}
         id="player"
       >
         {online && (

--- a/web/components/video/OwncastPlayer/OwncastPlayer.tsx
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.tsx
@@ -299,10 +299,7 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
         />
       )}
     >
-      <div
-        className={classNames(styles.container, className)}
-        id="player"
-      >
+      <div className={classNames(styles.container, className)} id="player">
         {online && (
           <div className={styles.player}>
             <VideoJS options={videoJsOptions} onReady={handlePlayerReady} aria-label={title} />

--- a/web/pages/embed/video/VideoEmbed.module.scss
+++ b/web/pages/embed/video/VideoEmbed.module.scss
@@ -1,8 +1,6 @@
 .onlineContainer {
-  height: 96vh;
+  height: 100vh;
   background-color: var(--theme-color-components-video-status-bar-background);
-
-  @media only screen and (width <= 768px) {
-    height: 100vh;
-  }
+	display: flex;
+	flex-direction: column;
 }

--- a/web/pages/embed/video/index.tsx
+++ b/web/pages/embed/video/index.tsx
@@ -79,7 +79,6 @@ export default function VideoEmbed() {
         online={online}
         initiallyMuted={initiallyMuted}
         title={streamTitle || name}
-        embedded
       />
       <Statusbar
         online={online}


### PR DESCRIPTION
# Description

This should resolve https://github.com/owncast/owncast/issues/3210.

As recommended in the discussion, flexbox was the way to solve this issue. The main thing that needed to be addressed though was not applying too many constraints on the OwncastPlayer component just because it was embedded. By removing the embedded constraints, styling appears to be working as expected. I'll attach screenshots to the pull request.

If there are other screenshots or material that would be good for me to gather for these UI changes to help with the review, please let me know.

# Screenshots

## Various configurations of `iframe`s (embedded)

<img width="1602" alt="Screenshot 2023-10-09 at 9 43 29 PM" src="https://github.com/owncast/owncast/assets/5209474/dbc58379-15b1-46d7-a808-4a46ad487055">

## `iframe` in docs (embedded)

<img width="1255" alt="Screenshot 2023-10-09 at 9 43 53 PM" src="https://github.com/owncast/owncast/assets/5209474/3edb406e-54f8-4c42-b74a-5e8d2fa6cd8d">

## Emulated mobile view of main stream site using Firefox (non-embedded)

<img width="779" alt="Screenshot 2023-10-09 at 9 44 09 PM" src="https://github.com/owncast/owncast/assets/5209474/5c3876e8-8151-4bd4-8ceb-c6495af17ee9">

## Desktop view of main stream site (non-embedded)

<img width="1720" alt="Screenshot 2023-10-09 at 9 44 20 PM" src="https://github.com/owncast/owncast/assets/5209474/ffdf1df9-d49e-4ce4-bd0d-a5a83637a19e">

