### PR TITLE
Remove "Live for XXX" message from aria-live area

### DIFF
--- a/web/components/ui/Statusbar/Statusbar.tsx
+++ b/web/components/ui/Statusbar/Statusbar.tsx
@@ -79,7 +79,9 @@ export const Statusbar: FC<StatusbarProps> = ({
 
   return (
     <div className={classNames(styles.statusbar, className)} role="status">
-      <span className={styles.onlineMessage}>{onlineMessage}</span>
+      <span aria-live="off" className={styles.onlineMessage}>
+        {onlineMessage}
+      </span>
       <span className={styles.viewerCount}>{rightSideMessage}</span>
     </div>
   );


### PR DESCRIPTION
This should resolve #3334 

### Description 
This PR sets the `aria-live` attribute to "off" on the `<span>` responsible for rendering the "live for XXX" message to avoid spamming screen readers with that message on every rendering cycle (i.e every second). 

I made sure to reproduce the issue and that it went away after introducing this fix. 