### PR TITLE
Fix golangci-lint debt (goconst, staticcheck h2c)

### DIFF
--- a/activitypub/controllers/nodeinfo.go
+++ b/activitypub/controllers/nodeinfo.go
@@ -14,6 +14,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// softwareName is the name of this server software reported in node info responses.
+	softwareName = "owncast"
+	// protocolActivityPub is the federation protocol name reported in node info responses.
+	protocolActivityPub = "activitypub"
+)
+
 // NodeInfoController returns the V1 node info response.
 func NodeInfoController(w http.ResponseWriter, r *http.Request) {
 	type links struct {
@@ -101,7 +108,7 @@ func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
 			Outbound: []string{},
 		},
 		Software: software{
-			Name:    "owncast",
+			Name:    softwareName,
 			Version: config.VersionNumber,
 		},
 		Usage: usage{
@@ -113,7 +120,7 @@ func NodeInfoV2Controller(w http.ResponseWriter, r *http.Request) {
 			LocalPosts: int(localPostCount),
 		},
 		OpenRegistrations: false,
-		Protocols:         []string{"activitypub"},
+		Protocols:         []string{protocolActivityPub},
 		Metadata: metadata{
 			ChatEnabled: !configRepository.GetChatDisabled(),
 		},
@@ -184,14 +191,14 @@ func XNodeInfo2Controller(w http.ResponseWriter, r *http.Request) {
 		Server: Server{
 			BaseURL:  serverURL,
 			Version:  config.VersionNumber,
-			Name:     "owncast",
-			Software: "owncast",
+			Name:     softwareName,
+			Software: softwareName,
 		},
 		Services: Services{
-			Inbound:  []string{"activitypub"},
-			Outbound: []string{"activitypub"},
+			Inbound:  []string{protocolActivityPub},
+			Outbound: []string{protocolActivityPub},
 		},
-		Protocols: []string{"activitypub"},
+		Protocols: []string{protocolActivityPub},
 		Version:   config.VersionNumber,
 		Usage: Usage{
 			Users: Users{

--- a/core/chat/events/actionEvent.go
+++ b/core/chat/events/actionEvent.go
@@ -9,10 +9,10 @@ type ActionEvent struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *ActionEvent) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"body":      e.Body,
-		"type":      e.GetMessageType(),
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyBody:      e.Body,
+		payloadKeyType:      e.GetMessageType(),
 	}
 }
 

--- a/core/chat/events/events.go
+++ b/core/chat/events/events.go
@@ -27,6 +27,14 @@ import (
 // EventPayload is a generic key/value map for sending out to chat clients.
 type EventPayload map[string]interface{}
 
+// Shared JSON payload keys used when building outbound chat event payloads.
+const (
+	payloadKeyType      = "type"
+	payloadKeyUser      = "user"
+	payloadKeyTimestamp = "timestamp"
+	payloadKeyBody      = "body"
+)
+
 // OutboundEvent represents an event that is sent out to all listeners of the chat server.
 type OutboundEvent interface {
 	GetBroadcastPayload() EventPayload

--- a/core/chat/events/fediverseEngagementEvent.go
+++ b/core/chat/events/fediverseEngagementEvent.go
@@ -18,14 +18,14 @@ func (e *FediverseEngagementEvent) GetBroadcastPayload() EventPayload {
 	configRepository := configrepository.Get()
 
 	return EventPayload{
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"body":      e.Body,
-		"image":     e.Image,
-		"type":      e.Type,
-		"title":     e.UserAccountName,
-		"link":      e.Link,
-		"user": EventPayload{
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyBody:      e.Body,
+		"image":             e.Image,
+		payloadKeyType:      e.Type,
+		"title":             e.UserAccountName,
+		"link":              e.Link,
+		payloadKeyUser: EventPayload{
 			"displayName": configRepository.GetServerName(),
 		},
 	}

--- a/core/chat/events/nameChangeEvent.go
+++ b/core/chat/events/nameChangeEvent.go
@@ -25,10 +25,10 @@ type NameChangeBroadcast struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *NameChangeBroadcast) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"user":      e.User,
-		"oldName":   e.Oldname,
-		"type":      UserNameChanged,
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyUser:      e.User,
+		"oldName":           e.Oldname,
+		payloadKeyType:      UserNameChanged,
 	}
 }

--- a/core/chat/events/setMessageVisibilityEvent.go
+++ b/core/chat/events/setMessageVisibilityEvent.go
@@ -12,11 +12,11 @@ type SetMessageVisibilityEvent struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *SetMessageVisibilityEvent) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"type":      VisibiltyUpdate,
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"ids":       e.MessageIDs,
-		"visible":   e.Visible,
+		payloadKeyType:      VisibiltyUpdate,
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		"ids":               e.MessageIDs,
+		"visible":           e.Visible,
 	}
 }
 

