### PR TITLE
Fix infinite loop when migrating from 0.1.3 -> 0.2.0

### DIFF
--- a/persistence/configrepository/sqlconfigrepository.go
+++ b/persistence/configrepository/sqlconfigrepository.go
@@ -38,7 +38,7 @@ func New(datastore *data.Datastore) ConfigRepository {
 		datastore: datastore,
 	}
 
-	migrateDatastoreValues(datastore)
+	migrateDatastoreValues(datastore, &r)
 
 	// Set the server initialization date if needed.
 	if hasSetInitDate, _ := r.GetServerInitTime(); hasSetInitDate == nil || !hasSetInitDate.Valid {


### PR DESCRIPTION
This fixes the infinite loop created when migrating from `v0.1.3` to `v0.2.0`.

Fixes #4025