### PR TITLE
Change websocket mock from empty function to empty class

### DIFF
--- a/web/components/layouts/Main/Main.stories.tsx
+++ b/web/components/layouts/Main/Main.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 
 // mock the Websocket to prevent ani webhook calls from being made in storybook
 // @ts-ignore
-window.WebSocket = () => {};
+window.WebSocket = class {};
 
 type StateInitializer = (mutableState: MutableSnapshot) => void;
 


### PR DESCRIPTION
Changes the websocket mock in the Main Layout story to an empty class.

Currently all 3 of the Online layout stories, eg: https://owncast.online/components/?path=/story/owncast-layout-main--online&globals=viewport:tablet have the chat disabled.

https://github.com/owncast/owncast/blob/97fcdfd914b70f2ba0f02900e72d46a9ea05af76/web/services/websocket-service.ts#L57

https://github.com/owncast/owncast/blob/97fcdfd914b70f2ba0f02900e72d46a9ea05af76/web/components/stores/ClientConfigStore.tsx#L385-L387

`startChat()` errors out because `WebSocket` doesn't have a constructor (no clue why it didn't trip before now). The catch block then disables chat. This PR fixes this.

Reverting commit since using `class {}` still works fine.

Added: The chromatic workflow seems a bit borked in general. You can check the published story here instead of the snapshot: https://629132c6e23893003a9e89c5-xswkrksufp.chromatic.com/?path=/story/owncast-layout-main--online. Works fine, as does the 3d01225 commit. The reason *that* commit's storybook doesn't show it working is because the workflow always checks out the fork's `develop` branch instead of the PR branch.