### PR TITLE
fix errorMessage being set as a raw error type instead of a string

### DIFF
--- a/web/components/modals/FediAuthModal/FediAuthModal.tsx
+++ b/web/components/modals/FediAuthModal/FediAuthModal.tsx
@@ -70,8 +70,8 @@ export const FediAuthModal: FC<FediAuthModalProps> = ({
 
     const content = await rawResponse.json();
     if (content.message) {
-      setErrorMessage(content.message);
       setLoading(false);
+      throw new Error(content.message); // let the callers handle setting error message since they already are
     }
   };
 
@@ -87,7 +87,7 @@ export const FediAuthModal: FC<FediAuthModalProps> = ({
       window.location.href = '/';
     } catch (e) {
       console.error(e);
-      setErrorMessage(e);
+      setErrorMessage(e.toString());
     }
     setLoading(false);
   };
@@ -108,7 +108,7 @@ export const FediAuthModal: FC<FediAuthModalProps> = ({
       setVerifyingCode(true);
     } catch (e) {
       console.error(e);
-      setErrorMessage(e);
+      setErrorMessage(e.toString());
     }
     setLoading(false);
   };


### PR DESCRIPTION
The fediauth modal assumes the `errorMessage` is a string|null to check a substring with the `string.includes(...)` call. `makeRequest` correctly sets the message from a response's json value, but network errors or json decode errors throw exceptions. The error handlers simply `setErrorMessage(err)` instead of converting the errors to strings. This gives the "C.includes is not a function" error in #4181. 

This PR corrects this.

Note: this hasn't really been tested.