### PR TITLE
Fix prometheus handlers

### DIFF
--- a/test/automated/.gitignore
+++ b/test/automated/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-ffmpeg
+ffmpeg-*/

--- a/test/automated/api/006_integrations.test.js
+++ b/test/automated/api/006_integrations.test.js
@@ -172,3 +172,8 @@ test('send an external integration action using access token expecting failure',
 		.send(payload)
 		.expect(401);
 });
+
+test('test prometheus metrics', async() => {
+	const res = await getAdminResponse('prometheus');
+	expect(res.text).toMatch(/owncast_instance_cpu_usage/);
+});

--- a/webserver/handlers/integrations.go
+++ b/webserver/handlers/integrations.go
@@ -95,34 +95,34 @@ func (*ServerInterfaceImpl) ExternalGetStatus(w http.ResponseWriter, r *http.Req
 func (*ServerInterfaceImpl) GetPrometheusAPI(w http.ResponseWriter, r *http.Request) {
 	// might need to bring this out of the codegen
 	middleware.RequireAdminAuth(func(w http.ResponseWriter, r *http.Request) {
-		promhttp.Handler()
+		promhttp.Handler().ServeHTTP(w, r)
 	})(w, r)
 }
 
 func (*ServerInterfaceImpl) PostPrometheusAPI(w http.ResponseWriter, r *http.Request) {
 	// might need to bring this out of the codegen
 	middleware.RequireAdminAuth(func(w http.ResponseWriter, r *http.Request) {
-		promhttp.Handler()
+		promhttp.Handler().ServeHTTP(w, r)
 	})(w, r)
 }
 
 func (*ServerInterfaceImpl) PutPrometheusAPI(w http.ResponseWriter, r *http.Request) {
 	// might need to bring this out of the codegen
 	middleware.RequireAdminAuth(func(w http.ResponseWriter, r *http.Request) {
-		promhttp.Handler()
+		promhttp.Handler().ServeHTTP(w, r)
 	})(w, r)
 }
 
 func (*ServerInterfaceImpl) DeletePrometheusAPI(w http.ResponseWriter, r *http.Request) {
 	// might need to bring this out of the codegen
 	middleware.RequireAdminAuth(func(w http.ResponseWriter, r *http.Request) {
-		promhttp.Handler()
+		promhttp.Handler().ServeHTTP(w, r)
 	})(w, r)
 }
 
 func (*ServerInterfaceImpl) OptionsPrometheusAPI(w http.ResponseWriter, r *http.Request) {
 	// might need to bring this out of the codegen
 	middleware.RequireAdminAuth(func(w http.ResponseWriter, r *http.Request) {
-		promhttp.Handler()
+		promhttp.Handler().ServeHTTP(w, r)
 	})(w, r)
 }


### PR DESCRIPTION
fixes #4272

Added a test for the prometheus endpoint, just checks if the string `owncast_instance_cpu_usage` metric exists in the response. Should be a good enough bar to clear but no clue on how to handle the rest of the methods, or if promhttp even handles those...