### PR TITLE
Increase max video bitrate and slider marks

### DIFF
--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -440,7 +440,7 @@ export const FRAMERATE_TOOLTIPS = {
 // VIDEO VARIANT FORM - bitrate
 export const VIDEO_BITRATE_DEFAULTS = {
   min: 400,
-  max: 6000,
+  max: 15000,
   defaultValue: 1200,
   unit: 'kbps',
   incrementBy: 100,
@@ -462,11 +462,11 @@ export const VIDEO_BITRATE_SLIDER_MARKS = {
     },
     label: `${VIDEO_BITRATE_DEFAULTS.min} ${VIDEO_BITRATE_DEFAULTS.unit}`,
   },
-  3000: 3000,
-  4500: 4500,
+  6000: 6000,
+  10000: 10000,
   [VIDEO_BITRATE_DEFAULTS.max]: {
     style: {
-      marginLeft: '-10px',
+      marginLeft: '-20px',
     },
     label: `${VIDEO_BITRATE_DEFAULTS.max} ${VIDEO_BITRATE_DEFAULTS.unit}`,
   },

--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -466,7 +466,7 @@ export const VIDEO_BITRATE_SLIDER_MARKS = {
   10000: 10000,
   [VIDEO_BITRATE_DEFAULTS.max]: {
     style: {
-      marginLeft: '-20px',
+      marginLeft: '-10px',
     },
     label: `${VIDEO_BITRATE_DEFAULTS.max} ${VIDEO_BITRATE_DEFAULTS.unit}`,
   },

--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -462,7 +462,7 @@ export const VIDEO_BITRATE_SLIDER_MARKS = {
     },
     label: `${VIDEO_BITRATE_DEFAULTS.min} ${VIDEO_BITRATE_DEFAULTS.unit}`,
   },
-  6000: 6000,
+  5000: 5000,
   10000: 10000,
   [VIDEO_BITRATE_DEFAULTS.max]: {
     style: {


### PR DESCRIPTION
Increases the max video bitrate to 15000 kbps, doesn't require changes in the backend.
Because it's 2024.

![image](https://github.com/owncast/owncast/assets/23409814/642f7d88-1d19-4431-a83e-e9c123c098c3)
