### PR TITLE
bug: fixed max viewers to Max viewers

### DIFF
--- a/web/i18n/en/translation.json
+++ b/web/i18n/en/translation.json
@@ -67,7 +67,7 @@
       "currentViewers": "Current viewers",
       "maxViewersThisStream": "Max viewers this stream",
       "maxViewersLastStream": "Max viewers last stream",
-      "maxViewers": "max viewers",
+      "maxViewers": "Max viewers",
       "pleaseWait": "Please wait",
       "noData": "No viewer data has been collected yet.",
       "viewers": "Viewers"

--- a/web/i18n/en/translation.json.backup
+++ b/web/i18n/en/translation.json.backup
@@ -923,7 +923,7 @@
   "keyword c": "<strong><em>Missing translation keyword c: Please report</em></strong>",
   "keyword d": "<strong><em>Missing translation keyword d: Please report</em></strong>",
   "let us know": "let us know",
-  "max viewers": "max viewers",
+  "max viewers": "Max viewers",
   "month": "<strong><em>Missing translation month: Please report</em></strong>",
   "new": "<strong><em>Missing translation new: Please report</em></strong>",
   "of all known players": {


### PR DESCRIPTION
Hi there!

This PR fixes a minor capitalization typo on the Admin Dashboard's "Viewer Info" card, as requested in issue `#4634`.

Description
The label "max viewers" was displayed in all lowercase, which was inconsistent with the other capitalized labels on the same card ("Max viewers last stream").

This change corrects the typo by capitalizing the "M" in the translation.json file, which appears to be the single source of truth for the UI text.

Change: Modified the value for the "maxViewers" key from "max viewers" to "Max viewers".