### PR TITLE
check for webfinger status code before parsing

### DIFF
--- a/activitypub/webfinger/webfinger.go
+++ b/activitypub/webfinger/webfinger.go
@@ -55,12 +55,16 @@ func GetWebfingerLinks(account string) ([]map[string]interface{}, error) {
 		return nil, err
 	}
 
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.New("webfinger request returned bad status code: " + http.StatusText(response.StatusCode) + ", check account details")
+	}
+
 	defer response.Body.Close()
 
 	var links webfingerResponse
 	decoder := json.NewDecoder(response.Body)
 	if err := decoder.Decode(&links); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error decoding webfinger response: %s", err)
 	}
 
 	return links.Links, nil


### PR DESCRIPTION
Closes #4215 

Tangentially affects #4181 since it should give some context as to *why* the remote server is returning html when json was requested.

The status code check should cover all cases where invalid/empty json is returned. So the current EOF now shows "webfinger request returned bad status code: Not Found, check account details". Invalid 200 OK gets decoded with a wrapping error to clarify context.

Could add errors more specific to the status code, or include the plain status code int in the error string.