### PR TITLE
fix(video): add eventType support for touch devices

### DIFF
--- a/web/components/video/settings-menu.ts
+++ b/web/components/video/settings-menu.ts
@@ -58,10 +58,17 @@ export function createVideoSettingsMenuButton(
         });
       });
 
+      let clickEvent;
+      if ('ontouchstart' in window) {
+        clickEvent = 'touchend'; // Use touchend event for touch devices
+      } else {
+        clickEvent = 'click'; // Use click for all other devices
+      }
+
       for (let i = 0; i < items.length; i += 1) {
         const item = items[i];
         // Quality selected
-        item.on('click', () => {
+        item.on(clickEvent, () => {
           // If for some reason tech doesn't exist, then don't do anything
           if (!tech) {
             console.warn('Invalid attempt to access null player tech');
@@ -77,7 +84,7 @@ export function createVideoSettingsMenuButton(
         });
       }
 
-      defaultAutoItem.on('click', () => {
+      defaultAutoItem.on(clickEvent, () => {
         // Re-enable all representations.
         tech.vhs.representations().forEach(rep => {
           rep.enabled(true);


### PR DESCRIPTION
fixes #3368 

The select event was not being fired on touch devices since we were using a callback to register only the `click` event. For most of the touch devices we need to register some sort of touch event like `touchstart` or `touchend`.

So now we have added `touchend` support to register touch events.

```
let clickEvent;
if ('ontouchstart' in window) {
    clickEvent = 'touchend'; // Use touchend event for touch devices
} else {
    clickEvent = 'click'; // Use click for all other devices
}
```

Tested these changes on LambdaTest iPhone 15 device in Real-Time