### PR TITLE
Trim U+0085 (NEXT LINE) in display name validation

### DIFF
--- a/web/tests/displayNameValidation.test.ts
+++ b/web/tests/displayNameValidation.test.ts
@@ -28,6 +28,16 @@ describe('Display Name Validation', () => {
       expect(result.trimmedName).toBe('NewUser');
     });
 
+    test('should trim U+0085 (NEL) padding and accept valid name', () => {
+      const result = validateDisplayName(
+        '\u0085\u0085 NewUser \u0085',
+        currentName,
+        characterLimit,
+      );
+      expect(result.isValid).toBe(true);
+      expect(result.trimmedName).toBe('NewUser');
+    });
+
     test('should accept name with Unicode characters', () => {
       const result = validateDisplayName('用户名', currentName, characterLimit);
       expect(result.isValid).toBe(true);

--- a/web/utils/displayNameValidation.ts
+++ b/web/utils/displayNameValidation.ts
@@ -16,8 +16,10 @@ export interface DisplayNameValidationResult {
  * This includes ASCII whitespace plus Unicode space characters and invisible characters
  */
 // Unicode whitespace character class used for trimming (matches Go's strings.TrimSpace)
+// U+0085 (NEXT LINE) is listed explicitly because JS \s does not match it, while Go's
+// unicode.IsSpace (used by strings.TrimSpace) and the Unicode White_Space property do.
 const UNICODE_WHITESPACE_CLASS =
-  '[\\s\\u00A0\\u1680\\u180E\\u2000-\\u200A\\u200B-\\u200D\\u2028\\u2029\\u202F\\u205F\\u3000\\uFEFF]';
+  '[\\s\\u0085\\u00A0\\u1680\\u180E\\u2000-\\u200A\\u200B-\\u200D\\u2028\\u2029\\u202F\\u205F\\u3000\\uFEFF]';
 
 export function trimUnicodeWhitespace(str: string): string {
   // Unicode whitespace regex that matches what Go's strings.TrimSpace() removes


### PR DESCRIPTION
## What

`trimUnicodeWhitespace` in `web/utils/displayNameValidation.ts` builds a character class that is meant to match what Go's `strings.TrimSpace` removes, but it omits U+0085 (NEXT LINE).

JavaScript's `\s` does not match U+0085, which is why the space characters it misses (U+00A0, U+1680, U+2000-U+200A, U+202F, U+205F, U+3000, ...) are already listed out one by one. U+0085 was the one that slipped through. Go's `unicode.IsSpace` (used by `strings.TrimSpace`) returns true for U+0085, and U+0085 has White_Space=Yes in the Unicode character database, so the frontend validator was inconsistent with the backend: a display name padded with NEXT LINE is trimmed by Go but was left intact here.

## Change

- Add U+0085 to the whitespace class, with a short comment explaining why it needs to be listed explicitly (JS \s does not cover it).
- Add a unit test for a name padded with U+0085.

## Testing

From the web directory, npm test passes (38 tests). Removing the U+0085 addition makes only the new test fail, which confirms the test exercises this change and nothing else regresses.
