### PR TITLE
fix: consolidate browser notification text into single localized string

### DIFF
--- a/web/components/modals/BrowserNotifyModal/BrowserNotifyModal.tsx
+++ b/web/components/modals/BrowserNotifyModal/BrowserNotifyModal.tsx
@@ -282,15 +282,10 @@ export const BrowserNotifyModal = () => {
             translationKey={Localization.Frontend.BrowserNotifyModal.mainDescription}
             defaultText="Get notified right in the browser each time this stream goes live."
           />
-          <span>
-            <a href="https://owncast.online/docs/notifications/#browser-notifications">
-              <Translation
-                translationKey={Localization.Frontend.BrowserNotifyModal.learnMore}
-                defaultText="Learn more"
-              />
-            </a>
-            &nbsp; about Owncast browser notifications.
-          </span>
+          <Translation
+            translationKey={Localization.Frontend.BrowserNotifyModal.learnMoreAboutNotifications}
+            defaultText="<a href='https://owncast.online/docs/notifications/#browser-notifications'>Learn more</a> about Owncast browser notifications."
+          />
         </Row>
         <Row>
           {error && (

--- a/web/types/localization.ts
+++ b/web/types/localization.ts
@@ -68,7 +68,8 @@ export const Localization = {
       deniedTitle: 'Frontend.BrowserNotifyModal.deniedTitle',
       deniedDescription: 'Frontend.BrowserNotifyModal.deniedDescription',
       mainDescription: 'Frontend.BrowserNotifyModal.mainDescription',
-      learnMore: 'Frontend.BrowserNotifyModal.learnMore',
+      learnMoreAboutNotifications:
+        'Frontend.BrowserNotifyModal.learnMoreAboutNotifications',
       errorTitle: 'Frontend.BrowserNotifyModal.errorTitle',
       errorMessage: 'Frontend.BrowserNotifyModal.errorMessage',
     },


### PR DESCRIPTION
## Summary

- Consolidates the "Learn more" link and surrounding text into a single Translation component
- Fixes the double space issue (`&nbsp;` + regular space)
- Enables the full sentence to be properly localized: `<a>Learn more</a> about Owncast browser notifications.`

## Changes

- Updated `BrowserNotifyModal.tsx` to use a single Translation with the complete sentence including HTML link
- Updated `localization.ts` to rename `learnMore` to `learnMoreAboutNotifications` to reflect the full sentence

Closes #4655