### PR TITLE
Add previous testRunner jasmine2, add ws dependency explicitly

### DIFF
--- a/test/automated/api/package.json
+++ b/test/automated/api/package.json
@@ -17,10 +17,13 @@
 		"crypto-random": "^2.0.1"
 	},
 	"devDependencies": {
-		"jest": "^29.7.0"
+		"jest": "^29.7.0",
+		"jest-jasmine2": "^29.7.0",
+		"ws": "^7.5.9"
 	},
 	"jest": {
 		"verbose": true,
-		"maxWorkers": 1
+		"maxWorkers": 1,
+		"testRunner": "jest-jasmine2"
 	}
 }


### PR DESCRIPTION
- v27 changed the default `testRunner` from `jest-jasmine2` to `jest-circus`. v28 moved `jest-jasmine2` to its own module.
- v28 also removed `jest-environment-jsdom` from the jest deps, which is why `ws` was even being installed. v8 `ws` has breaking changes as well, `websocket` is just not used.

https://jestjs.io/blog/2020/05/05/jest-26

Not including the package-lock since my npm install keeps shuffling things around for no reason.