### PR TITLE
Fix for initial client status and config not hydrating

### DIFF
--- a/web/components/stores/ClientConfigStore.tsx
+++ b/web/components/stores/ClientConfigStore.tsx
@@ -32,6 +32,36 @@ import { DisplayableError } from '../../types/displayable-error';
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 const SERVER_STATUS_POLL_DURATION = 5000;
+
+// Helper to safely parse hydration data from window object
+// This runs during module initialization so data is available for first render
+const getInitialConfig = (): ClientConfig => {
+  if (typeof window !== 'undefined' && (window as any).configHydration) {
+    try {
+      return JSON.parse((window as any).configHydration);
+    } catch (e) {
+      console.error('Error parsing config hydration during init', e);
+    }
+  }
+  return makeEmptyClientConfig();
+};
+
+const getInitialStatus = (): ServerStatus => {
+  if (typeof window !== 'undefined' && (window as any).statusHydration) {
+    try {
+      return JSON.parse((window as any).statusHydration);
+    } catch (e) {
+      console.error('Error parsing status hydration during init', e);
+    }
+  }
+  return makeEmptyServerStatus();
+};
+
+// Cache the initial values to avoid re-parsing
+const initialConfig = getInitialConfig();
+const initialStatus = getInitialStatus();
+const hasHydratedConfig = typeof window !== 'undefined' && !!(window as any).configHydration;
+const hasHydratedStatus = typeof window !== 'undefined' && !!(window as any).statusHydration;
 const ACCESS_TOKEN_KEY = 'accessToken';
 
 let serverStatusRefreshPoll: ReturnType<typeof setInterval>;
