### PR TITLE
mvdan/xurls 2.x bump fixes

### DIFF
--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -17,7 +17,7 @@ import (
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/util"
-	"mvdan.cc/xurls"
+	"mvdan.cc/xurls/v2"
 
 	"github.com/owncast/owncast/core/data"
 	"github.com/owncast/owncast/models"

--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -220,7 +220,7 @@ func RenderMarkdown(raw string) string {
 					[]byte("https:"),
 				}),
 				extension.WithLinkifyURLRegexp(
-					xurls.Strict,
+					xurls.Strict(),
 				),
 			),
 			emoji.New(

--- a/go.sum
+++ b/go.sum
@@ -269,4 +269,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 mvdan.cc/xurls v1.1.0 h1:kj0j2lonKseISJCiq1Tfk+iTv65dDGCl0rTbanXJGGc=
 mvdan.cc/xurls v1.1.0/go.mod h1:TNWuhvo+IqbUCmtUIb/3LJSQdrzel8loVpgFm0HikbI=
+mvdan.cc/xurls/v2 v2.5.0 h1:lyBNOm8Wo71UknhUs4QTFUNNMyxy2JEIaKKo0RWOh+8=
 mvdan.cc/xurls/v2 v2.5.0/go.mod h1:yQgaGQ1rFtJUzkmKiHYSSfuQxqfYmd//X6PxvholpeE=

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -162,7 +162,7 @@ func RenderSimpleMarkdown(raw string) string {
 					[]byte("https:"),
 				}),
 				extension.WithLinkifyURLRegexp(
-					xurls.Strict,
+					xurls.Strict(),
 				),
 			),
 		),
@@ -191,7 +191,7 @@ func RenderPageContentMarkdown(raw string) string {
 					[]byte("https:"),
 				}),
 				extension.WithLinkifyURLRegexp(
-					xurls.Strict,
+					xurls.Strict(),
 				),
 			),
 		),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,7 +21,7 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
-	"mvdan.cc/xurls"
+	"mvdan.cc/xurls/v2"
 )
 
 // DoesFileExists checks if the file exists.


### PR DESCRIPTION
Builds successfully.

See https://github.com/mvdan/xurls/releases/tag/v2.0.0 for relevant changes:

- Convert to a Go module, now `mvdan.cc/xurls/v2`
- Convert Strict and Regexp to functions