### PR TITLE
fix: issue with lint and prettier during js format build

### DIFF
--- a/.github/workflows/javascript-format-build.yml
+++ b/.github/workflows/javascript-format-build.yml
@@ -40,17 +40,13 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
+          path: 'web'
           files_ignore: |
             static/**
             web/next.config.js
           files_yaml: |
             src:
-              - 'web/**.js'
-              - 'web/**.ts'
-              - 'web/**.tsx'
-              - 'web/**.jsx'
-              - 'web/**.css'
-              - 'web/**.md'
+              - '**/*.{js,ts,tsx,jsx,css,md}'
 
       - name: Cache node modules
         uses: actions/cache@v3


### PR DESCRIPTION
Fixes: #3360 

The issue was with tj-action/changed-files step, it was trying to find files under `web` folder while working folder was also the `web`.
I have provided the path as `web` and refactor the `src` in a single line adding all the file formats.