### PR TITLE
prevent css-loader v7 renaming default to _default, needed for storybook

### DIFF
--- a/web/.storybook/main.js
+++ b/web/.storybook/main.js
@@ -50,6 +50,7 @@ module.exports = {
                   // Want to add more CSS Modules options? Read more here: https://github.com/webpack-contrib/css-loader#modules
                   modules: {
                     auto: true,
+		    namedExport: false,
                   },
                   importLoaders: 2,
                 },


### PR DESCRIPTION
Storybook works again locally. Might still need this for v8.

See [here](https://www.github.com/webpack-contrib/css-loader/issues/1589) for ref