### PR TITLE
Fixed page size stale state on LogTable component

### DIFF
--- a/web/components/admin/LogTable.tsx
+++ b/web/components/admin/LogTable.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { Table, Tag, Typography } from 'antd';
 import Linkify from 'react-linkify';
-import { SortOrder } from 'antd/lib/table/interface';
+import { SortOrder, TablePaginationConfig } from 'antd/lib/table/interface';
 import format from 'date-fns/format';
 
 const { Title } = Typography;
@@ -24,13 +24,19 @@ function renderMessage(text) {
 
 export type LogTableProps = {
   logs: object[];
-  pageSize: number;
+  initialPageSize: number;
 };
 
-export const LogTable: FC<LogTableProps> = ({ logs, pageSize }) => {
+export const LogTable: FC<LogTableProps> = ({ logs, initialPageSize }) => {
   if (!logs?.length) {
     return null;
   }
+
+  const [pageSize, setPageSize] = useState(initialPageSize);
+  const handleTableChange = (pagination: TablePaginationConfig) => {
+    setPageSize(pagination.pageSize);
+  };
+
   const columns = [
     {
       title: 'Level',
@@ -81,7 +87,10 @@ export const LogTable: FC<LogTableProps> = ({ logs, pageSize }) => {
         dataSource={logs}
         columns={columns}
         rowKey={row => row.time}
-        pagination={{ pageSize: pageSize || 20 }}
+        pagination={{
+          pageSize,
+        }}
+        onChange={handleTableChange}
       />
     </div>
   );

--- a/web/components/admin/Offline.tsx
+++ b/web/components/admin/Offline.tsx
@@ -170,7 +170,7 @@ export const Offline: FC<OfflineProps> = ({ logs = [], config }) => {
           <NewsFeed />
         </Col>
       </Row>
-      <LogTable logs={logs} pageSize={5} />
+      <LogTable logs={logs} initialPageSize={5} />
     </>
   );
 };

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -187,7 +187,7 @@ export default function Home() {
         </Row>
       </div>
       <br />
-      <LogTable logs={logsData} pageSize={5} />
+      <LogTable logs={logsData} initialPageSize={5} />
     </div>
   );
 }

--- a/web/pages/admin/logs.tsx
+++ b/web/pages/admin/logs.tsx
@@ -32,7 +32,7 @@ export default function Logs() {
     };
   }, []);
 
-  return <LogTable logs={logs} pageSize={20} />;
+  return <LogTable logs={logs} initialPageSize={20} />;
 }
 
 Logs.getLayout = function getLayout(page: ReactElement) {


### PR DESCRIPTION
Closes #3511 

@gabek, In fact, I think I was right about the stale state causing the page size to revert back to whatever was being passed as props. I therefore added a piece of state to the `LogTable` component that gets updated when the state changes and this fixed the issue. 

Another alternative is to just change the table component to be called as follows. 

`<Table
        size="middle"
        dataSource={logs}
        columns={columns}
        rowKey={row => row.time}
        pagination={{
          defaultPageSize: pageSize,
          showSizeChanger: true, 
          pageSizeOptions: [10, 20, 50, 100]
        }}
      />`

However, this will cause the size changer to appear right away even if there is only a few logs as opposed to it appearing automatically after a certain amount of logs have been generated (which is the current behavior)

Let me know which one you prefer and I can adjust the code accordingly.