### PR TITLE
fix: remove optimistic UI updates in external actions to prevent race condition

### DIFF
--- a/web/pages/admin/actions.tsx
+++ b/web/pages/admin/actions.tsx
@@ -274,8 +274,10 @@ const Actions = () => {
     actionsData.splice(index, 1);
 
     try {
-      setActions(actionsData);
-      save(actionsData);
+      // Don't optimistically update local state - let the server response
+      // update externalActions in context, which will then update actions
+      // via useEffect. This prevents race conditions causing visual glitches.
+      await save(actionsData);
     } catch (error) {
       console.error(error);
     }
@@ -312,7 +314,9 @@ const Actions = () => {
         actionsData.push(newAction);
       }
 
-      setActions(actionsData);
+      // Don't optimistically update local state - let the server response
+      // update externalActions in context, which will then update actions
+      // via useEffect. This prevents race conditions causing visual glitches.
       await save(actionsData);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## Summary

Fixes the visual cloning/duplication bug when adding or deleting external actions in the admin panel.

**The Problem:**
When adding/deleting external actions, the UI would sometimes show duplicated or cloned rows. This was caused by a race condition between:
1. The optimistic `setActions()` call updating local state immediately
2. The `save()` callback updating `externalActions` in the server status context
3. The `useEffect` syncing `actions` from `externalActions`

**The Fix:**
Remove the optimistic `setActions()` calls from `handleDelete` and `handleSave`. Instead, let the server response be the single source of truth - the UI updates only after the context is updated via the `save()` success callback.

This follows the pattern recommended by @gabek in the issue discussion.

## Test Plan

- [x] Lint passes
- [ ] Add multiple external actions
- [ ] Delete actions in quick succession
- [ ] Verify no visual duplication/cloning occurs
- [ ] Verify the table updates correctly after each operation

Fixes #4347