### PR TITLE
set content-type for customjavascript

### DIFF
--- a/controllers/customJavascript.go
+++ b/controllers/customJavascript.go
@@ -8,6 +8,8 @@ import (
 
 // ServeCustomJavascript will serve optional custom Javascript.
 func ServeCustomJavascript(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript")
+
 	js := data.GetCustomJavascript()
 	_, _ = w.Write([]byte(js))
 }

--- a/controllers/customJavascript.go
+++ b/controllers/customJavascript.go
@@ -8,7 +8,7 @@ import (
 
 // ServeCustomJavascript will serve optional custom Javascript.
 func ServeCustomJavascript(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/javascript")
+	w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
 
 	js := data.GetCustomJavascript()
 	_, _ = w.Write([]byte(js))


### PR DESCRIPTION
Currently (v0.1.2) the resource /customjavascript is served with "content-type: text/plain; charset=utf-8" and is therefore blocked when combined with "X-Content-Type-Options: nosniff", which may be added by a reverse proxy. So we should set the correct content-type header when we deliver this resource. 

I'm a complete stranger to GO, therefore please review/validate/test before merging.