### PR TITLE
Fix loading user provided static files

### DIFF
--- a/static/static.go
+++ b/static/static.go
@@ -71,10 +71,10 @@ func getFileSystemStaticFileOrDefault(path string, defaultData []byte) []byte {
 	fullPath := filepath.Join("static", path)
 	data, err := os.ReadFile(fullPath) //nolint: gosec
 	if err != nil {
-		return defaultData
+		return data
 	}
 
-	return data
+	return defaultData
 }
 
 //go:embed metadata.html.tmpl


### PR DESCRIPTION
Actually attempt to load user provided files in the "static" directory.

Before, on successful reading, the file would be ignored. This change fixes that.