### PR TITLE
Fix banUser API call missing enabled parameter

### DIFF
--- a/web/services/moderation-service.ts
+++ b/web/services/moderation-service.ts
@@ -28,7 +28,7 @@ class ChatModerationService {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ userId: id }),
+      body: JSON.stringify({ userId: id, enabled: false }),
     };
 
     await fetch(hideMessageUrl, options);


### PR DESCRIPTION
The banUser function in ChatModerationService was sending an incomplete request body to the /api/chat/users/setenabled endpoint. The API requires both userId and enabled fields, but only userId was being sent.

This caused the endpoint to return a 400 Bad Request with the error: "must provide userId and enabled state"

Added the missing enabled: false parameter to properly disable the user when banning.

New Request:
```
{"userId":"wk9dSzIDR","enabled":false}
```

Fixes #4724
This is related to 3b25e295e835ea776f2054d94326bf00b847389e

## Double check

- [x] I included a screenshot, logs, or example payload to demonstrate the change.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] This change has actually been tested.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
- [x] I read the "Read first" details about filing this PR.

