### PR TITLE
Added a check for the port before calling the splitHostPort function

### DIFF
--- a/utils/clientId.go
+++ b/utils/clientId.go
@@ -26,14 +26,16 @@ func GetIPAddressFromRequest(req *http.Request) string {
 	xForwardedFor := req.Header.Get("X-FORWARDED-FOR")
 	if xForwardedFor != "" {
 		clientIpString := strings.Split(xForwardedFor, ", ")[0]
-		ip, _, err := net.SplitHostPort(clientIpString)
-		if err != nil {
-			log.Errorln(err)
-			return ""
+		if strings.Contains(clientIpString, ":") {
+			ip, _, err := net.SplitHostPort(clientIpString)
+			if err != nil {
+				log.Errorln(err)
+				return ""
+			}
+			return ip
 		}
-		return ip
+		return clientIpString
 	}
-
 	ip, _, err := net.SplitHostPort(ipAddressString)
 	if err != nil {
 		log.Errorln(err)


### PR DESCRIPTION
Resolves #3371  

The `net.SplitHostPart` returns an error in case a port is not present (i.e, no ":" in the string provided to the function). I therefore added a check for the semicolon before calling that function. 

@gabek Sorry for the confusion. Also, please let me know if you would rather see this bug fixed in a different way. 