### PR TITLE
Let a pending fediverse auth request recover instead of erroring

### DIFF
--- a/webserver/handlers/auth/fediverse/fediverse.go
+++ b/webserver/handlers/auth/fediverse/fediverse.go
@@ -69,8 +69,11 @@ func (h *Handler) RegisterFediverseOTPRequest(u models.User, w http.ResponseWrit
 		return
 	}
 
+	// A false success with no error means a valid code is already pending for
+	// this account. Don't send a second message, but let the user proceed to
+	// enter the code they already received instead of dead-ending them.
 	if !success {
-		webutils.WriteSimpleResponse(w, false, "Could not register auth request. One may already be pending. Try again later.")
+		webutils.WriteSimpleResponse(w, true, "")
 		return
 	}
 

--- a/webserver/handlers/auth/fediverse/fediverse_test.go
+++ b/webserver/handlers/auth/fediverse/fediverse_test.go
@@ -1,0 +1,53 @@
+package fediverse
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	fediverseauth "github.com/owncast/owncast/auth/fediverse"
+	"github.com/owncast/owncast/models"
+)
+
+// When a code is already pending for the same account, RegisterFediverseOTP
+// returns success=false with no error (so we don't send a second message).
+// The handler must treat that as success and let the client continue to the
+// code entry step, rather than dead-ending the user with an error.
+func TestRegisterFallsThroughWhenCodeAlreadyPending(t *testing.T) {
+	const accessToken = "test-access-token"
+	const account = "someone@example.com"
+
+	svc := fediverseauth.New()
+
+	// Seed a pending request directly on the service so the handler's own
+	// register call hits the duplicate path. Going through the service here
+	// (rather than the handler) avoids sending the first OTP message, which
+	// the duplicate path under test never reaches anyway.
+	if _, ok, err := svc.RegisterFediverseOTP(accessToken, "uid", "display name", account); err != nil || !ok {
+		t.Fatalf("seeding a pending request failed: ok=%v err=%v", ok, err)
+	}
+
+	// Only FediverseAuth is needed; the duplicate path returns before touching
+	// activitypub, chat, or the config repository.
+	h := New(Deps{FediverseAuth: svc})
+
+	body := strings.NewReader(`{"account":"` + account + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/fediverse?accessToken="+accessToken, body)
+	rec := httptest.NewRecorder()
+
+	h.RegisterFediverseOTPRequest(models.User{}, rec, req)
+
+	var resp struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	if !resp.Success {
+		t.Fatalf("expected success when a code is already pending, got success=false (message=%q)", resp.Message)
+	}
+}


### PR DESCRIPTION
Closes #4887

## Summary

Re-requesting a fediverse OTP for the same account no longer dead-ends the user. The auth service already returns the existing pending code (`success=false`, no error) instead of issuing a second one, but the handler was treating that as a hard failure and responding with "Could not register auth request. One may already be pending. Try again later." That's exactly the state people hit in #4887: the "enter code" modal gets dismissed (e.g. switching apps on mobile to copy the code), and trying again just bounces off that error until the 10-minute request expires.

Now the handler returns success on that path without sending a second DM, so the client moves straight to the code entry step with the code the user already received.

## Why

The duplicate-request handling is intentional on the service side — we don't want to send someone a new code every time they re-open the modal. The bug was only in how the handler reported it: a deliberate "already pending" wasn't an error, but we were surfacing it as one.

## Testing

- `go test ./webserver/handlers/auth/fediverse/ ./auth/fediverse/`
- Added `TestRegisterFallsThroughWhenCodeAlreadyPending`, which seeds a pending request and asserts the handler responds with success on the duplicate. Reverting the one-line change makes it fail with the old "one may already be pending" message, so it actually guards the regression.

## Notes

- Backend only. The frontend already advances to the code entry step on a success response, so no web changes are needed.
- This doesn't address the separate UI annoyance of the modal disappearing on focus loss — just makes recovery work when it does.
