### PR TITLE
fix(web): long usernames in chat truncated and added ellipsis

### DIFF
--- a/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
+++ b/web/components/chat/ChatUserMessage/ChatUserMessage.module.scss
@@ -33,6 +33,11 @@ $p-v-size: 2px;
     display: none;
   }
 
+  .userName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .userBadges {
     margin-left: 3px;
     display: flex;


### PR DESCRIPTION

## Description

Added overflow hidden and text-overflow ellipsis to class userName 

Fixes #3749 

## Screenshot Examples or Logs
![image](https://github.com/user-attachments/assets/d7048212-3f74-4f34-b95e-e53f5993e0ca)
---