### PR TITLE
Fix parsing of Authorization Bearer header

### DIFF
--- a/router/middleware/auth.go
+++ b/router/middleware/auth.go
@@ -69,10 +69,13 @@ func RequireExternalAPIAccessToken(scope string, handler ExternalAccessTokenHand
 			return
 		}
 
-		authHeader := strings.Split(r.Header.Get("Authorization"), "Bearer ")
-		token := strings.Join(authHeader, "")
+		authHeader := r.Header.Get("Authorization")
+		token := ""
+		if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+			token = authHeader[len("bearer "):]
+		}
 
-		if len(authHeader) == 0 || token == "" {
+		if token == "" {
 			log.Warnln("invalid access token")
 			accessDenied(w)
 			return

--- a/test/automated/api/integrations.test.js
+++ b/test/automated/api/integrations.test.js
@@ -83,7 +83,7 @@ test('send a system message using access token', async (done) => {
 	};
 	const res = await request
 		.post('/api/integrations/chat/system')
-		.set('Authorization', 'Bearer ' + accessToken)
+		.set('Authorization', 'bearer ' + accessToken)
 		.send(payload)
 		.expect(200);
 	done();


### PR DESCRIPTION
The semantics of the Authorization header are defined by RFC 9110, which says:

> It uses a case-insensitive token to identify the authentication scheme:

Therefore, "bearer", "Bearer", and "bEARER" are equivalent.  This patch fixes the parsing of the Authorization header to check for the Bearer authentication scheme case insensitively.

I've modified one of the test cases to use lowercase "bearer", so there's test coverage for this.