### PR TITLE
Slight refactor of HLS segment cleanup to fix object storage thumbs/previews

### DIFF
--- a/core/storageproviders/localCleanup.go
+++ b/core/storageproviders/localCleanup.go
@@ -1,0 +1,39 @@
+package storageproviders
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/owncast/owncast/config"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func localCleanup(maxNumber int) error {
+	baseDirectory := config.HLSStoragePath
+
+	files, err := getAllFilesRecursive(baseDirectory)
+	if err != nil {
+		return errors.Wrap(err, "unable find old video files for cleanup")
+	}
+
+	// Delete old private HLS files on disk
+	for directory := range files {
+		files := files[directory]
+		if len(files) < maxNumber {
+			continue
+		}
+
+		filesToDelete := files[maxNumber:]
+		log.Traceln("Deleting", len(filesToDelete), "old files from", baseDirectory, "for video variant", directory)
+
+		for _, file := range filesToDelete {
+			fileToDelete := filepath.Join(baseDirectory, directory, file.Name())
+			err := os.Remove(fileToDelete)
+			if err != nil {
+				return errors.Wrap(err, "unable to delete old video files")
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #3522

Previously, when using object storage, we would immediately delete the local version of the file once it's been uploaded. This means there's often there's no available segments on disk to generate thumbnails and previews from.

This change makes the local and object storage providers share the same cleanup logic and allows for some segments on disk to create thumbs and previews from.