### PR TITLE
Addresses superfluous response.WriteHeader call warning in index template rendering

### DIFF
--- a/webserver/handlers/index.go
+++ b/webserver/handlers/index.go
@@ -108,9 +108,15 @@ func renderIndexHtml(w http.ResponseWriter, nonce string) {
 		return
 	}
 
-	if err := index.Execute(w, content); err != nil {
+	// Use a buffer to ensure that we do not write a partial response header before checking for errors
+	var buf bytes.Buffer
+	if err := index.Execute(&buf, content); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(buf.Bytes())
 }
 
 // MetadataPage represents a server-rendered web page for bots and web scrapers.


### PR DESCRIPTION
Fixes #4114 

Turns out that template.Execute, writes headers to the response writer. Therefore, if that function returns an error, we would end up calling writeHeader twice, resulting in the warning.

The fix addresses this by writing the output of the execute function to a buffer which is then written to the response writer if no errors have been detected.