### PR TITLE
fix(web): set page title on chat embed pages

### DIFF
--- a/web/i18n/en/translation.json
+++ b/web/i18n/en/translation.json
@@ -221,7 +221,8 @@
 		"offlineBasic": "This stream is offline. Check back soon!",
 		"offlineFediverseOnly": "This stream is offline. <span class='follow-link'>Follow</span> {{fediverseAccount}} on the Fediverse to see the next time {{streamer}} goes live.",
 		"offlineNotifyAndFediverse": "This stream is offline. You can <span class='notify-link'>be notified</span> the next time {{streamer}} goes live or <span class='follow-link'>follow</span> {{fediverseAccount}} on the Fediverse.",
-		"offlineNotifyOnly": "This stream is offline. <span class='notify-link'>Be notified</span> the next time {{streamer}} goes live."
+		"offlineNotifyOnly": "This stream is offline. <span class='notify-link'>Be notified</span> the next time {{streamer}} goes live.",
+		"chatEmbedTitle": "{{name}} Chat"
 	},
 	"Testing": {
 		"itemCount": "You have {{count}} items",

--- a/web/pages/embed/chat/readonly/index.tsx
+++ b/web/pages/embed/chat/readonly/index.tsx
@@ -1,4 +1,6 @@
 import { useRecoilValue } from 'recoil';
+import Head from 'next/head';
+import { useTranslation } from 'next-export-i18n';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ChatMessage } from '../../../../interfaces/chat-message.model';
 import { ChatContainer } from '../../../../components/chat/ChatContainer/ChatContainer';
@@ -6,22 +8,34 @@ import {
   ClientConfigStore,
   currentUserAtom,
   visibleChatMessagesSelector,
+  clientConfigStateAtom,
   isChatAvailableSelector,
 } from '../../../../components/stores/ClientConfigStore';
+import { ClientConfig } from '../../../../interfaces/client-config.model';
 import { Theme } from '../../../../components/theme/Theme';
 import { ComponentError } from '../../../../components/ui/ComponentError/ComponentError';
+import { Localization } from '../../../../types/localization';
 
 export default function ReadOnlyChatEmbed() {
   const currentUser = useRecoilValue(currentUserAtom);
   const messages = useRecoilValue<ChatMessage[]>(visibleChatMessagesSelector);
+  const clientConfig = useRecoilValue<ClientConfig>(clientConfigStateAtom);
   const isChatAvailable = useRecoilValue(isChatAvailableSelector);
+
+  const { name } = clientConfig;
+  const { t } = useTranslation();
+
+  const pageTitle = name ? t(Localization.Frontend.chatEmbedTitle, { name }) : 'Chat';
 
   return (
     <div>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
       <ErrorBoundary
         // eslint-disable-next-line react/no-unstable-nested-components
         fallbackRender={({ error }) => (
-          <ComponentError componentName="ReadWriteChatEmbed" message={error.message} />
+          <ComponentError componentName="ReadOnlyChatEmbed" message={error.message} />
         )}
       >
         <ClientConfigStore />

--- a/web/pages/embed/chat/readwrite/index.tsx
+++ b/web/pages/embed/chat/readwrite/index.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/no-unknown-property */
 import { useRecoilValue } from 'recoil';
 import { useEffect } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
+import Head from 'next/head';
 import { useTranslation } from 'next-export-i18n';
+import { ErrorBoundary } from 'react-error-boundary';
 import { ChatMessage } from '../../../../interfaces/chat-message.model';
 import { ChatContainer } from '../../../../components/chat/ChatContainer/ChatContainer';
 import {
@@ -50,6 +51,8 @@ export default function ReadWriteChatEmbed() {
 
   const headerText = online ? streamTitle || name : name;
 
+  const pageTitle = name ? t(Localization.Frontend.chatEmbedTitle, { name }) : 'Chat';
+
   // This is a hack to force a specific body background color for just this page.
   useEffect(() => {
     document.body.classList.add('body-background');
@@ -57,6 +60,9 @@ export default function ReadWriteChatEmbed() {
 
   return (
     <div>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
       <style jsx global>
         {`
           .body-background {

--- a/web/types/localization.ts
+++ b/web/types/localization.ts
@@ -9,6 +9,7 @@ export const Localization = {
    */
   Frontend: {
     // Chat interface
+    chatEmbedTitle: 'Frontend.chatEmbedTitle',
     chatOffline: 'Chat is offline',
     chatDisabled: 'Chat is disabled',
     chatWillBeAvailable: 'Chat will be available when the stream is live',


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---

## Summary

Fixes #4794

The chat embed pages (`/embed/chat/readwrite` and `/embed/chat/readonly`) had no `<title>` tag, which caused:
- **Firefox**: Popup chat windows displayed a blank title bar, making window management difficult
- **Chromium**: Showed the raw URL path (e.g., `[host]/embed/chat/readwrite`) instead of a meaningful name

This PR adds a `<Head><title>` tag to both chat embed pages using the server's configured stream name, following the same pattern used in `OfflineEmbed.tsx`. The title format is `{streamName} Chat`.

## Changes

- **`web/pages/embed/chat/readwrite/index.tsx`**: Added `Head` import and `<title>` tag using the existing `name` from `clientConfig`
- **`web/pages/embed/chat/readonly/index.tsx`**: Added `Head` import, `clientConfigStateAtom` + `ClientConfig` imports, and `<title>` tag

## Test plan

- [x] ESLint passes on both changed files
- [x] Open a stream page → pop out chat → verify the popup window title shows `{streamName} Chat` in both Firefox and Chromium
- [x] Navigate to `/embed/chat/readonly` directly → verify the page title is set

## Screenshots
<img width="730" height="403" alt="Screenshot 2026-03-06 at 8 50 21 AM" src="https://github.com/user-attachments/assets/841fc88e-08bf-4de0-a963-394ad3ca71c3" />
<img width="696" height="917" alt="Screenshot 2026-03-06 at 8 43 31 AM" src="https://github.com/user-attachments/assets/dabd5a52-c3ac-4d3d-a74d-7e5143c8f86d" />