### PR TITLE
Fix Fediverse chat action overflows

### DIFF
--- a/web/components/chat/ChatSocialMessage/ChatSocialMessage.module.scss
+++ b/web/components/chat/ChatSocialMessage/ChatSocialMessage.module.scss
@@ -1,3 +1,10 @@
+.containerColumn {
+  position: relative;
+  max-width: 100%;
+  min-width: 1px;
+  display: grid;
+} 
+
 .followerPadding {
   padding: 0.5em;
 }
@@ -39,9 +46,13 @@
   }
 
   .account {
+    text-overflow: ellipsis;
     font-family: var(--theme-text-display-font-family);
     font-weight: 600;
     color: var(--theme-color-components-text-on-light);
+    overflow: hidden;
+    display: inline-block;
+    white-space: nowrap;
   }
 
   .icon {

--- a/web/components/chat/ChatSocialMessage/ChatSocialMessage.module.scss
+++ b/web/components/chat/ChatSocialMessage/ChatSocialMessage.module.scss
@@ -3,7 +3,7 @@
   max-width: 100%;
   min-width: 1px;
   display: grid;
-} 
+}
 
 .followerPadding {
   padding: 0.5em;

--- a/web/components/chat/ChatSocialMessage/ChatSocialMessage.tsx
+++ b/web/components/chat/ChatSocialMessage/ChatSocialMessage.tsx
@@ -50,7 +50,7 @@ export const ChatSocialMessage: FC<ChatSocialMessageProps> = ({ message }) => {
 
               <Icon className={styles.icon} />
             </Col>
-            <Col>
+            <Col className={styles.containerColumn}>
               <Row className={styles.account}>{title}</Row>
               <Row className={styles.body} dangerouslySetInnerHTML={{ __html: body }} />
             </Col>


### PR DESCRIPTION
## Double check


- [X] I included a screenshot, logs, or example payload to demonstrate the change.
- [X] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [X] This change has actually been tested.
- [X] The code has been run through the proper linters and/or formatters for the language.
- [X] There is an issue discussing this change and it's assigned to me.
- [X] I read the "Read first" details about filing this PR.




## Description

Fixes issue #4773:
Where the ferdiverse action titles spill over when there's a large username and/or small viewport. As discussed in the issue, the title is truncated with '...'


<img width="450" height="143" alt="image" src="https://github.com/user-attachments/assets/e1fd2095-0af2-4d44-b7aa-a8428e19b2e5" />

(before)

<img width="1579" height="736" alt="image" src="https://github.com/user-attachments/assets/9f73b34d-7167-40bb-b8a6-6ebb3e5a4895" />

(after)



thank you @gabek for helping me get over some hiccups while setting up!


