### PR TITLE
fix(api): document fediverse follow webhook event

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4077,6 +4077,7 @@ components:
         - USER_JOINED
         - USER_PARTED
         - NAME_CHANGE
+        - FEDIVERSE_ENGAGEMENT_FOLLOW
         - VISIBILITY-UPDATE
         - PING
         - PONG

--- a/webserver/handlers/generated/generated-types.gen.go
+++ b/webserver/handlers/generated/generated-types.gen.go
@@ -18,18 +18,19 @@ const (
 
 // Defines values for WebhookEventType.
 const (
-	CHAT               WebhookEventType = "CHAT"
-	CHATACTION         WebhookEventType = "CHAT_ACTION"
-	NAMECHANGE         WebhookEventType = "NAME_CHANGE"
-	PING               WebhookEventType = "PING"
-	PONG               WebhookEventType = "PONG"
-	STREAMSTARTED      WebhookEventType = "STREAM_STARTED"
-	STREAMSTOPPED      WebhookEventType = "STREAM_STOPPED"
-	STREAMTITLEUPDATED WebhookEventType = "STREAM_TITLE_UPDATED"
-	SYSTEM             WebhookEventType = "SYSTEM"
-	USERJOINED         WebhookEventType = "USER_JOINED"
-	USERPARTED         WebhookEventType = "USER_PARTED"
-	VISIBILITYUPDATE   WebhookEventType = "VISIBILITY-UPDATE"
+	CHAT                      WebhookEventType = "CHAT"
+	CHATACTION                WebhookEventType = "CHAT_ACTION"
+	FEDIVERSEENGAGEMENTFOLLOW WebhookEventType = "FEDIVERSE_ENGAGEMENT_FOLLOW"
+	NAMECHANGE                WebhookEventType = "NAME_CHANGE"
+	PING                      WebhookEventType = "PING"
+	PONG                      WebhookEventType = "PONG"
+	STREAMSTARTED             WebhookEventType = "STREAM_STARTED"
+	STREAMSTOPPED             WebhookEventType = "STREAM_STOPPED"
+	STREAMTITLEUPDATED        WebhookEventType = "STREAM_TITLE_UPDATED"
+	SYSTEM                    WebhookEventType = "SYSTEM"
+	USERJOINED                WebhookEventType = "USER_JOINED"
+	USERPARTED                WebhookEventType = "USER_PARTED"
+	VISIBILITYUPDATE          WebhookEventType = "VISIBILITY-UPDATE"
 )
 
 // ActionMessage defines model for ActionMessage.


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---
fixes #4875

---
**Note:**

I had opened  issue #4875 in order to follow the guidelines above, even though this patch was ready on my end. Not long after, PR https://github.com/owncast/owncast/pull/4876 was opened by another person, before any discussion or assignment on the issue. 

As the work was done on my end already, I'll create this PR even though I'm not assigned to the issue. I believe it is more correct than the existing one. Happy to amend if needed.

---

## Summary

This updates the OpenAPI webhook event enum to document the existing `FEDIVERSE_ENGAGEMENT_FOLLOW` event.

## Motivation

The OpenAPI schema did not include the `FEDIVERSE_ENGAGEMENT_FOLLOW` webhook payload in `WebhookEventType`, so generated API consumers could not see the full set of supported webhook events.

This is a documentation/schema change only.

## Changes

- Added `FEDIVERSE_ENGAGEMENT_FOLLOW` to the `WebhookEventType` enum in `openapi.yaml`.
- Regenerated the Go OpenAPI types so `webserver/handlers/generated/generated-types.gen.go` now includes `FEDIVERSEENGAGEMENTFOLLOW`.
  - The larger-looking generated Go diff is from `gofmt` realigning the `WebhookEventType` constant block after the longer `FEDIVERSEENGAGEMENTFOLLOW` identifier was added; the semantic change is the single new enum value.