--- a/core/chat/events/systemMessageEvent.go
+++ b/core/chat/events/systemMessageEvent.go
@@ -15,11 +15,11 @@ func (e *SystemMessageEvent) GetBroadcastPayload() EventPayload {
 	configRepository := configrepository.Get()
 
 	return EventPayload{
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"body":      e.Body,
-		"type":      SystemMessageSent,
-		"user": EventPayload{
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyBody:      e.Body,
+		payloadKeyType:      SystemMessageSent,
+		payloadKeyUser: EventPayload{
 			"displayName": configRepository.GetServerName(),
 		},
 	}

--- a/core/chat/events/userDisabledEvent.go
+++ b/core/chat/events/userDisabledEvent.go
@@ -9,9 +9,9 @@ type UserDisabledEvent struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *UserDisabledEvent) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"type":      ErrorUserDisabled,
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"user":      e.User,
+		payloadKeyType:      ErrorUserDisabled,
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyUser:      e.User,
 	}
 }

--- a/core/chat/events/userJoinedEvent.go
+++ b/core/chat/events/userJoinedEvent.go
@@ -9,9 +9,9 @@ type UserJoinedEvent struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *UserJoinedEvent) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"type":      UserJoined,
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"user":      e.User,
+		payloadKeyType:      UserJoined,
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyUser:      e.User,
 	}
 }

--- a/core/chat/events/userMessageEvent.go
+++ b/core/chat/events/userMessageEvent.go
@@ -10,12 +10,12 @@ type UserMessageEvent struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *UserMessageEvent) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"body":      e.Body,
-		"user":      e.User,
-		"type":      MessageSent,
-		"visible":   e.HiddenAt == nil,
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyBody:      e.Body,
+		payloadKeyUser:      e.User,
+		payloadKeyType:      MessageSent,
+		"visible":           e.HiddenAt == nil,
 	}
 }
 

