### PR TITLE
fix(webhooks): include serverURL in fediverse follow event

### DIFF
--- a/services/webhooks/fediverseEngagement.go
+++ b/services/webhooks/fediverseEngagement.go
@@ -24,8 +24,15 @@ func (s *Service) SendFediverseEngagementFollowEvent(iri string) {
 
 func (s *Service) sendFediverseEngagementEventFollow(event events.FediverseEngagementFollowEvent) {
 	webhookEvent := WebhookEvent{
-		Type:      models.FediverseEngagementFollow,
-		EventData: event,
+		Type: models.FediverseEngagementFollow,
+		EventData: &WebhookFediverseEngagementFollowEventData{
+			ID:        event.ID,
+			Timestamp: event.Timestamp,
+			Name:      event.Name,
+			Username:  event.Username,
+			Image:     event.Image,
+			ServerURL: s.serverURL(),
+		},
 	}
 
 	s.SendEventToWebhooks(webhookEvent)

--- a/services/webhooks/fediverseEngagement_test.go
+++ b/services/webhooks/fediverseEngagement_test.go
@@ -22,6 +22,7 @@ func TestSendFediverseEngagementEventFollow(t *testing.T) {
 		"id": "id",
 		"image": "",
 		"name": "be",
+		"serverURL": "http://localhost:8080",
 		"timestamp": "1970-01-01T00:01:12.000000006Z",
 		"username": "be@witch.me"
 		}`)

--- a/services/webhooks/webhooks.go
+++ b/services/webhooks/webhooks.go
@@ -74,6 +74,20 @@ type WebhookVisibilityToggleEventData struct {
 	MessageIDs []string     `json:"ids"`
 }
 
+// WebhookFediverseEngagementFollowEventData represents Fediverse follow engagement
+// event data sent as a webhook payload. Unlike stream-state events it does not
+// embed BaseWebhookData; the live stream status is unrelated to a follow action.
+// ServerURL is included so receivers can identify which Owncast instance sent
+// the webhook.
+type WebhookFediverseEngagementFollowEventData struct {
+	ID        string    `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
+	Name      string    `json:"name"`
+	Username  string    `json:"username"`
+	Image     string    `json:"image"`
+	ServerURL string    `json:"serverURL,omitempty"`
+}
+
 // SendEventToWebhooks fans an event out to every configured webhook
 // destination subscribed to that event type.
 func (s *Service) SendEventToWebhooks(payload WebhookEvent) {


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---

## Description

Fixes #4881.

The `FEDIVERSE_ENGAGEMENT_FOLLOW` webhook reused `events.FediverseEngagementFollowEvent` directly as the payload, so it had no way for the receiver to identify which Owncast instance sent the event. This adds `serverURL` to the follow payload.

Per the issue discussion (gabek and taintedcypher), the live stream `status` block is intentionally not included on this event. A follow happens regardless of whether the stream is online, so viewer counts and stream title are not meaningful context for the receiver. To keep that boundary clear in code, `WebhookFediverseEngagementFollowEventData` does not embed `BaseWebhookData`; it adds `serverURL` directly.

## Example payload

`go test -v -run TestSendFediverseEngagementEventFollow ./core/webhooks/...` passes. The follow webhook now delivers:

```json
{
  "id": "id",
  "image": "",
  "name": "be",
  "serverURL": "http://localhost:8080",
  "timestamp": "1970-01-01T00:01:12.000000006Z",
  "username": "be@witch.me"
}
```

`go vet` and `golangci-lint run ./core/webhooks/...` both clean.
