### PR TITLE
fix: X-axis labels and ticks

### DIFF
--- a/web/components/admin/Chart.tsx
+++ b/web/components/admin/Chart.tsx
@@ -45,13 +45,22 @@ export type ChartProps = {
   dataCollections?: any[];
   minYValue?: number;
   yStepSize?: number;
+  timeWindowKey?: number; 
 };
 
-function createGraphDataset(dataArray) {
+function getLabelFormat(timeWindowKey?: number) {
+  // 0: current stream, 1: 12h, 2: 24h, 3: 7d, 4: 30d, 5: 3mo, 6: 6mo
+  if (timeWindowKey === 1 || timeWindowKey === 2) return 'H:mm'; // 12/24h: hour
+  if (timeWindowKey === 3 || timeWindowKey === 4) return 'MMM d'; // 7/30d: day
+  if (timeWindowKey === 5 || timeWindowKey === 6) return 'MMM'; // 3/6mo: month
+  return 'H:mm'; 
+}
+
+function createGraphDataset(dataArray, labelFormat) {
   const dataValues = {};
   dataArray.forEach(item => {
     const dateObject = new Date(item.time);
-    const dateString = format(dateObject, 'H:mma');
+    const dateString = format(dateObject, labelFormat);
     dataValues[dateString] = item.value;
   });
   return dataValues;
@@ -67,10 +76,13 @@ export const Chart: FC<ChartProps> = ({
   yLogarithmic,
   minYValue,
   yStepSize = 0,
+  timeWindowKey, 
 }) => {
   const renderData = [];
-
   const chartRef = useRef(null);
+
+  const labelFormat = getLabelFormat(timeWindowKey);
+
   const downloadChart = () => {
     if (chartRef.current) {
       const link = document.createElement('a');
@@ -87,7 +99,7 @@ export const Chart: FC<ChartProps> = ({
       backgroundColor: color,
       borderColor: color,
       borderWidth: 3,
-      data: createGraphDataset(data),
+      data: createGraphDataset(data, labelFormat),
     });
   }
 
@@ -95,7 +107,7 @@ export const Chart: FC<ChartProps> = ({
     renderData.push({
       id: collection.name,
       label: collection.name,
-      data: createGraphDataset(collection.data),
+      data: createGraphDataset(collection.data, labelFormat),
       backgroundColor: collection.color,
       borderColor: collection.color,
       borderWidth: 3,
@@ -107,8 +119,14 @@ export const Chart: FC<ChartProps> = ({
   const options = {
     responsive: true,
     clip: false,
-
     scales: {
+      x: {
+        title: { display: false },
+        ticks: {
+          autoSkip: true,
+          maxTicksLimit: 10,
+        },
+      },
       y: {
         type: yLogarithmic ? ('logarithmic' as const) : ('linear' as const),
         reverse: yFlipped,

--- a/web/components/admin/Chart.tsx
+++ b/web/components/admin/Chart.tsx
@@ -54,7 +54,7 @@ export type ChartProps = {
   dataCollections?: any[];
   minYValue?: number;
   yStepSize?: number;
-  timeWindowKey?: TimeWindow; 
+  timeWindowKey?: TimeWindow;
 };
 
 function getLabelFormat(timeWindowKey?: TimeWindow) {

--- a/web/components/admin/Chart.tsx
+++ b/web/components/admin/Chart.tsx
@@ -28,6 +28,15 @@ ChartJS.register(
   Legend,
 );
 
+export enum TimeWindow {
+  Hour12 = 1,
+  Hour24 = 2,
+  Day7 = 3,
+  Day30 = 4,
+  Month3 = 5,
+  Month6 = 6,
+}
+
 interface TimedValue {
   time: Date;
   value: number;
@@ -45,15 +54,26 @@ export type ChartProps = {
   dataCollections?: any[];
   minYValue?: number;
   yStepSize?: number;
-  timeWindowKey?: number; 
+  timeWindowKey?: TimeWindow; 
 };
 
-function getLabelFormat(timeWindowKey?: number) {
-  // 0: current stream, 1: 12h, 2: 24h, 3: 7d, 4: 30d, 5: 3mo, 6: 6mo
-  if (timeWindowKey === 1 || timeWindowKey === 2) return 'H:mm'; // 12/24h: hour
-  if (timeWindowKey === 3 || timeWindowKey === 4) return 'MMM d'; // 7/30d: day
-  if (timeWindowKey === 5 || timeWindowKey === 6) return 'MMM'; // 3/6mo: month
-  return 'H:mm'; 
+function getLabelFormat(timeWindowKey?: TimeWindow) {
+  switch (timeWindowKey) {
+    case TimeWindow.Hour12:
+    case TimeWindow.Hour24:
+      return 'H:mm'; // 12/24h: hour
+
+    case TimeWindow.Day7:
+    case TimeWindow.Day30:
+      return 'MMM d'; // 7/30d: day
+
+    case TimeWindow.Month3:
+    case TimeWindow.Month6:
+      return 'MMM'; // 3/6mo: month
+
+    default:
+      return 'H:mm';
+  }
 }
 
 function createGraphDataset(dataArray, labelFormat) {
@@ -76,7 +96,7 @@ export const Chart: FC<ChartProps> = ({
   yLogarithmic,
   minYValue,
   yStepSize = 0,
-  timeWindowKey, 
+  timeWindowKey,
 }) => {
   const renderData = [];
   const chartRef = useRef(null);

--- a/web/pages/admin/viewer-info.tsx
+++ b/web/pages/admin/viewer-info.tsx
@@ -50,6 +50,7 @@ export default function ViewersOverTime() {
   const [viewerInfo, setViewerInfo] = useState([]);
   const [viewerDetails, setViewerDetails] = useState([]);
   const [timeWindowStart, setTimeWindowStart] = useState(times[1]);
+  const [timeWindowKey, setTimeWindowKey] = useState(1);
 
   const getInfo = async () => {
     try {
@@ -86,6 +87,7 @@ export default function ViewersOverTime() {
 
   const onTimeWindowSelect = ({ key }) => {
     setTimeWindowStart(times[key]);
+    setTimeWindowKey(Number(key));
   };
 
   const offset: number = online && streamStart ? 0 : 1;
@@ -147,6 +149,7 @@ export default function ViewersOverTime() {
             unit="viewers"
             minYValue={0}
             yStepSize={1}
+            timeWindowKey={timeWindowKey}
           />
         )}
 


### PR DESCRIPTION
## Double check

- [X] I included a screenshot, logs, or example payload to demonstrate the change.
- [X] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [X] This change has actually been tested.
- [X] The code has been run through the proper linters and/or formatters for the language.
- [X] There is an issue discussing this change and it's assigned to me.
- [X] I read the "Read first" details about filing this PR.

---
## Description

This PR fixes the X-axis label formatting for chart time windows. Previously, charts were showing only hourly timestamps making it hard to interpret which day or month each point referred to

- Short time windows (12h, 24h) now display as `H:mm`
- Medium windows (7d,20d) display as `MMM d`
- Long windows (3mo,6mo) display as `MMM`

Also set `maxTicksLimit` to 10 to prevent crowding.

Fixes #4408 

### Changes in code 

- Added a new optional prop `timeWindowKey` to ChartProps.
- Created a new helper function `getLabelFormat` to return different date label formats based on timeWindowKey.
- Updated createGraphDataset to accept a `labelFormat` parameter instead of using a hardcoded `H:mma`.
- Modified chart data creation to pass labelFormat into createGraphDataset.
- In `viewer-info.tsx`, added state for timeWindowKey, updated onTimeWindowSelect to set it, and passed it as a prop to the Chart component.

## Screenshot Examples or Logs

<img width="1535" height="557" alt="image" src="https://github.com/user-attachments/assets/f287b0c3-f109-4ac2-b24c-4729d704e37f" />
<img width="1534" height="398" alt="image" src="https://github.com/user-attachments/assets/c193a047-da8c-4f3d-b040-aa0415d7b46e" />
<img width="1564" height="417" alt="image" src="https://github.com/user-attachments/assets/0f37bea3-0541-4d1b-a03a-a9e413d14191" />


---