@@ -42,15 +72,17 @@ const serverConnectivityError = `Cannot connect to the Owncast service. Please c
 
 // Server status is what gets updated such as viewer count, durations,
 // stream title, online/offline state, etc.
+// Initialize with hydration data if available for faster first render.
 export const serverStatusState = atom<ServerStatus>({
   key: 'serverStatusState',
-  default: makeEmptyServerStatus(),
+  default: initialStatus,
 });
 
 // The config that comes from the API.
+// Initialize with hydration data if available for faster first render.
 export const clientConfigStateAtom = atom({
   key: 'clientConfigState',
-  default: makeEmptyClientConfig(),
+  default: initialConfig,
 });
 
 export const accessTokenAtom = atom<string>({
@@ -181,7 +213,7 @@ export const ClientConfigStore: FC = () => {
   const setGlobalFatalErrorMessage = useSetRecoilState<DisplayableError>(fatalErrorStateAtom);
   const setWebsocketService = useSetRecoilState<WebsocketService>(websocketServiceAtom);
   const setHiddenMessageIds = useSetRecoilState<string[]>(removedMessageIdsAtom);
-  const [hasLoadedConfig, setHasLoadedConfig] = useState(false);
+  const [hasLoadedConfig, setHasLoadedConfig] = useState(hasHydratedConfig);
 
   let ws: WebsocketService;
 
@@ -394,36 +426,25 @@ export const ClientConfigStore: FC = () => {
     }
   };
 
-  // Read the config and status on initial load from a JSON string that lives
-  // in window. This is placed there server-side and allows for fast initial
-  // load times because we don't have to wait for the API calls to complete.
+  // Handle initial state machine transition when hydration data was available.
+  // The atoms are already initialized with hydration data at module load time,
+  // so we just need to update the app state machine and calculate clock skew.
   useEffect(() => {
-    try {
-      if ((window as any).configHydration) {
-        const config = JSON.parse((window as any).configHydration);
-        setClientConfig(config);
-        setHasLoadedConfig(true);
+    if (hasHydratedConfig && hasHydratedStatus) {
+      // Transition app state machine based on hydrated status
+      const events = [AppStateEvent.Loaded];
+      if (initialStatus.online) {
+        events.push(AppStateEvent.Online);
+      } else {
+        events.push(AppStateEvent.Offline);
       }
-    } catch (e) {
-      console.error('Error parsing config hydration', e);
-    }
+      sendEvent(events);
 
-    try {
-      if ((window as any).statusHydration) {
-        const status = JSON.parse((window as any).statusHydration);
-        setServerStatus(status);
-        handleStatusChange(status);
+      // Calculate clock skew from hydrated server time
+      if (initialStatus.serverTime) {
+        const clockSkew = new Date(initialStatus.serverTime).getTime() - Date.now();
+        setClockSkew(clockSkew);
       }
-    } catch (e) {
-      console.error('error parsing status hydration', e);
-    }
-
-    try {
-      if ((window as any).configHydration && (window as any).statusHydration) {
-        sendEvent([AppStateEvent.Loaded]);
-      }
-    } catch (e) {
-      console.error('error sending loaded event', e);
     }
   }, []);
 
@@ -448,11 +469,13 @@ export const ClientConfigStore: FC = () => {
   }, [hasLoadedConfig, accessToken]);
 
   useEffect(() => {
-    if (!(window as any).configHydration) {
+    // Only fetch config from API if not hydrated from server
+    if (!hasHydratedConfig) {
       updateClientConfig();
     }
     handleUserRegistration();
-    if (!(window as any).statusHydration) {
+    // Only fetch status from API if not hydrated from server
+    if (!hasHydratedStatus) {
       updateServerStatus();
     }
     clearInterval(serverStatusRefreshPoll);

--- a/web/components/stores/ClientConfigStore.tsx
+++ b/web/components/stores/ClientConfigStore.tsx
@@ -35,33 +35,42 @@ const SERVER_STATUS_POLL_DURATION = 5000;
 
 // Helper to safely parse hydration data from window object
 // This runs during module initialization so data is available for first render
-const getInitialConfig = (): ClientConfig => {
+// Returns both the config and whether parsing succeeded
+const getInitialConfig = (): { config: ClientConfig; success: boolean } => {
   if (typeof window !== 'undefined' && (window as any).configHydration) {
     try {
-      return JSON.parse((window as any).configHydration);
+      const parsed = JSON.parse((window as any).configHydration);
+      if (parsed) {
+        return { config: parsed, success: true };
+      }
     } catch (e) {
       console.error('Error parsing config hydration during init', e);
     }
   }
-  return makeEmptyClientConfig();
+  return { config: makeEmptyClientConfig(), success: false };
 };
 
-const getInitialStatus = (): ServerStatus => {
+const getInitialStatus = (): { status: ServerStatus; success: boolean } => {
   if (typeof window !== 'undefined' && (window as any).statusHydration) {
     try {
-      return JSON.parse((window as any).statusHydration);
+      const parsed = JSON.parse((window as any).statusHydration);
+      if (parsed) {
+        return { status: parsed, success: true };
+      }
     } catch (e) {
       console.error('Error parsing status hydration during init', e);
     }
   }
-  return makeEmptyServerStatus();
+  return { status: makeEmptyServerStatus(), success: false };
 };
 
 // Cache the initial values to avoid re-parsing
-const initialConfig = getInitialConfig();
-const initialStatus = getInitialStatus();
-const hasHydratedConfig = typeof window !== 'undefined' && !!(window as any).configHydration;
-const hasHydratedStatus = typeof window !== 'undefined' && !!(window as any).statusHydration;
+const configResult = getInitialConfig();
+const statusResult = getInitialStatus();
+const initialConfig = configResult.config;
+const initialStatus = statusResult.status;
+const hasHydratedConfig = configResult.success;
+const hasHydratedStatus = statusResult.success;
 const ACCESS_TOKEN_KEY = 'accessToken';
 
 let serverStatusRefreshPoll: ReturnType<typeof setInterval>;

--- a/web/i18n/en/translation.json
+++ b/web/i18n/en/translation.json
@@ -205,6 +205,7 @@
 			"overLimit": "Over limit",
 			"placeholder": "Your chat display name"
 		},
+		"chatDisabled": "<strong><em>Missing translation Frontend.chatDisabled: Please report</em></strong>",
 		"chatOffline": "Chat is offline",
 		"componentError": "Error: {{message}}",
 		"helloWorld": "Hello world",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14348,15 +14348,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1572739",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1572739.tgz",
-      "integrity": "sha512-Dd0z5UXw7TJBRtlbCK/X0hePwrUm6/zxxVkwGTQU7kclkxgept8e4xdHYCDX1t59dcpRxpJNGim9ViUOjKfjNg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/diff": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -28613,6 +28604,22 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/pure-rand": {
       "version": "7.0.1",


### PR DESCRIPTION
The initial client config+status hydration was waiting until the first `useEffect` was firing, and what wasn't firing until after a complete render. This change makes it so the global application state store is initialized with the hydrated data in the first place.

- [x] I included a screenshot, logs, or example payload to demonstrate the change.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] This change has actually been tested.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
- [x] I read the "Read first" details about filing this PR.

```json
$ curl http://localhost:8080 |grep configHydration
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  window.configHydration = "{\"appearanceVariables\":{},\"name\":\"New Owncast Server\",\"customStyles\":\"\",\"offlineMessage\":\"\",\"logo\":\"/logo\",\"version\":\"Owncast v0.2.4-dev (20260128)\",\"extraPageContent\":\"\\u003ch1\\u003eWelcome to Owncast!\\u003c/h1\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eThis is a live stream powered by \\u003ca href=\\\"https://owncast.online\\\"\\u003eOwncast\\u003c/a\\u003e, a free and open source live streaming server.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eTo discover more examples of streams, visit \\u003ca href=\\\"https://owncast.directory\\\"\\u003eOwncast's directory\\u003c/a\\u003e.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eIf you're the owner of this server you should visit the admin and customize the content on this page.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\n\\u003c/ul\\u003e\\n\\u003chr/\\u003e\\n\\u003cvideo id=\\\"video\\\" controls preload=\\\"metadata\\\" style=\\\"width: 60vw; max-width: 600px; min-width: 200px;\\\" poster=\\\"https://videos.owncast.online/t/xaJ3xNn9Y6pWTdB25m9ai3\\\"\\u003e\\n  \\u003csource src=\\\"https://assets.owncast.tv/video/owncast-embed.mp4\\\" type=\\\"video/mp4\\\" /\\u003e\\n\\u003c/video\\u003e\",\"summary\":\"This is a new live video streaming server powered by Owncast.\",\"tags\":[\"owncast\",\"streaming\"],\"socialHandles\":[{\"platform\":\"github\",\"url\":\"https://github.com/owncast/owncast\",\"icon\":\"/img/platformlogos/github.svg\"}],\"externalActions\":[],\"notifications\":{\"browser\":{\"publicKey\":\"BDq7E-9uQzQ-ObZdk4nroVBroEVm8hwXELBNPKEkevWRM1bGZVT3yjcINaVFTDYTrXLOuGg2_bTJ2z1sIAmFN1s\",\"enabled\":true}},\"federation\":{\"enabled\":false},\"maxSocketPayloadSize\":2048,\"hideViewerCount\":false,\"chatDisabled\":false,\"chatSpamProtectionDisabled\":true,\"chatRequireAuthentication\":true,\"nsfw\":false,\"authentication\":{\"indieAuthEnabled\":true}}";
```