### PR TITLE
Restore the fediverse code-entry step after a page reload

### DIFF
--- a/web/components/common/UserDropdown/UserDropdown.tsx
+++ b/web/components/common/UserDropdown/UserDropdown.tsx
@@ -2,7 +2,7 @@ import { MenuProps, Dropdown, Button } from 'antd';
 import classnames from 'classnames';
 
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import dynamic from 'next/dynamic';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -15,6 +15,7 @@ import {
 import styles from './UserDropdown.module.scss';
 import { AppStateOptions } from '../../stores/application-state';
 import { ComponentError } from '../../ui/ComponentError/ComponentError';
+import { getPendingFediverseAuth } from '../../../utils/fediverseAuthSession';
 
 // Lazy loaded components
 
@@ -82,6 +83,15 @@ export const UserDropdown: FC<UserDropdownProps> = ({
   const [chatState, setChatState] = useRecoilState(chatStateAtom);
   const [popupWindow, setPopupWindow] = useState<Window>(null);
   const appState = useRecoilValue<AppStateOptions>(appStateAtom);
+
+  // Reopen the auth modal on load if a fediverse verification was still in
+  // progress, so a viewer who reloaded mid-flow (issue #4887) lands back on the
+  // code-entry step instead of losing it.
+  useEffect(() => {
+    if (getPendingFediverseAuth()) {
+      setShowAuthModal(true);
+    }
+  }, []);
 
   const toggleChatVisibility = () => {
     // If we don't support the hide chat option then don't do anything.

--- a/web/components/modals/AuthModal/AuthModal.tsx
+++ b/web/components/modals/AuthModal/AuthModal.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { IndieAuthModal } from '../IndieAuthModal/IndieAuthModal';
 import { FediAuthModal } from '../FediAuthModal/FediAuthModal';
+import { getPendingFediverseAuth } from '../../../utils/fediverseAuthSession';
 
 import styles from './AuthModal.module.scss';
 import {
@@ -67,6 +68,10 @@ export const AuthModal: FC<AuthModalProps> = ({ forceTabs }) => {
     { label: fediAuthTabTitle, key: '2', children: fediAuthTab },
   ];
 
+  // If a fediverse verification is still in progress (restored after a reload),
+  // open straight to that tab so the recovered code-entry step is visible.
+  const defaultActiveKey = getPendingFediverseAuth() ? '2' : '1';
+
   return (
     <ErrorBoundary
       // eslint-disable-next-line react/no-unstable-nested-components
@@ -80,7 +85,7 @@ export const AuthModal: FC<AuthModalProps> = ({ forceTabs }) => {
     >
       <div>
         <Tabs
-          defaultActiveKey="1"
+          defaultActiveKey={defaultActiveKey}
           items={items}
           type="card"
           size="small"

--- a/web/components/modals/AuthModal/AuthModal.tsx
+++ b/web/components/modals/AuthModal/AuthModal.tsx
@@ -69,8 +69,9 @@ export const AuthModal: FC<AuthModalProps> = ({ forceTabs }) => {
   ];
 
   // If a fediverse verification is still in progress (restored after a reload),
-  // open straight to that tab so the recovered code-entry step is visible.
-  const defaultActiveKey = getPendingFediverseAuth() ? '2' : '1';
+  // open straight to that tab so the recovered code-entry step is visible. Only
+  // when federation is enabled, since the FediAuth tab is unreachable otherwise.
+  const defaultActiveKey = fediverseEnabled && getPendingFediverseAuth() ? '2' : '1';
 
   return (
     <ErrorBoundary

--- a/web/components/modals/FediAuthModal/FediAuthModal.tsx
+++ b/web/components/modals/FediAuthModal/FediAuthModal.tsx
@@ -1,8 +1,13 @@
 import { Alert, Button, Input, Space, Spin, Collapse } from 'antd';
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import styles from './FediAuthModal.module.scss';
 import { isValidFediverseAccount } from '../../../utils/validators';
+import {
+  getPendingFediverseAuth,
+  setPendingFediverseAuth,
+  clearPendingFediverseAuth,
+} from '../../../utils/fediverseAuthSession';
 
 const { Panel } = Collapse;
 
@@ -29,6 +34,17 @@ export const FediAuthModal: FC<FediAuthModalProps> = ({
   const [account, setAccount] = useState('');
   const [code, setCode] = useState('');
   const [verifyingCode, setVerifyingCode] = useState(false);
+
+  // Restore an in-progress verification if the viewer left and came back (e.g.
+  // backgrounded the tab to copy their code) within the OTP lifetime.
+  useEffect(() => {
+    const pending = getPendingFediverseAuth();
+    if (pending) {
+      setAccount(pending.account);
+      setValid(isValidFediverseAccount(pending.account));
+      setVerifyingCode(true);
+    }
+  }, []);
 
   const message = !authenticated ? (
     <span>
@@ -94,7 +110,8 @@ export const FediAuthModal: FC<FediAuthModalProps> = ({
     try {
       await makeRequest(url, data);
 
-      // Success. Reload the page.
+      // Verified. Drop the persisted state and reload the page.
+      clearPendingFediverseAuth();
       window.location.href = '/';
     } catch (e) {
       console.error(e);
@@ -116,6 +133,7 @@ export const FediAuthModal: FC<FediAuthModalProps> = ({
 
     try {
       await makeRequest(url, data);
+      setPendingFediverseAuth(normalizedAccount);
       setVerifyingCode(true);
     } catch (e) {
       console.error(e);

--- a/web/tests/fediverseAuthSession.test.ts
+++ b/web/tests/fediverseAuthSession.test.ts
@@ -25,6 +25,11 @@ describe('parsePendingFediverseAuth', () => {
     expect(parsePendingFediverseAuth(raw, now)).toBeNull();
   });
 
+  test('drops entries with a future or non-finite timestamp', () => {
+    expect(parsePendingFediverseAuth(JSON.stringify({ account, ts: now + 1 }), now)).toBeNull();
+    expect(parsePendingFediverseAuth(`{"account":"${account}","ts":1e999}`, now)).toBeNull();
+  });
+
   test('returns null for missing or malformed data', () => {
     expect(parsePendingFediverseAuth(null, now)).toBeNull();
     expect(parsePendingFediverseAuth('not json', now)).toBeNull();

--- a/web/tests/fediverseAuthSession.test.ts
+++ b/web/tests/fediverseAuthSession.test.ts
@@ -1,0 +1,34 @@
+import {
+  parsePendingFediverseAuth,
+  PENDING_FEDIVERSE_AUTH_EXPIRY_MS,
+} from '../utils/fediverseAuthSession';
+
+describe('parsePendingFediverseAuth', () => {
+  const now = 1_700_000_000_000;
+  const account = 'streamer@example.com';
+
+  test('returns the account for a fresh entry', () => {
+    const raw = JSON.stringify({ account, ts: now });
+    expect(parsePendingFediverseAuth(raw, now)).toEqual({ account, ts: now });
+  });
+
+  test('keeps an entry right at the expiry boundary', () => {
+    const raw = JSON.stringify({ account, ts: now - PENDING_FEDIVERSE_AUTH_EXPIRY_MS });
+    expect(parsePendingFediverseAuth(raw, now)).toEqual({
+      account,
+      ts: now - PENDING_FEDIVERSE_AUTH_EXPIRY_MS,
+    });
+  });
+
+  test('drops an entry past the OTP lifetime so the viewer is not stranded', () => {
+    const raw = JSON.stringify({ account, ts: now - PENDING_FEDIVERSE_AUTH_EXPIRY_MS - 1 });
+    expect(parsePendingFediverseAuth(raw, now)).toBeNull();
+  });
+
+  test('returns null for missing or malformed data', () => {
+    expect(parsePendingFediverseAuth(null, now)).toBeNull();
+    expect(parsePendingFediverseAuth('not json', now)).toBeNull();
+    expect(parsePendingFediverseAuth(JSON.stringify({ ts: now }), now)).toBeNull();
+    expect(parsePendingFediverseAuth(JSON.stringify({ account }), now)).toBeNull();
+  });
+});

--- a/web/utils/fediverseAuthSession.ts
+++ b/web/utils/fediverseAuthSession.ts
@@ -36,6 +36,12 @@ export function parsePendingFediverseAuth(
     return null;
   }
 
+  // Reject non-finite or future timestamps so a bad value can't pin the modal
+  // open forever (Infinity or a future ts never crosses the expiry check).
+  if (!Number.isFinite(parsed.ts) || parsed.ts > now) {
+    return null;
+  }
+
   if (now - parsed.ts > PENDING_FEDIVERSE_AUTH_EXPIRY_MS) {
     return null;
   }

--- a/web/utils/fediverseAuthSession.ts
+++ b/web/utils/fediverseAuthSession.ts
@@ -1,0 +1,77 @@
+// Persists an in-progress fediverse OTP verification across a page reload so a
+// viewer who backgrounds the tab to copy their code (issue #4887) returns to the
+// code-entry step instead of an empty account form.
+//
+// The window mirrors the backend OTP lifetime (auth/fediverse registrationTimeout
+// is 10 minutes). Past that the code the viewer received is dead, so we drop the
+// persisted state and send them back to the account step rather than stranding
+// them at a code box that can never succeed.
+
+const PENDING_FEDIVERSE_AUTH_KEY = 'pendingFediverseAuth';
+export const PENDING_FEDIVERSE_AUTH_EXPIRY_MS = 10 * 60 * 1000;
+
+export type PendingFediverseAuth = {
+  account: string;
+  ts: number;
+};
+
+// Pure decode + expiry check, kept separate from storage I/O so it can be tested
+// with a plain string and clock value.
+export function parsePendingFediverseAuth(
+  raw: string | null,
+  now: number,
+): PendingFediverseAuth | null {
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: PendingFediverseAuth;
+  try {
+    parsed = JSON.parse(raw) as PendingFediverseAuth;
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed.account !== 'string' || typeof parsed.ts !== 'number') {
+    return null;
+  }
+
+  if (now - parsed.ts > PENDING_FEDIVERSE_AUTH_EXPIRY_MS) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function getPendingFediverseAuth(): PendingFediverseAuth | null {
+  try {
+    const result = parsePendingFediverseAuth(
+      sessionStorage.getItem(PENDING_FEDIVERSE_AUTH_KEY),
+      Date.now(),
+    );
+    if (!result) {
+      sessionStorage.removeItem(PENDING_FEDIVERSE_AUTH_KEY);
+    }
+    return result;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
+export function setPendingFediverseAuth(account: string): void {
+  try {
+    const value: PendingFediverseAuth = { account, ts: Date.now() };
+    sessionStorage.setItem(PENDING_FEDIVERSE_AUTH_KEY, JSON.stringify(value));
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export function clearPendingFediverseAuth(): void {
+  try {
+    sessionStorage.removeItem(PENDING_FEDIVERSE_AUTH_KEY);
+  } catch (e) {
+    console.error(e);
+  }
+}


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---

Part of #4887.

This is the third piece of #4887, on top of #4893 (don't lose the modal on an accidental tap) and #4972 (don't error on a re-request). Those make the mobile case recoverable. This makes it not happen in the first place.

The reporter's actual scenario is a mobile tab reload: you request a fediverse code, switch to your Fedi app to copy it, and when you come back the tab has reloaded, the SPA remounts, and the code-entry step is gone. You'd have to start over.

## What it does

- When you request a code, the account is saved to sessionStorage.
- On load, if a request is still in progress, the auth modal reopens straight to the FediAuth tab with the code-entry step restored, so you can paste the code you already received.
- The saved state is dropped once the code verifies.

The saved state expires after 10 minutes to match the backend OTP lifetime (auth/fediverse registrationTimeout). Past that the code is dead, so instead of stranding you at a code box that can't succeed, it sends you back to the account step.

## Testing

- Added a unit test for the parse + expiry logic.
- Verified end to end against the local two-instance federation dev env (test/automated/activitypub/dev-up.sh): instance A sent a real OTP DM to a fediverse account on instance B, a page reload restored the code box on the FediAuth tab, and pasting the real code linked the identity and cleared the saved state. A stale (>10 min) entry correctly did not reopen the modal and was purged.

## Notes

- Frontend only.