### PR TITLE
Idea: Changing Final Docker Image from Alphine to Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 
 # Create the image by copying the result of the build into a new alpine image
 FROM ubuntu:noble
-RUN apt update && apt install ffmpeg ca-certificates && update-ca-certificates
+RUN apt update && apt install -y ffmpeg ca-certificates && update-ca-certificates
 
 RUN addgroup -g 101 -S owncast && adduser -u 101 -S owncast -G owncast
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,14 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 FROM ubuntu:noble
 RUN apt update && apt upgrade -y && apt install -y ffmpeg ca-certificates && update-ca-certificates
 
-RUN addgroup --gid 1001 owncast 
-RUN adduser --uid 1001 --gid 1001 owncast
+#RUN addgroup --gid 1001 owncast 
+#RUN adduser --uid 1001 --gid 1001 owncast
 
 # Copy owncast assets
 WORKDIR /app
 COPY --from=build /build/owncast /app/owncast
 RUN mkdir /app/data
-RUN chown -R owncast:owncast /app
-USER owncast
+RUN chown -R ubuntu:ubuntu /app
+USER ubuntu
 ENTRYPOINT ["/app/owncast"]
 EXPOSE 8080 1935

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 
 # Create the image by copying the result of the build into a new alpine image
 FROM ubuntu:noble
-RUN apt update && apt install ffmpeg ffmpeg-libs ca-certificates && update-ca-certificates
+RUN apt update && apt install ffmpeg ca-certificates && update-ca-certificates
 
 RUN addgroup -g 101 -S owncast && adduser -u 101 -S owncast -G owncast
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENV NAME=${NAME}
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflags \"-static\" -s -w -X github.com/owncast/owncast/config.GitCommit=$GIT_COMMIT -X github.com/owncast/owncast/config.VersionNumber=$VERSION -X github.com/owncast/owncast/config.BuildPlatform=$NAME" -o owncast .
 
 # Create the image by copying the result of the build into a new alpine image
-FROM alpine:3.21.3
-RUN apk update && apk add --no-cache ffmpeg ffmpeg-libs ca-certificates && update-ca-certificates
+FROM ubuntu:noble
+RUN apt update && apt install ffmpeg ffmpeg-libs ca-certificates && update-ca-certificates
 
 RUN addgroup -g 101 -S owncast && adduser -u 101 -S owncast -G owncast
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 FROM ubuntu:noble
 RUN apt update && apt upgrade -y && apt install -y ffmpeg ca-certificates && update-ca-certificates
 
-RUN addgroup --gid 1000 owncast && adduser --uid 1000 --gid 1000 owncast
+RUN addgroup --gid 1001 owncast 
+RUN adduser --uid 1001 --gid 1001 owncast
 
 # Copy owncast assets
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 FROM ubuntu:noble
 RUN apt update && apt upgrade -y && apt install -y ffmpeg ca-certificates && update-ca-certificates
 
-RUN adduser --uid 101 --gid 101 owncast
+RUN addgroup --gid 101 owncast && adduser --uid 101 --gid 101 owncast
 
 # Copy owncast assets
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflag
 FROM ubuntu:noble
 RUN apt update && apt upgrade -y && apt install -y ffmpeg ca-certificates && update-ca-certificates
 
-RUN addgroup --gid 101 owncast && adduser --uid 101 --gid 101 owncast
+RUN addgroup --gid 1000 owncast && adduser --uid 1000 --gid 1000 owncast
 
 # Copy owncast assets
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ ENV NAME=${NAME}
 
 RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -ldflags "-extldflags \"-static\" -s -w -X github.com/owncast/owncast/config.GitCommit=$GIT_COMMIT -X github.com/owncast/owncast/config.VersionNumber=$VERSION -X github.com/owncast/owncast/config.BuildPlatform=$NAME" -o owncast .
 
-# Create the image by copying the result of the build into a new alpine image
+# Create the image by copying the result of the build into a new ubuntu image
 FROM ubuntu:noble
-RUN apt update && apt install -y ffmpeg ca-certificates && update-ca-certificates
+RUN apt update && apt upgrade -y && apt install -y ffmpeg ca-certificates && update-ca-certificates
 
-RUN addgroup -g 101 -S owncast && adduser -u 101 -S owncast -G owncast
+RUN adduser --uid 101 --gid 101 owncast
 
 # Copy owncast assets
 WORKDIR /app


### PR DESCRIPTION
As discussed in #4335 and #4350, I think that changing the final docker image of alpine to ubuntu will allow for better hardware acceleration support without needing owncast specific ffmpeg builds and allowing using to bring their own ffmpeg binaries.

I have done this in the attached PR, with the change I have then added the mount path for ffmpeg from the base device, in my case I have elected to use jellyfin's ffmpeg portable build enabling me to use nvenc inside the container.

In the configuration below I had in input of 2560x1440 stream with a CPU load of 2%

the final docker compose I had is:
```
services:
  owncast:
    #image: owncast/owncast:latest
    image: owncast:ubuntu
    ports:
      - "8080:8080"
      - "1935:1935"
      - "1935:1935/udp"
    volumes:
      - ./data:/app/data
      - ./ffmpeg:/ffmpeg
    environment:
      - NVIDIA_DRIVER_CAPABILITIES=all
      - NVIDIA_VISIBLE_DEVICES=all
    devices:
      - /dev/dri:/dev/dri
    deploy:
      resources:
        reservations:
          devices:
          - driver: nvidia
            count: all
            capabilities: [compute,video,graphics,utility]
```

Hardware configuration Used
```
OS: Ubuntu 24.04.2 LTS x86_64
Host: KVM/QEMU (Standard PC (Q35 + ICH9, 2009) pc-q35-9.0)
Kernel: 6.8.0-60-generic
Uptime: 4 days, 22 hours, 17 mins
Packages: 833 (dpkg)
Shell: bash 5.2.21
Resolution: 1280x800
Terminal: /dev/pts/0
CPU: Intel Xeon Gold 6138 (10) @ 1.995GHz
GPU: NVIDIA Tesla P4
Memory: 599MiB / 7901MiB
```