--- a/core/chat/events/userPartEvent.go
+++ b/core/chat/events/userPartEvent.go
@@ -9,9 +9,9 @@ type UserPartEvent struct {
 // GetBroadcastPayload will return the object to send to all chat users.
 func (e *UserPartEvent) GetBroadcastPayload() EventPayload {
 	return EventPayload{
-		"type":      UserParted,
-		"id":        e.ID,
-		"timestamp": e.Timestamp,
-		"user":      e.User,
+		payloadKeyType:      UserParted,
+		"id":                e.ID,
+		payloadKeyTimestamp: e.Timestamp,
+		payloadKeyUser:      e.User,
 	}
 }

--- a/core/transcoder/codecs.go
+++ b/core/transcoder/codecs.go
@@ -1,5 +1,3 @@
-//nolint:goconst
-
 package transcoder
 
 import (
@@ -9,6 +7,18 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+// ffmpeg x264-style encoding preset names, ordered from fastest to slowest.
+const (
+	presetUltrafast = "ultrafast"
+	presetSuperfast = "superfast"
+	presetVeryfast  = "veryfast"
+	presetFaster    = "faster"
+	presetFast      = "fast"
+)
+
+// codecNameVAAPI is the ffmpeg identifier for the VA-API hardware codec/device.
+const codecNameVAAPI = "vaapi"
 
 // Codec represents a supported codec on the system.
 type Codec interface {
@@ -26,7 +36,7 @@ type Codec interface {
 var supportedCodecs = map[string]string{
 	(&Libx264Codec{}).Name():      "libx264",
 	(&OmxCodec{}).Name():          "omx",
-	(&VaapiCodec{}).Name():        "vaapi",
+	(&VaapiCodec{}).Name():        codecNameVAAPI,
 	(&QuicksyncCodec{}).Name():    "qsv",
 	(&NvencCodec{}).Name():        "NVIDIA nvenc",
 	(&VideoToolboxCodec{}).Name(): "videotoolbox",
@@ -85,11 +95,11 @@ func (c *Libx264Codec) VariantFlags(v *HLSVariant) []string {
 // GetPresetForLevel returns the string preset for this codec given an integer level.
 func (c *Libx264Codec) GetPresetForLevel(l int) string {
 	presetMapping := map[int]string{
-		0: "ultrafast",
-		1: "superfast",
-		2: "veryfast",
-		3: "faster",
-		4: "fast",
+		0: presetUltrafast,
+		1: presetSuperfast,
+		2: presetVeryfast,
+		3: presetFaster,
+		4: presetFast,
 	}
 
 	preset, ok := presetMapping[l]
@@ -150,11 +160,11 @@ func (c *OmxCodec) VariantFlags(v *HLSVariant) []string {
 // GetPresetForLevel returns the string preset for this codec given an integer level.
 func (c *OmxCodec) GetPresetForLevel(l int) string {
 	presetMapping := map[int]string{
-		0: "ultrafast",
-		1: "superfast",
-		2: "veryfast",
-		3: "faster",
-		4: "fast",
+		0: presetUltrafast,
+		1: presetSuperfast,
+		2: presetVeryfast,
+		3: presetFaster,
+		4: presetFast,
 	}
 
 	preset, ok := presetMapping[l]
@@ -183,8 +193,8 @@ func (c *VaapiCodec) DisplayName() string {
 // GlobalFlags are the global flags used with this codec in the transcoder.
 func (c *VaapiCodec) GlobalFlags() []string {
 	flags := []string{
-		"-hwaccel", "vaapi",
-		"-hwaccel_output_format", "vaapi",
+		"-hwaccel", codecNameVAAPI,
+		"-hwaccel_output_format", codecNameVAAPI,
 		"-vaapi_device", "/dev/dri/renderD128",
 	}
 
@@ -193,7 +203,7 @@ func (c *VaapiCodec) GlobalFlags() []string {
 
 // PixelFormat is the pixel format required for this codec.
 func (c *VaapiCodec) PixelFormat() string {
-	return "vaapi"
+	return codecNameVAAPI
 }
 
 // Scaler is the scaler used for resizing the video in the transcoder.
@@ -219,11 +229,11 @@ func (c *VaapiCodec) VariantFlags(v *HLSVariant) []string {
 // GetPresetForLevel returns the string preset for this codec given an integer level.
 func (c *VaapiCodec) GetPresetForLevel(l int) string {
 	presetMapping := map[int]string{
-		0: "ultrafast",
-		1: "superfast",
-		2: "veryfast",
-		3: "faster",
-		4: "fast",
+		0: presetUltrafast,
+		1: presetSuperfast,
+		2: presetVeryfast,
+		3: presetFaster,
+		4: presetFast,
 	}
 
 	preset, ok := presetMapping[l]
@@ -357,8 +367,8 @@ func (c *QuicksyncCodec) VariantFlags(v *HLSVariant) []string {
 // GetPresetForLevel returns the string preset for this codec given an integer level.
 func (c *QuicksyncCodec) GetPresetForLevel(l int) string {
 	presetMapping := map[int]string{
-		0: "veryfast",
-		1: "fast",
+		0: presetVeryfast,
+		1: presetFast,
 		2: "medium",
 		3: "slow",
 		4: "veryslow",
@@ -420,11 +430,11 @@ func (c *Video4Linux) VariantFlags(v *HLSVariant) []string {
 // GetPresetForLevel returns the string preset for this codec given an integer level.
 func (c *Video4Linux) GetPresetForLevel(l int) string {
 	presetMapping := map[int]string{
-		0: "ultrafast",
-		1: "superfast",
-		2: "veryfast",
-		3: "faster",
-		4: "fast",
+		0: presetUltrafast,
+		1: presetSuperfast,
+		2: presetVeryfast,
+		3: presetFaster,
+		4: presetFast,
 	}
 
 	preset, ok := presetMapping[l]
@@ -486,11 +496,11 @@ func (c *VideoToolboxCodec) VariantFlags(v *HLSVariant) []string {
 // GetPresetForLevel returns the string preset for this codec given an integer level.
 func (c *VideoToolboxCodec) GetPresetForLevel(l int) string {
 	presetMapping := map[int]string{
-		0: "ultrafast",
-		1: "superfast",
-		2: "veryfast",
-		3: "faster",
-		4: "fast",
+		0: presetUltrafast,
+		1: presetSuperfast,
+		2: presetVeryfast,
+		3: presetFaster,
+		4: presetFast,
 	}
 
 	preset, ok := presetMapping[l]

--- a/core/transcoder/transcoder.go
+++ b/core/transcoder/transcoder.go
@@ -19,6 +19,9 @@ import (
 	"github.com/owncast/owncast/utils"
 )
 
+// ffmpegFlagMap is the ffmpeg stream selection flag.
+const ffmpegFlagMap = "-map"
+
 var _commandExec *exec.Cmd
 
 type execInfo struct {
@@ -411,14 +414,15 @@ func (v *HLSVariant) SetVideoBitrate(bitrate int) {
 func (v *HLSVariant) getVideoQualityString(t *Transcoder) []string {
 	if v.isVideoPassthrough {
 		return []string{
-			"-map", "v:0", fmt.Sprintf("-c:v:%d", v.index), "copy",
+			ffmpegFlagMap, "v:0", fmt.Sprintf("-c:v:%d", v.index), "copy",
 		}
 	}
 
 	gop := v.framerate * t.currentLatencyLevel.SecondsPerSegment // force an i-frame every segment
 	cmd := make([]string, 0, 20)
-	cmd = append(cmd,
-		"-map", "v:0",
+	cmd = append(
+		cmd,
+		ffmpegFlagMap, "v:0",
 		fmt.Sprintf("-c:v:%d", v.index), t.codec.Name(), // Video codec used for this variant
 		fmt.Sprintf("-b:v:%d", v.index), fmt.Sprintf("%dk", v.getAllocatedVideoBitrate()), // The average bitrate for this variant allowing space for audio
 		fmt.Sprintf("-maxrate:v:%d", v.index), fmt.Sprintf("%dk", v.getMaxVideoBitrate()), // The max bitrate allowed for this variant
@@ -451,14 +455,14 @@ func (v *HLSVariant) SetAudioBitrate(bitrate string) {
 func (v *HLSVariant) getAudioQualityString() []string {
 	if v.isAudioPassthrough {
 		return []string{
-			"-map", "a:0?", fmt.Sprintf("-c:a:%d", v.index), "copy",
+			ffmpegFlagMap, "a:0?", fmt.Sprintf("-c:a:%d", v.index), "copy",
 		}
 	}
 
 	// libfdk_aac is not a part of every ffmpeg install, so use "aac" instead
 	encoderCodec := "aac"
 	return []string{
-		"-map", "a:0?",
+		ffmpegFlagMap, "a:0?",
 		fmt.Sprintf("-c:a:%d", v.index), encoderCodec,
 		fmt.Sprintf("-b:a:%d", v.index), v.audioBitrate,
 	}

--- a/webserver/handlers/hls.go
+++ b/webserver/handlers/hls.go
@@ -52,5 +52,10 @@ func HandleHLSRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	middleware.EnableCors(w)
+	// fullPath is built from r.URL.Path, which is normalized and cleaned by the
+	// http.ServeMux that routes to this handler (stripping ".." traversal
+	// segments), and is further constrained to .m3u8/.ts files under
+	// config.HLSStoragePath via the extension check above and filepath.Join.
+	//nolint:gosec // G703: requested path is normalized and confined to HLSStoragePath.
 	http.ServeFile(w, r, fullPath)
 }

--- a/webserver/handlers/images.go
+++ b/webserver/handlers/images.go
@@ -15,6 +15,9 @@ const (
 	contentTypeGIF  = "image/gif"
 )
 
+// thumbnailFilename is the filename of the generated stream thumbnail image.
+const thumbnailFilename = "thumbnail.jpg"
+
 var previewThumbCache = ttlcache.New(
 	ttlcache.WithTTL[string, []byte](15),
 	ttlcache.WithCapacity[string, []byte](1),
@@ -23,7 +26,7 @@ var previewThumbCache = ttlcache.New(
 
 // GetThumbnail will return the thumbnail image as a response.
 func GetThumbnail(w http.ResponseWriter, r *http.Request) {
-	imageFilename := "thumbnail.jpg"
+	imageFilename := thumbnailFilename
 	imagePath := filepath.Join(config.TempDir, imageFilename)
 	httpCacheTime := utils.GetCacheDurationSecondsForPath(imagePath)
 	inMemoryCacheTime := time.Duration(15) * time.Second

--- a/webserver/handlers/index.go
+++ b/webserver/handlers/index.go
@@ -93,8 +93,8 @@ func renderIndexHtml(w http.ResponseWriter, nonce string) {
 		Summary:          configRepository.GetServerSummary(),
 		RequestedURL:     fmt.Sprintf("%s%s", configRepository.GetServerURL(), "/"),
 		TagsString:       strings.Join(configRepository.GetServerMetadataTags(), ","),
-		ThumbnailURL:     "thumbnail.jpg",
-		Thumbnail:        "thumbnail.jpg",
+		ThumbnailURL:     thumbnailFilename,
+		Thumbnail:        thumbnailFilename,
 		Image:            "logo/external",
 		StatusJSON:       string(sb),
 		ServerConfigJSON: string(cb),
@@ -174,7 +174,7 @@ func handleScraperMetadataPage(w http.ResponseWriter, r *http.Request) {
 
 	// If the thumbnail does not exist or we're offline then just use the logo image
 	var thumbnailURL string
-	if status.Online && utils.DoesFileExists(filepath.Join(config.DataDirectory, "tmp", "thumbnail.jpg")) {
+	if status.Online && utils.DoesFileExists(filepath.Join(config.DataDirectory, "tmp", thumbnailFilename)) {
 		thumbnail, err := url.Parse(fmt.Sprintf("%s://%s%s", scheme, r.Host, "/thumbnail.jpg"))
 		if err != nil {
 			log.Errorln(err)

--- a/webserver/router/router.go
+++ b/webserver/router/router.go
@@ -10,8 +10,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	chiMW "github.com/go-chi/chi/v5/middleware"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/owncast/owncast/activitypub"
 	aphandlers "github.com/owncast/owncast/activitypub/controllers"
@@ -66,8 +64,7 @@ func Start(enableVerboseLogging bool) error {
 	// Create a custom mux handler to intercept the /debug/vars endpoint.
 	// This is a hack because Prometheus enables this endpoint by default
 	// due to its use of expvar and we do not want this exposed.
-	h2s := &http2.Server{}
-	http2Handler := h2c.NewHandler(r, h2s)
+	rootHandler := r
 	m := http.NewServeMux()
 
 	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -79,18 +76,25 @@ func Start(enableVerboseLogging bool) error {
 			// Redirect /embed/chat
 			http.Redirect(w, r, "/embed/chat/readonly", http.StatusTemporaryRedirect)
 		default:
-			http2Handler.ServeHTTP(w, r)
+			rootHandler.ServeHTTP(w, r)
 		}
 	})
 
 	port := config.WebServerPort
 	ip := config.WebServerIP
 
+	// Allow cleartext (unencrypted) HTTP/2 in addition to HTTP/1, replacing the
+	// previously used and now-deprecated golang.org/x/net/http2/h2c wrapper.
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
 	compress, _ := httpcompression.DefaultAdapter() // Use the default configuration
 	server := &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", ip, port),
 		ReadHeaderTimeout: 4 * time.Second,
 		Handler:           compress(m),
+		Protocols:         protocols,
 	}
 
 	if ip != "0.0.0.0" {


### PR DESCRIPTION
## Summary

Clears the accumulated `golangci-lint` debt on `develop` so the full-repo lint run is clean. All changes are mechanical and behavior-preserving — extracted repeated literals into named constants and migrated one deprecated stdlib usage.

> **Stacked on #4909.** This PR's base is `gek/fix-indieauth-open-redirect`, not `develop`. The lone remaining lint finding (gosec G710 open redirect in the IndieAuth handler) is a real bug fixed by #4909; the two were mutually blocking on the full-repo push-event lint run, so this PR sits on top of #4909 to show fully-green checks. **Merge #4909 first**, then GitHub retargets this PR to `develop`. The diff here is lint-only.

- **goconst** — extracted repeated string literals into named constants:
  - `core/chat/events/*` — JSON payload keys (`type`, `user`, `timestamp`, `body`) → `payloadKey*` constants, applied across the 9 event files.
  - `core/transcoder/codecs.go` + `transcoder.go` — ffmpeg preset names, the `vaapi` codec name, and the `-map` flag.
  - `webserver/handlers/{images,index}.go` — shared `thumbnail.jpg` filename constant.
  - `activitypub/controllers/nodeinfo.go` — `owncast` software name and `activitypub` protocol name.
- **staticcheck SA1019** — migrated `webserver/router/router.go` off the deprecated `golang.org/x/net/http2/h2c` cleartext-HTTP/2 wrapper to the stdlib `http.Server.Protocols` API (`SetHTTP1(true)` + `SetUnencryptedHTTP2(true)`), preserving HTTP/1 and cleartext HTTP/2.
- **gosec G703** — documented the `hls.go` path-traversal report as a false positive (request path is normalized by the fronting `http.ServeMux`, extension-gated to `.m3u8`/`.ts`, joined under `HLSStoragePath`).

## Notes

- Constants equal the literals they replace exactly — no JSON or runtime behavior change.
- Why the debt surfaced: on a push of a new branch, `golangci-lint-action`'s `only-new-issues` has no diff base (`event.before` is the null SHA) and reports the whole repo, so pre-existing debt shows as a failing "Go linter" run on every new branch. Clearing it stops that.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` (v2.12.2, matching CI) reports `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)