### PR TITLE
Refactor Ip address parsing to support ipv4 and ipv6

### DIFF
--- a/utils/clientId_test.go
+++ b/utils/clientId_test.go
@@ -7,21 +7,82 @@ import (
 
 func TestGetIPAddressFromRequest(t *testing.T) {
 
-	expectedResult := "203.0.113.195"
+	expectedIpv4Result := "203.0.113.195"
+	expectedIpv6Result := "2001:9e8:5221:4201:5221:7dff:fe53"
 
 	request := httptest.NewRequest("GET", "/", nil)
+
+	//Test ipv4 address without X-FORWARDED-FOR header (With Port set up)
 	request.RemoteAddr = "203.0.113.195:41237"
-	//First Test without X-FORWARDED-FOR header
 	result := GetIPAddressFromRequest(request)
-	if result != expectedResult {
-		t.Errorf("Remote address only test failed: Expected %s, got %s", expectedResult, result)
+	if result != expectedIpv4Result {
+		t.Errorf("IPV4 Remote address only (with Port) test failed: Expected %s, got %s", expectedIpv4Result, result)
 	}
 
-	//Test with X-FORWARDED-FOR header
-	request.Header.Set("X-FORWARDED-FOR header", "203.0.113.195:41237, 198.51.100.100:38523, 140.248.67.176:12345")
+	//Test ipv4 without X-FORWARDED-FOR header (Without Port set up)
+	request.RemoteAddr = "203.0.113.195"
 	result = GetIPAddressFromRequest(request)
-	if result != expectedResult {
-		t.Errorf("X-FORWARD-FOR header test failed: Expected %s, got %s", expectedResult, result)
+	if result != expectedIpv4Result {
+		t.Errorf("IPV4 Remote address only (without Port) test failed: Expected %s, got %s", expectedIpv4Result, result)
 	}
 
+	//Test ipv4 with X-FORWARDED-FOR header (With Port SetUp)
+	request.Header.Set("X-FORWARDED-FOR", "203.0.113.195:41237, 198.51.100.100:38523, 140.248.67.176:12345")
+	result = GetIPAddressFromRequest(request)
+	if result != expectedIpv4Result {
+		t.Errorf("IPV4 X-FORWARDED-FOR header (With Port) test failed: Expected %s, got %s", expectedIpv4Result, result)
+	}
+
+	//Test ipv4 with X-FORWARDED-FOR header (Without Port SetUp)
+	request.Header.Set("X-FORWARDED-FOR", "203.0.113.195, 198.51.100.100, 140.248.67.176")
+	result = GetIPAddressFromRequest(request)
+	if result != expectedIpv4Result {
+		t.Errorf("IPV4 X-FORWARDED-FOR header (Without Port) test failed: Expected %s, got %s", expectedIpv4Result, result)
+	}
+
+	//Reset X-FORWARDED-FOR Header
+	request.Header.Set("X-FORWARDED-FOR", "")
+
+	//Test ipv6 address without X-FORWARDED-FOR header (With Port Set Up)
+	request.RemoteAddr = "[2001:9e8:5221:4201:5221:7dff:fe53]:9080"
+	result = GetIPAddressFromRequest(request)
+	if result != expectedIpv6Result {
+		t.Errorf("IPV6 Remote address only (with Port) test failed: Expected %s, got %s", expectedIpv6Result, result)
+	}
+
+	//Test ipv6 address without X-FORWARDED-FOR header (Without Port Set Up)
+	request.RemoteAddr = "2001:9e8:5221:4201:5221:7dff:fe53"
+	result = GetIPAddressFromRequest(request)
+	if result != expectedIpv6Result {
+		t.Errorf("IPV6 Remote address only (with Port) test failed: Expected %s, got %s", expectedIpv6Result, result)
+	}
+
+	//Test ipv6 with X-FORWARDED-FOR header (Without Port SetUp)
+	request.Header.Set("X-FORWARDED-FOR", "2001:9e8:5221:4201:5221:7dff:fe53, 2002:9e7:5231:4211:5211:7eff:ee53, 2003:7e8:5221:4231:5221:7dff:ff53")
+	result = GetIPAddressFromRequest(request)
+	if result != expectedIpv6Result {
+		t.Errorf("IPV6 X-FORWARDED-FOR header (Without Port) test failed: Expected %s, got %s", expectedIpv6Result, result)
+	}
+
+	//Test ipv6 with X-FORWARDED-FOR header (With Port SetUp)
+	request.Header.Set("X-FORWARDED-FOR", "[2001:9e8:5221:4201:5221:7dff:fe53]:9080, [2002:9e7:5231:4211:5211:7eff:ee53]:9080, [2003:7e8:5221:4231:5221:7dff:ff53]:9080")
+	result = GetIPAddressFromRequest(request)
+	if result != expectedIpv6Result {
+		t.Errorf("IPV6 X-FORWARDED-FOR header (Without Port) test failed: Expected %s, got %s", expectedIpv6Result, result)
+	}
+}
+
+func TestIsIpv6(t *testing.T) {
+	ipv6AddressWithoutPort := "2001:9e8:5221:4201:5221:7dff:fe53"
+	ipv6AddressWithPort := "[2001:9e8:5221:4201:5221:7dff:fe53]:9080"
+	ipv4AddressWithoutPort := "203.0.113.195"
+	ipv4AddressWithPort := "203.0.113.195:9080"
+
+	if !isIPv6(ipv6AddressWithPort) || !isIPv6(ipv6AddressWithoutPort) {
+		t.Error("IPV6 format test returned false on a valid ipv6 address")
+	}
+
+	if isIPv6(ipv4AddressWithPort) || isIPv6(ipv4AddressWithoutPort) {
+		t.Error("IPV6 format test returned true on an invalid ipv6 address")
+	}
 }


### PR DESCRIPTION
Resolves #3419 
@gabek Sorry for taking a little while to get to this.  Here is a brief explanation of what was going on and how I addressed the issue: 

The `net.SplitHostPort` function does not have support for ipv6 addresses unless it is in the `[Host]:Port` format. Therefore, to go around this, I had to add a small check to determine which forma the input address is in (ipv4 or ipv6) and then if it's in the ipv6 format, check whether or not a port was provided (this is done via checking the existence of an open square bracket in the address), and if it is, pass the address to the `net.SplitHostPort`, otherwise, return the original address. 

I also did some refactoring of the `GetIPAddressFromRequest` function and it is now much more concise and readable. 

I finally added more tests for the different kind of scenarios that this function could face. 

Please let me know if you think there's something else that needs to be done to resolve this issue. I apologize for the incomplete/ugly implementation a while back as I was just starting with golang and the open source world in general 😅 