### PR TITLE
fix: prevent chat container from overflowing viewport in embedded view

### DIFF
--- a/web/components/chat/ChatContainer/ChatContainer.module.scss
+++ b/web/components/chat/ChatContainer/ChatContainer.module.scss
@@ -30,7 +30,6 @@
   flex-direction: column;
   background-color: var(--theme-color-components-chat-background);
   height: 100%;
-  max-height: 100vh;
   font-size: var(--chat-message-text-size);
 }
 

--- a/web/components/chat/ChatContainer/ChatContainer.module.scss
+++ b/web/components/chat/ChatContainer/ChatContainer.module.scss
@@ -30,6 +30,7 @@
   flex-direction: column;
   background-color: var(--theme-color-components-chat-background);
   height: 100%;
+  max-height: 100vh;
   font-size: var(--chat-message-text-size);
 }
 

--- a/web/pages/embed/chat/readwrite/index.tsx
+++ b/web/pages/embed/chat/readwrite/index.tsx
@@ -62,6 +62,28 @@ export default function ReadWriteChatEmbed() {
           .body-background {
             background: var(--theme-color-components-chat-background);
           }
+          .embed-container {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            height: 100dvh;
+            overflow: hidden;
+          }
+          .embed-container > #chat-container {
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+          }
+          .embed-container #chat-container #chat-container {
+            flex: 1 1 0;
+            min-height: 0;
+          }
+          .embed-container #chat-container #virtuoso {
+            flex: 1;
+            min-height: 0;
+            height: auto !important;
+          }
         `}
       </style>
       <ErrorBoundary
@@ -70,29 +92,31 @@ export default function ReadWriteChatEmbed() {
           <ComponentError componentName="ReadWriteChatEmbed" message={error.message} />
         )}
       >
-        <ClientConfigStore />
-        <Theme />
-        <Header
-          name={headerText}
-          chatAvailable
-          chatDisabled={chatDisabled}
-          online={videoAvailable}
-        />
-        {currentUser && (
-          <div id="chat-container">
-            <ChatContainer
-              messages={messages}
-              usernameToHighlight={currentUser.displayName}
-              chatUserId={currentUser.id}
-              isModerator={currentUser.isModerator}
-              showInput
-              height="92vh"
-              chatAvailable={isChatAvailable}
-              inputEnabled={chatInputEnabled}
-              inputDisabledPlaceholder={chatInputDisabledMessage}
-            />
-          </div>
-        )}
+        <div className="embed-container">
+          <ClientConfigStore />
+          <Theme />
+          <Header
+            name={headerText}
+            chatAvailable
+            chatDisabled={chatDisabled}
+            online={videoAvailable}
+          />
+          {currentUser && (
+            <div id="chat-container">
+              <ChatContainer
+                messages={messages}
+                usernameToHighlight={currentUser.displayName}
+                chatUserId={currentUser.id}
+                isModerator={currentUser.isModerator}
+                showInput
+                height="100%"
+                chatAvailable={isChatAvailable}
+                inputEnabled={chatInputEnabled}
+                inputDisabledPlaceholder={chatInputDisabledMessage}
+              />
+            </div>
+          )}
+        </div>
       </ErrorBoundary>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds `max-height: 100vh;` to the `.chatContainer` class to prevent the chat from getting cut off vertically in the `/embed/chat/readwrite` view.

## Related Issue

Fixes #4492

## Credit

Thanks to @germainelee for identifying the fix in the issue discussion.

---
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
