### PR TITLE
Override default videojs volume panel width

### DIFF
--- a/web/components/video/VideoJS/VideoJS.scss
+++ b/web/components/video/VideoJS/VideoJS.scss
@@ -9,6 +9,12 @@
     flex-shrink: 0;
   }
 
+	.vjs-hover.vjs-volume-panel-horizontal {
+		// vjs default is 5em icon+padding + 5em slider.
+		// should match the value above.
+  	width: calc(5em + 100px) !important;
+	}
+	
   .vjs-menu li {
     color: var(--theme-color-components-text-on-dark);
   }


### PR DESCRIPTION
Closes #3497.

Fixes the fade out for > 55% volume. Height may or may not also need to be changed.