### PR TITLE
Communicate and handle apub outgoing updates being delayed

### DIFF
--- a/activitypub/workerpool/outbound.go
+++ b/activitypub/workerpool/outbound.go
@@ -19,7 +19,7 @@ var queue chan Job
 
 // InitOutboundWorkerPool starts n go routines that await ActivityPub jobs.
 func InitOutboundWorkerPool() {
-	queue = make(chan Job)
+	queue = make(chan Job, workerPoolSize*5) // arbitrary buffer value.
 
 	// start workers
 	for i := 1; i <= workerPoolSize; i++ {

--- a/activitypub/workerpool/outbound.go
+++ b/activitypub/workerpool/outbound.go
@@ -31,11 +31,11 @@ func InitOutboundWorkerPool() {
 func AddToOutboundQueue(req *http.Request) {
 	select {
 	case queue <- Job{req}:
-		log.Tracef("Queued request for ActivityPub destination %s", req.RequestURI)
 	default:
 		log.Warnln("Outbound ActivityPub job queue is full")
 		queue <- Job{req} // will block until received by a worker at this point
 	}
+	log.Tracef("Queued request for ActivityPub destination %s", req.RequestURI)
 }
 
 func worker(workerID int, queue <-chan Job) {

--- a/web/components/admin/FormStatusIndicator.tsx
+++ b/web/components/admin/FormStatusIndicator.tsx
@@ -12,7 +12,7 @@ export const FormStatusIndicator: FC<FormStatusIndicatorProps> = ({ status }) =>
   const classes = classNames({
     'status-container': true,
     [`status-${type}`]: type,
-    empty: !message,
+    empty: !message && !icon,
   });
   return (
     <span className={classes}>

--- a/web/components/admin/config/general/EditSocialLinks.tsx
+++ b/web/components/admin/config/general/EditSocialLinks.tsx
@@ -19,7 +19,12 @@ import {
   DEFAULT_TEXTFIELD_URL_PATTERN,
 } from '../../../../utils/validators';
 import { TextField } from '../../TextField';
-import { createInputStatus, STATUS_ERROR, STATUS_SUCCESS } from '../../../../utils/input-statuses';
+import {
+  createInputStatus,
+  STATUS_ERROR,
+  STATUS_PROCESSING,
+  STATUS_SUCCESS,
+} from '../../../../utils/input-statuses';
 import { FormStatusIndicator } from '../../FormStatusIndicator';
 
 const { Title } = Typography;
@@ -140,6 +145,10 @@ export default function EditSocialLinks() {
 
   // posts all the variants at once as an array obj
   const postUpdateToAPI = async (postValue: any) => {
+    if (!displayModal) { // only create the processing status if the modal is inactive
+      resetTimer = null;
+      setSubmitStatus(createInputStatus(STATUS_PROCESSING));
+    }
     await postConfigUpdateToAPI({
       apiPath: API_SOCIAL_HANDLES,
       data: { value: postValue },

--- a/web/components/admin/config/general/EditSocialLinks.tsx
+++ b/web/components/admin/config/general/EditSocialLinks.tsx
@@ -145,7 +145,8 @@ export default function EditSocialLinks() {
 
   // posts all the variants at once as an array obj
   const postUpdateToAPI = async (postValue: any) => {
-    if (!displayModal) { // only create the processing status if the modal is inactive
+    if (!displayModal) {
+      // only create the processing status if the modal is inactive
       resetTimer = null;
       setSubmitStatus(createInputStatus(STATUS_PROCESSING));
     }


### PR DESCRIPTION
#3229 and #3811. Mitigation, not a full fix.

Currently, some API calls will federate updates to followers. While this does not wait for all requests to receive a response, this will wait for *all requests to be queued*. This only happens once (n followers - workerPoolSize) requests have been processed in the best case. This will block the API call from returning anything, and since the progress status indicator has also not been working, there is no feedback to the admin. This PR:

- Makes icon-only status messages (current default for processing) show up for all input fields.
- Buffer the apub outbound queue so more messages can be queued without blocking.
- Add a warning message in the event that the outbound queue is full.

Potential additions, not sure if needed:
- Just having a delay means there's a potential for weird desync issues. Maybe disable the input if the request is processing?
- Can make this execution a goroutine: https://github.com/owncast/owncast/blob/41a64498366d6dbe29a72d02cd868bbefe32cb1c/activitypub/outbox/outbox.go#L237 This will fix the delay entirely, but can spawn way too many goroutines.
- The queue being full will cause the same problems as now with this PR. Can simply skip any requests that can't be queued, but will cause problems if anything important gets skipped instead of an update.

Beyond the scope of this:
- Since this is being caused by the API calls also federating activity, it might make more sense to split the functionality into separate calls. That has the advantage of allowing a configuration of auto-updates on changes, or consolidating a shotgun of multiple rapid changes into a single `UpdateFollowersWithAccountUpdates` call to respect rate-limiting.