### PR TITLE
Fix websocket reconnection

### DIFF
--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/web/services/websocket-service.ts
+++ b/web/services/websocket-service.ts
@@ -56,7 +56,7 @@ export default class WebsocketService {
 
     const ws = new WebSocket(url.toString());
     ws.onopen = this.onOpen.bind(this);
-    ws.onerror = this.onError.bind(this);
+    ws.onclose = this.onClose.bind(this);
     ws.onmessage = this.onMessage.bind(this);
 
     this.websocket = ws;
@@ -70,12 +70,10 @@ export default class WebsocketService {
     this.backOff = 0;
   }
 
-  // On ws error just close the socket and let it re-connect again for now.
-  onError() {
-    handleNetworkingError();
-    this.socketDisconnected();
-    this.websocket.close();
+  onClose() {
     if (!this.isShutdown) {
+      handleNetworkingError();
+      this.socketDisconnected();
       this.scheduleReconnect();
     }
   }


### PR DESCRIPTION
The `onerror` event is only triggered if the buffer is full while the socket is closed, while the `onclose` event is called for any kind of disconnection: https://websockets.spec.whatwg.org/#closeWebSocket

Fixes https://github.com/owncast/owncast/issues/3958