### PR TITLE
feat(web): include chat userId in external action query params

### DIFF
--- a/web/components/ui/Content/Content.tsx
+++ b/web/components/ui/Content/Content.tsx
@@ -161,10 +161,13 @@ export const Content: FC = () => {
       updatedUrl.searchParams.append('instance', currentBrowserWindowUrl);
 
       if (currentUser) {
-        const { displayName } = currentUser;
+        const { id, displayName } = currentUser;
 
-        // Append url and username to params so the link knows where we came from and who we are.
+        // Append url, username and userId to params so the link knows where we
+        // came from and who we are. Display names are not unique, so userId
+        // gives external actions a stable identifier for the chat user.
         updatedUrl.searchParams.append('username', displayName);
+        updatedUrl.searchParams.append('userId', id);
       }
       const fullUrl = updatedUrl.toString();
       // Overwrite URL with the updated one that includes the params.


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---

## Description

Fixes #4953

When an external action opens, Owncast already appends the instance URL and the chat display name (`username`) as query parameters. As noted in the issue, display names are not guaranteed unique, so they aren't a reliable identifier for add-ons that want to key off the current chat user.

This appends the chat user's stable `id` as a `userId` query parameter alongside the existing `username`, inside the same `if (currentUser)` block in `web/components/ui/Content/Content.tsx`. The id is already present on the client (`currentUser.id`, the same value passed as `chatUserId` to the chat container), so this is a small, self-contained change.

Resulting external-action URL params: `instance`, `username`, `userId`.

## Verification

- `userId` is appended via `URLSearchParams.append`, which handles encoding.
- The value comes from the existing `currentUser.id` field (`CurrentUser.id: string`), already used elsewhere in the same component.
- Verified with `eslint` and `tsc --noEmit` (both clean). The change adds no user-facing strings, so there is nothing new to translate. No visual change, so there is no screenshot to add; the effect is the additional `userId` parameter on the external-action URL.
