### PR TITLE
change go:embed call to use the go:embed all: directive

### DIFF
--- a/static/static.go
+++ b/static/static.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// The 'all:' prefix is used to include all files and subdirectories under 'web/'.
+// This avoids errors if optional subdirectories (e.g., 'web/_next') are missing.
 //go:embed all:web/*
 var webFiles embed.FS
 

--- a/static/static.go
+++ b/static/static.go
@@ -11,10 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-//go:embed web/*
-//go:embed web/_next/static
-//go:embed web/_next/static/chunks/pages/*.js
-//go:embed web/_next/static/*/*.js
+//go:embed all:web/*
 var webFiles embed.FS
 
 // GetWeb will return an embedded filesystem reference to the admin web app.


### PR DESCRIPTION
This makes use of [this](https://go-review.googlesource.com/c/go/+/359413) golang embed directive to include all files in the target static directory.

This allows embed of directories like _next without go complaining if those files are absent (like for a custom non-nextjs frontend)