### PR TITLE
Add a rule that passwords and stream keys must not contain any dashes

### DIFF
--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -619,9 +619,13 @@ export const PASSWORD_COMPLEXITY_RULES = [
     message: '- at least one digit',
   },
   {
-    pattern: /^(?=.*?[#?!@$%^&*-])/,
+    pattern: /^(?=.*?[#?!@$%^&*])/,
     message: '- at least one special character: !@#$%^&*',
+  },
+  {
+    pattern: /^[^-]+$/,
+    message: '- must NOT contain a dash: -',
   },
 ];
 
-export const REGEX_PASSWORD = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[!@#$%^&*]).{8,192}$/;
+export const REGEX_PASSWORD = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[!@#$%^&*])[^-]{8,192}$/;


### PR DESCRIPTION
This is my attempt at fixing #3105 -- ran into this when setting up Owncast for the first time, and Apple's suggested strong password didn't work because it contains dashes.

