### PR TITLE
fix skip link visibility and it moving logo upon focus

### DIFF
--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -59,17 +59,22 @@
 
 .skipLink {
   position: absolute;
+  z-index: 2;
   left: -10000px;
-  top: auto;
+  top: var(--header-height);
   width: 1px;
   height: 1px;
   overflow: hidden;
+  background-color: var(--component-background);
+  padding: 8px;
+  border-radius: var(--theme-rounded-corners);
 }
 
 .skipLink:focus {
-  position: static;
   width: auto;
   height: auto;
+  left: var(--content-padding);
+  outline: var(--theme-color-components-text-on-dark) solid 2px;
 }
 
 .offlineTag {

--- a/web/components/ui/Header/Header.module.scss
+++ b/web/components/ui/Header/Header.module.scss
@@ -65,7 +65,8 @@
   width: 1px;
   height: 1px;
   overflow: hidden;
-  background-color: var(--component-background);
+  background-color: var(--theme-color-background-header);
+  color: var(--theme-color-components-text-on-dark);
   padding: 8px;
   border-radius: var(--theme-rounded-corners);
 }


### PR DESCRIPTION
Currently when the skip links gain focus, they will shift the main logo over.
![image](https://github.com/user-attachments/assets/d3f652e5-49ca-4c69-a9bc-fe80343ec5b8)

This fix keeps the skiplinks in place, and improves their visibility.
<img width="727" alt="image" src="https://github.com/user-attachments/assets/4ffbacbd-47e8-4f03-9446-4400c7c5a7d7" />
