### PR TITLE
docs: clarify admin password is not the stream key (#4405)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -55,9 +55,10 @@ The pages under `/admin` require authentication to make API calls.
 
 Auth: HTTP Basic
 
-username: admin
+- **Username:** `admin`
+- **Password:** your **admin** password (not your stream key)
 
-pw: [your streamkey]
+> **Note:** your **stream key** is only used by your streaming software to publish video; it is _not_ your admin password.
 
 ### Learn More
 


### PR DESCRIPTION
Update Readme/Doc in Admin Authentication section to:

- Separate “admin password” and “stream key” terminology
- Emphasize stream key is only for streaming software (RTMP/SRT)
- Note that admin password is used for HTTP Basic auth to `/admin`

Closes #4405.