### PR TITLE
fix: username wrapping for parting message

### DIFF
--- a/web/components/chat/ChatPartMessage/ChatPartMessage.module.scss
+++ b/web/components/chat/ChatPartMessage/ChatPartMessage.module.scss
@@ -1,16 +1,26 @@
 .root {
   display: inline-flex;
   padding: 10px 0;
-  color: var(--theme-color-components-chat-text);
-  font-weight: 400;
-  font-size: var(--chat-message-text-size);
 
   .moderatorBadge,
   .user {
     margin-right: 5px;
+    word-break: break-all;
+  }
+
+  .partMessage {
+    font-weight: 400;
+    color: var(--theme-color-components-chat-text);
+    font-size: var(--chat-message-text-size);
   }
 }
 
 .icon {
   padding: 0 var(--chat-notification-icon-padding) 0 16px;
+}
+
+@media screen and (width <= 350px) {
+  .icon {
+    padding-left: 0;
+  }
 }

--- a/web/components/chat/ChatPartMessage/ChatPartMessage.tsx
+++ b/web/components/chat/ChatPartMessage/ChatPartMessage.tsx
@@ -35,8 +35,8 @@ export const ChatPartMessage: FC<ChatPartMessageProps> = ({
             <ModerationBadge userColor={userColor} />
           </span>
         )}
+        <span className={styles.partMessage}>left the chat.</span>
       </span>
-      left the chat.
     </div>
   );
 };


### PR DESCRIPTION
              Great work @nekojanai! This looks good to me. 

Maybe you can take a look at [Chat leave message](https://owncast.online/components/?path=/story/owncast-chat-messages-chat-part--regular) when Gabe is ok with your implementation as they kind of come in a set.

_Originally posted by @germainelee in https://github.com/owncast/owncast/issues/3975#issuecomment-2440462652_

---

Follow up commit to the comment above.