### PR TITLE
Make the error alert in OfflineEmbed closable

### DIFF
--- a/web/components/ui/OfflineEmbed/OfflineEmbed.tsx
+++ b/web/components/ui/OfflineEmbed/OfflineEmbed.tsx
@@ -80,6 +80,11 @@ export const OfflineEmbed: FC<OfflineEmbedProps> = ({
     setLoading(false);
   };
 
+  const handleErrorClose = () => {
+    setErrorMessage('');
+    setCurrentMode(EmbedMode.FollowPrompt);
+  };
+
   const handleAccountChange = a => {
     setRemoteAccount(a);
     if (isValidFediverseAccount(a)) {
@@ -104,7 +109,14 @@ export const OfflineEmbed: FC<OfflineEmbedProps> = ({
             <div className={styles.pageName}>{streamName}</div>
 
             {errorMessage && (
-              <Alert message="Follow Error" description={errorMessage} type="error" showIcon />
+              <Alert
+                message="Follow Error"
+                description={errorMessage}
+                type="error"
+                showIcon
+                closable
+                onClose={handleErrorClose}
+              />
             )}
 
             {currentMode === EmbedMode.CanFollow && (


### PR DESCRIPTION
For #4056

This adds an option to close the alert in the OfflineEmbed component. Since the error message only ever pops up in a failed follow, the callback resets the embed state back to `FollowPrompt`, which returns to the input prompt state.

This does not address what happens if the close button ends up out of bounds.