### PR TITLE
fix(chat): fire USER_JOINED webhook when join/part messages are disabled

### DIFF
--- a/services/chat/server.go
+++ b/services/chat/server.go
@@ -138,24 +138,30 @@ func (s *Service) Addclient(conn *websocket.Conn, user *models.User, accessToken
 		ConnectedAt: time.Now(),
 	}
 
-	shouldSendJoinedMessages := s.configRepository.GetChatJoinPartMessagesEnabled()
+	// isNewJoin tracks whether this connection is a genuinely new chat join, as
+	// opposed to an additional client for an already-connected user or a quick
+	// reconnect. The admin "show join/part messages" setting is intentionally
+	// NOT consulted here: it governs only the visible broadcast in
+	// sendUserJoinedMessage, not whether the join occurred (so webhooks still
+	// fire when join/part messages are hidden). See #4950.
+	isNewJoin := true
 
-	// If there are existing clients connected for this user do not send
-	// a user joined message. Do not put this under a mutex, as
-	// GetClientsForUser already has a lock.
+	// If there are existing clients connected for this user this is not a new
+	// join. Do not put this under a mutex, as GetClientsForUser already has a
+	// lock.
 	if existingConnectedClients, _ := s.GetClientsForUser(user.ID); len(existingConnectedClients) > 0 {
-		shouldSendJoinedMessages = false
+		isNewJoin = false
 	}
 
 	s.mu.Lock()
 	{
-		// If there is a pending disconnect timer then clear it.
-		// Do not send user joined message if enough time hasn't passed where the
-		// user chat part message hasn't been sent yet.
+		// If there is a pending disconnect timer then clear it. A quick
+		// reconnect before the part was sent is not a new join, so neither the
+		// join broadcast nor the webhook should fire for it.
 		if ticker, ok := s.userPartedTimers[user.ID]; ok {
 			ticker.Stop()
 			delete(s.userPartedTimers, user.ID)
-			shouldSendJoinedMessages = false
+			isNewJoin = false
 		}
 
 		client.Id = s.seq
@@ -172,7 +178,7 @@ func (s *Service) Addclient(conn *websocket.Conn, user *models.User, accessToken
 	client.sendConnectedClientInfo()
 
 	if s.getStatus().Online {
-		if shouldSendJoinedMessages {
+		if isNewJoin {
 			s.sendUserJoinedMessage(client)
 		}
 		s.sendWelcomeMessageToClient(client)
@@ -192,8 +198,12 @@ func (s *Service) sendUserJoinedMessage(c *Client) {
 	userJoinedEvent.User = c.User
 	userJoinedEvent.ClientID = c.Id
 
-	if err := s.Broadcast(userJoinedEvent.GetBroadcastPayload()); err != nil {
-		log.Errorln("error adding client to chat server", err)
+	// Only broadcast the visible join message when join/part messages are
+	// enabled; the webhook below fires regardless, mirroring sendUserPartedMessage (#4950).
+	if s.configRepository.GetChatJoinPartMessagesEnabled() {
+		if err := s.Broadcast(userJoinedEvent.GetBroadcastPayload()); err != nil {
+			log.Errorln("error adding client to chat server", err)
+		}
 	}
 
 	// Send chat user joined webhook

--- a/services/chat/server_test.go
+++ b/services/chat/server_test.go
@@ -1,0 +1,105 @@
+package chat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/owncast/owncast/models"
+	"github.com/owncast/owncast/persistence/configrepository"
+	"github.com/owncast/owncast/persistence/webhookrepository"
+	"github.com/owncast/owncast/services/datastore"
+	"github.com/owncast/owncast/services/webhooks"
+)
+
+// fakeJoinPartConfig overrides only GetChatJoinPartMessagesEnabled; every other
+// ConfigRepository method is inherited from the embedded (nil) interface and is
+// never called by sendUserJoinedMessage.
+type fakeJoinPartConfig struct {
+	configrepository.ConfigRepository
+	enabled bool
+}
+
+func (f fakeJoinPartConfig) GetChatJoinPartMessagesEnabled() bool { return f.enabled }
+
+// TestSendUserJoinedMessage_WebhookFiresRegardlessOfJoinPartSetting guards the
+// fix for #4950: the USER_JOINED webhook must fire on a genuine join even when
+// the admin "show join/part messages" setting is off (it only governs the
+// visible chat broadcast), mirroring how the PART path already behaves.
+func TestSendUserJoinedMessage_WebhookFiresRegardlessOfJoinPartSetting(t *testing.T) {
+	for _, joinPartEnabled := range []bool{true, false} {
+		joinPartEnabled := joinPartEnabled
+		t.Run(map[bool]string{true: "messages-enabled", false: "messages-disabled"}[joinPartEnabled], func(t *testing.T) {
+			// A real datastore-backed webhooks service so dispatch actually runs.
+			dbFile, err := os.CreateTemp(t.TempDir(), "owncast-test-*.db")
+			if err != nil {
+				t.Fatal(err)
+			}
+			dbFile.Close()
+
+			ds, err := datastore.SetupPersistence(dbFile.Name(), t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			realConfig := configrepository.New(ds)
+			realConfig.SetServerURL("http://localhost:8080")
+			webhookRepo := webhookrepository.New(ds)
+
+			whSvc := webhooks.New(webhooks.Deps{
+				GetStatus:         func() models.Status { return models.Status{Online: true} },
+				ConfigRepository:  realConfig,
+				WebhookRepository: webhookRepo,
+			})
+			whSvc.Start()
+
+			received := make(chan struct{}, 1)
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received <- struct{}{}
+			}))
+			defer svr.Close()
+
+			if _, err := webhookRepo.InsertWebhook(svr.URL, []models.EventType{models.UserJoined}); err != nil {
+				t.Fatal(err)
+			}
+
+			chatSvc := New(Deps{
+				Webhooks:         whSvc,
+				ConfigRepository: fakeJoinPartConfig{enabled: joinPartEnabled},
+				GetStatus:        func() models.Status { return models.Status{Online: true} },
+			})
+
+			// An already-connected observer so we can detect whether the join was
+			// broadcast to chat (Broadcast delivers to registered clients).
+			observer := &Client{
+				User: &models.User{ID: "observer", DisplayName: "Observer"},
+				Id:   99,
+				send: make(chan []byte, 8),
+			}
+			chatSvc.clients[observer.Id] = observer
+
+			joining := &Client{
+				User: &models.User{ID: "u1", DisplayName: "Tester"},
+				Id:   1,
+				send: make(chan []byte, 8),
+			}
+
+			chatSvc.sendUserJoinedMessage(joining)
+
+			// The webhook must always fire for a real join (the #4950 bug: it did not when messages were disabled).
+			select {
+			case <-received:
+			case <-time.After(3 * time.Second):
+				t.Fatalf("USER_JOINED webhook did not fire (joinPartEnabled=%v)", joinPartEnabled)
+			}
+
+			// The visible chat broadcast is gated on the display setting.
+			gotBroadcast := len(observer.send) > 0
+			if gotBroadcast != joinPartEnabled {
+				t.Errorf("broadcast sent=%v, want %v (joinPartEnabled=%v)", gotBroadcast, joinPartEnabled, joinPartEnabled)
+			}
+		})
+	}
+}

--- a/services/chat/server_test.go
+++ b/services/chat/server_test.go
@@ -43,6 +43,10 @@ func TestSendUserJoinedMessage_WebhookFiresRegardlessOfJoinPartSetting(t *testin
 			if err != nil {
 				t.Fatal(err)
 			}
+			// Release the DB file handle before t.TempDir's RemoveAll runs;
+			// Windows cannot delete a file that is still open (registered after
+			// t.TempDir so it runs first, LIFO).
+			t.Cleanup(func() { _ = ds.DB.Close() })
 
 			realConfig := configrepository.New(ds)
 			realConfig.SetServerURL("http://localhost:8080")


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---

## Description

Fixes #4950.

The admin "show join/part messages" setting (`GetChatJoinPartMessagesEnabled`) gated both the visible chat broadcast and the `USER_JOINED` webhook. Turning the setting off therefore silently stopped the webhook from firing, which breaks integrations that rely on `USER_JOINED` even when a streamer doesn't want join lines cluttering chat.

The `USER_PARTED` path already does the right thing: in `sendUserPartedMessage`, the setting gates only the broadcast while `SendChatEventUserParted` fires unconditionally. This change makes the join path symmetric.

### What changed

In `Addclient`, the gate that decided whether to call `sendUserJoinedMessage` was seeded from the display setting and also forced off for two cases (an additional client for an already-connected user, and a quick reconnect before the part was sent). That gate is renamed `isNewJoin` and seeded `true`; it still suppresses both cases (so `USER_JOINED`/`USER_PARTED` webhook pairs stay balanced), but it no longer consults the display setting.

The display setting is now checked inside `sendUserJoinedMessage` to gate only the `Broadcast`, mirroring `sendUserPartedMessage`. The webhook fires for every genuine join.

### Why it won't regress join/part balance

- New single user: `isNewJoin` true, JOIN fires; on full disconnect the part timer fires PART.
- Second client (extra tab): suppressed (not a new join); that client's disconnect is also suppressed in `handleClientDisconnected`. Neither fires.
- Quick reconnect within the part-timer window: the pending part is cancelled and the rejoin is suppressed. Neither fires.
- Messages disabled: webhook fires, broadcast suppressed (the bug being fixed).

### Logs / verification

I am not assigned to #4950 yet, but the change references it and I am happy to have it assigned for release credit.

Added `services/chat/server_test.go` with a regression test asserting the `USER_JOINED` webhook fires whether the join/part display setting is on or off, while the visible broadcast remains gated on the setting. It uses a datastore-backed webhooks service with an `httptest` capture endpoint.

```
$ go test ./services/chat/
ok  	github.com/owncast/owncast/services/chat

$ go vet ./services/chat/   # clean
$ gofmt -l services/chat/   # no output (gofumpt-clean too)
```

