### PR TITLE
fix: add missing FEDIVERSE_ENGAGEMENT webhook types to openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4085,6 +4085,9 @@ components:
         - STREAM_TITLE_UPDATED
         - SYSTEM
         - CHAT_ACTION
+        - FEDIVERSE_ENGAGEMENT_FOLLOW
+        - FEDIVERSE_ENGAGEMENT_LIKE
+        - FEDIVERSE_ENGAGEMENT_REPOST
     ExternalAPIUser:
       type: object
       properties:


### PR DESCRIPTION
Fixes #4875.

The `FEDIVERSE_ENGAGEMENT_FOLLOW`, `FEDIVERSE_ENGAGEMENT_LIKE`, and `FEDIVERSE_ENGAGEMENT_REPOST` event types are defined in Go code (`core/chat/events/eventtype.go`) but missing from the `WebhookEventType` enum in `openapi.yaml`.

1 file, 3 lines added.