### PR TITLE
Adjust CleanupDirectory function to support tmpfs mounts.

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -306,17 +306,17 @@ func VerifyFFMpegPath(path string) error {
 func CleanupDirectory(path string) {
 	log.Traceln("Cleaning", path)
 	if err := os.MkdirAll(path, 0o750); err != nil {
-	    log.Fatalf("Unable to create '%s'. Please check the ownership and permissions: %s\n", path, err)
+		log.Fatalf("Unable to create '%s'. Please check the ownership and permissions: %s\n", path, err)
 	}
 	entries, err := os.ReadDir(path)
 	if err != nil {
-	    log.Fatalf("Unable to read contents of '%s'. Please check the ownership and permissions: %s\n", path, err)
+		log.Fatalf("Unable to read contents of '%s'. Please check the ownership and permissions: %s\n", path, err)
 	}
 	for _, entry := range entries {
-	    entryPath := filepath.Join(path, entry.Name())
-	    if err := os.RemoveAll(entryPath); err != nil {
-	        log.Fatalf("Unable to remove file or directory contained in '%s'. Please check the ownership and permissions: %s\n", path, err)
-	    }
+		entryPath := filepath.Join(path, entry.Name())
+		if err := os.RemoveAll(entryPath); err != nil {
+			log.Fatalf("Unable to remove file or directory contained in '%s'. Please check the ownership and permissions: %s\n", path, err)
+		}
 	}
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -307,16 +307,16 @@ func VerifyFFMpegPath(path string) error {
 func CleanupDirectory(path string) {
 	log.Traceln("Cleaning", path)
 	if err := os.MkdirAll(path, 0o750); err != nil {
-	    log.Fatalln("Unable to create directory. Please check the ownership and permissions", err)
+	    log.Fatalf("Unable to create '%s'. Please check the ownership and permissions: %s\n", path, err)
 	}
 	entries, err := ioutil.ReadDir(path)
 	if err != nil {
-	    log.Fatalln("Unable to read contents of directory. Please check the ownership and permissions", err)
+	    log.Fatalf("Unable to read contents of '%s'. Please check the ownership and permissions: %s\n", path, err)
 	}
 	for _, entry := range entries {
 	    entryPath := filepath.Join(path, entry.Name())
 	    if err := os.RemoveAll(entryPath); err != nil {
-	        log.Fatalln("Unable to remove directory. Please check the ownership and permissions", err)
+	        log.Fatalf("Unable to remove file or directory contained in '%s'. Please check the ownership and permissions: %s\n", path, err)
 	    }
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -309,7 +308,7 @@ func CleanupDirectory(path string) {
 	if err := os.MkdirAll(path, 0o750); err != nil {
 	    log.Fatalf("Unable to create '%s'. Please check the ownership and permissions: %s\n", path, err)
 	}
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 	    log.Fatalf("Unable to read contents of '%s'. Please check the ownership and permissions: %s\n", path, err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -303,9 +303,12 @@ func VerifyFFMpegPath(path string) error {
 	return nil
 }
 
-// CleanupDirectory removes all contents within the directory. Throws fatal error on failure.
+// CleanupDirectory removes all contents within the directory, or creates it if it does not exist. Throws fatal error on failure.
 func CleanupDirectory(path string) {
 	log.Traceln("Cleaning", path)
+	if err := os.MkdirAll(path, 0o750); err != nil {
+	    log.Fatalln("Unable to create directory. Please check the ownership and permissions", err)
+	}
 	entries, err := ioutil.ReadDir(path)
 	if err != nil {
 	    log.Fatalln("Unable to read contents of directory. Please check the ownership and permissions", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -302,14 +303,18 @@ func VerifyFFMpegPath(path string) error {
 	return nil
 }
 
-// CleanupDirectory removes the directory and makes it fresh again. Throws fatal error on failure.
+// CleanupDirectory removes all contents within the directory. Throws fatal error on failure.
 func CleanupDirectory(path string) {
 	log.Traceln("Cleaning", path)
-	if err := os.RemoveAll(path); err != nil {
-		log.Fatalln("Unable to remove directory. Please check the ownership and permissions", err)
+	entries, err := ioutil.ReadDir(path)
+	if err != nil {
+	    log.Fatalln("Unable to read contents of directory. Please check the ownership and permissions", err)
 	}
-	if err := os.MkdirAll(path, 0o750); err != nil {
-		log.Fatalln("Unable to create directory. Please check the ownership and permissions", err)
+	for _, entry := range entries {
+	    entryPath := filepath.Join(path, entry.Name())
+	    if err := os.RemoveAll(entryPath); err != nil {
+	        log.Fatalln("Unable to remove directory. Please check the ownership and permissions", err)
+	    }
 	}
 }
 


### PR DESCRIPTION
On my Owncast instance, I wanted to reduce the number of writes to my server's solid state drives caused by constant writes to the "hls" folder during live streams. To accomplish this, I set up a tmpfs mount on the "hls" folder to use a RAM-based filesystem rather than the normal SSD-backed filesystem. Below is the relevant snippet from my Docker compose file:

```yml
tmpfs:
  - /app/data/hls:mode=755,uid=101,gid=101
```

However, Owncast currently clears out the "hls" directory by deleting and recreating it entirely. While simple and effective, this method isn't compatible with mounts at that location. As a result, when Owncast tries to clear the "hls" directory on startup, it fails with the following error:

```
owncast    | time="2024-07-05T00:18:55Z" level=info msg="Owncast v0.1.3-linux-64bit (6ae3167b61d8485d3f269bd422f0c1a1f072ea5c)"
owncast    | time="2024-07-05T00:18:55Z" level=fatal msg="Unable to remove directory. Please check the ownership and permissions unlinkat data/hls: device or resource busy"
```

To work around this issue, I modified the `CleanupDirectory` function to iterate through and delete each file and folder within the "hls" directory individually. This approach maintains compatibility with mounts and prevents the "device or resource busy" error while still achieving the desired cleanup.

I have tested this change on my main instance with a tmpfs mount on the "hls" folder, as well as on a brand new normal install without any custom mounts.