### PR TITLE
fix: update Alpine base image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION --new-platform 0.6
 
-FROM --platform=linux/amd64 alpine:3.15.5
+FROM --platform=linux/amd64 alpine:3.20.3
 ARG version=develop
 
 WORKDIR /build
@@ -119,7 +119,7 @@ docker:
 	# in as space separated strings using the full account/repo:tag format.
 	# https://github.com/earthly/earthly/blob/aea38448fa9c0064b1b70d61be717ae740689fb9/docs/earthfile/earthfile.md#assigning-multiple-image-names
   ARG TARGETPLATFORM
-  FROM --platform=$TARGETPLATFORM alpine:3.15.5
+  FROM --platform=$TARGETPLATFORM alpine:3.20.3
   RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs ca-certificates unzip && update-ca-certificates
   RUN addgroup -g 101 -S owncast && adduser -u 101 -S owncast -G owncast
   WORKDIR /app

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,13 @@
 	"major": {
 		"dependencyDashboardApproval": true
 	},
+	"docker": {
+		"fileMatch": [
+			"(^|/)Earthfile$",
+			"(^|/|\\.)Dockerfile$",
+			"(^|/)Dockerfile[^/]*$"
+		]
+	},
 	"packageRules": [
 		{
 			"description": "Automatically merge minor and patch-level updates",


### PR DESCRIPTION
Alpine 3.11 is out of support since nearly a year.

This also brings the versions in `Dockerfile` and `Earthfile` in sync again.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)