### PR TITLE
Add a central scheduler service for recurring background work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/extism/go-sdk v1.7.1
 	github.com/go-chi/chi/v5 v5.2.4
+	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/go-fed/httpsig v1.1.0
 	github.com/gobwas/glob v0.2.3
 	github.com/gorilla/websocket v1.5.3
@@ -73,6 +74,7 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20240805132620-81f5be970eca // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lestrrat-go/strftime v1.1.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
@@ -84,6 +86,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/go-chi/chi/v5 v5.2.4 h1:WtFKPHwlywe8Srng8j2BhOD9312j9cGUxG1SP4V2cR4=
 github.com/go-chi/chi/v5 v5.2.4/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-co-op/gocron/v2 v2.21.2 h1:bD8/YwkojYHgXFr3iEulL148KBdTbKVxUZzFKpXcdbY=
+github.com/go-co-op/gocron/v2 v2.21.2/go.mod h1:5lEiCKk1oVJV39Zg7/YG10OnaVrDAV5GGR6O0663k6U=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
@@ -168,6 +170,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a h1:w3tdWGKbLGBPtR/8/oO74W6hmz0qE5q0z9aqSAewaaM=
 github.com/rogpeppe/go-internal v1.13.2-0.20241226121412-a5dc8ff20d0a/go.mod h1:S8kfXMp+yh77OxPD4fdM6YUknrZpQxLhvxzS4gDHENY=
 github.com/schollz/sqlite3dump v1.3.1 h1:QXizJ7XEJ7hggjqjZ3YRtF3+javm8zKtzNByYtEkPRA=

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/owncast/owncast/services/dispatcher"
 	"github.com/owncast/owncast/services/rtmp"
 	"github.com/owncast/owncast/services/schedule"
+	"github.com/owncast/owncast/services/scheduler"
 	"github.com/owncast/owncast/services/stalefeaturedcheckservice"
 	"github.com/owncast/owncast/services/stream"
 	"github.com/owncast/owncast/services/webhooks"
@@ -294,11 +295,32 @@ func main() {
 	}
 	defer streamSvc.Stop(ctx)
 
-	// Background sweep that marks federated peer servers offline when
-	// they stop sending stream-status pings, keeping the
-	// featured-streams directory honest.
-	stalefeaturedcheckservice.Start()
-	defer stalefeaturedcheckservice.Stop()
+	// The central scheduler owns all recurring background work. Services
+	// expose an idempotent job method plus an interval constant, and get
+	// registered here.
+	schedulerSvc, err := scheduler.New()
+	if err != nil {
+		log.Fatalln("failed to create the scheduler", err)
+	}
+
+	// Marks federated peer servers offline when they stop sending
+	// stream-status pings, keeping the featured-streams directory honest.
+	staleFeaturedSvc := stalefeaturedcheckservice.New(stalefeaturedcheckservice.Deps{
+		ConfigRepository:           configRepository,
+		FederatedServersRepository: federatedServersRepository,
+	})
+
+	schedulerJobs := []scheduler.Job{
+		{Name: "stale-featured-servers", Interval: stalefeaturedcheckservice.CheckInterval, RunAtStart: true, Run: staleFeaturedSvc.Run},
+		{Name: "chat-data-pruner", Interval: chat.DataPruneInterval, RunAtStart: true, Run: chatSvc.RunDataPruner},
+	}
+	for _, job := range schedulerJobs {
+		if err := schedulerSvc.Register(job); err != nil {
+			log.Fatalln("failed to register scheduler job", job.Name, err)
+		}
+	}
+	schedulerSvc.Start()
+	defer schedulerSvc.Stop()
 
 	// Materializes scheduled stream occurrences from recurring series and
 	// keeps the next-event answer warm for the status endpoint.

--- a/services/chat/chat.go
+++ b/services/chat/chat.go
@@ -60,8 +60,9 @@ func (s *Service) SetGetStatus(fn func() models.Status) {
 	s.getStatus = fn
 }
 
-// Start initializes persistence, launches the broadcast loop, and
-// registers the Prometheus counter. Safe to call once.
+// Start launches the broadcast loop and registers the Prometheus counter.
+// Safe to call once. History pruning runs as a job on the central
+// scheduler (RunDataPruner), registered by main.go.
 func (s *Service) Start() error {
 	go s.Run()
 

--- a/services/chat/chat.go
+++ b/services/chat/chat.go
@@ -63,8 +63,6 @@ func (s *Service) SetGetStatus(fn func() models.Status) {
 // Start initializes persistence, launches the broadcast loop, and
 // registers the Prometheus counter. Safe to call once.
 func (s *Service) Start() error {
-	s.setupPersistence()
-
 	go s.Run()
 
 	log.Traceln("Chat server started with max connection count of", s.maxSocketConnectionLimit)

--- a/services/chat/persistence.go
+++ b/services/chat/persistence.go
@@ -1,19 +1,20 @@
 package chat
 
 import (
+	"context"
 	"time"
 )
 
 const (
 	maxBacklogHours = 2 // Keep backlog max hours worth of messages
+
+	// DataPruneInterval is how often RunDataPruner should run, registered
+	// on the central scheduler by main.go.
+	DataPruneInterval = 5 * time.Minute
 )
 
-func (s *Service) setupPersistence() {
-	chatDataPruner := time.NewTicker(5 * time.Minute)
-	go func() {
-		s.runPruner()
-		for range chatDataPruner.C {
-			s.runPruner()
-		}
-	}()
+// RunDataPruner is the scheduler job body that trims chat history down to
+// the backlog window.
+func (s *Service) RunDataPruner(_ context.Context) {
+	s.runPruner()
 }

--- a/services/scheduler/scheduler.go
+++ b/services/scheduler/scheduler.go
@@ -1,0 +1,158 @@
+// Package scheduler is the application's central home for recurring
+// background work: a registry of named jobs running on fixed intervals,
+// replacing the ad-hoc time.NewTicker loops that used to be scattered
+// across services.
+//
+// The scheduling engine is gocron (github.com/go-co-op/gocron/v2), a
+// widely-used, actively-maintained library, wrapped in this thin service so
+// consumers depend on one small Owncast-shaped API instead of a third-party
+// surface, and so every job gets the same conventions: overlap protection
+// (a run that outlives its interval causes the next tick to be skipped,
+// never stacked), panic recovery, and a shutdown that waits for in-flight
+// runs.
+//
+// Jobs are expected to be idempotent sweeps that read their own state and
+// tolerate rerunning after a restart, the same contract the old tickers
+// had. Interval-based on purpose: every recurring internal task Owncast
+// has is "every N". gocron supports crontab and wall-clock schedules too,
+// so a RegisterCron variant can join Register if a real calendar-time need
+// ever appears.
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+// Job is one recurring unit of background work.
+type Job struct {
+	// Name uniquely identifies the job in logs and status listings.
+	Name string
+	// Interval is how often the job runs. Must be positive.
+	Interval time.Duration
+	// RunAtStart also runs the job once immediately when the scheduler
+	// starts instead of waiting a full interval for the first run.
+	RunAtStart bool
+	// Run does the work. It should honor ctx, which is cancelled when the
+	// scheduler stops.
+	Run func(ctx context.Context)
+}
+
+// JobStatus is a point-in-time view of a registered job, for logging and
+// future admin or debug surfaces.
+type JobStatus struct {
+	Name      string    `json:"name"`
+	LastRunAt time.Time `json:"lastRunAt"`
+	NextRunAt time.Time `json:"nextRunAt"`
+}
+
+// Service runs registered jobs until stopped. Construct with New in
+// main.go and inject into anything that needs to register work.
+type Service struct {
+	engine gocron.Scheduler
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// New constructs the scheduler.
+func New() (*Service, error) {
+	engine, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Service{
+		engine: engine,
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
+}
+
+// Register adds a job. Jobs registered before Start begin running at
+// Start; jobs registered after Start (but before Stop) are picked up
+// immediately. Names must be unique and intervals positive.
+func (s *Service) Register(job Job) error {
+	if job.Name == "" {
+		return errors.New("scheduler job needs a name")
+	}
+	if job.Interval <= 0 {
+		return errors.New("scheduler job " + job.Name + " needs a positive interval")
+	}
+	if job.Run == nil {
+		return errors.New("scheduler job " + job.Name + " needs a Run function")
+	}
+	for _, existing := range s.engine.Jobs() {
+		if existing.Name() == job.Name {
+			return errors.New("scheduler job " + job.Name + " is already registered")
+		}
+	}
+
+	options := []gocron.JobOption{
+		gocron.WithName(job.Name),
+		// A run that outlives its interval causes following ticks to be
+		// skipped rather than queued or run concurrently.
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
+	}
+	if job.RunAtStart {
+		options = append(options, gocron.WithStartAt(gocron.WithStartImmediately()))
+	}
+
+	run := job.Run
+	name := job.Name
+	_, err := s.engine.NewJob(
+		gocron.DurationJob(job.Interval),
+		gocron.NewTask(func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("Scheduler job %s panicked: %v", name, r)
+				}
+			}()
+			if s.ctx.Err() != nil {
+				return
+			}
+			run(s.ctx)
+		}),
+		options...,
+	)
+	return err
+}
+
+// Start begins running every registered job.
+func (s *Service) Start() {
+	s.engine.Start()
+	log.Infof("Started scheduler with %d job(s)", len(s.engine.Jobs()))
+}
+
+// Stop cancels the job context and shuts the engine down, waiting for
+// in-flight runs to finish. A stopped Service is permanently done: it
+// cannot be restarted, and Register calls after Stop are silent no-ops.
+func (s *Service) Stop() {
+	s.cancel()
+	if err := s.engine.Shutdown(); err != nil {
+		log.Errorf("error shutting down scheduler: %v", err)
+		return
+	}
+	log.Infoln("Stopped scheduler")
+}
+
+// Statuses lists every registered job.
+func (s *Service) Statuses() []JobStatus {
+	jobs := s.engine.Jobs()
+	statuses := make([]JobStatus, 0, len(jobs))
+	for _, job := range jobs {
+		status := JobStatus{Name: job.Name()}
+		if lastRun, err := job.LastRunStartedAt(); err == nil {
+			status.LastRunAt = lastRun
+		}
+		if nextRun, err := job.NextRun(); err == nil {
+			status.NextRunAt = nextRun
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses
+}

--- a/services/scheduler/scheduler.go
+++ b/services/scheduler/scheduler.go
@@ -22,6 +22,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -56,6 +57,9 @@ type Service struct {
 	engine gocron.Scheduler
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	stoppedMutex sync.Mutex
+	stopped      bool
 }
 
 // New constructs the scheduler.
@@ -77,6 +81,12 @@ func New() (*Service, error) {
 // Start; jobs registered after Start (but before Stop) are picked up
 // immediately. Names must be unique and intervals positive.
 func (s *Service) Register(job Job) error {
+	s.stoppedMutex.Lock()
+	stopped := s.stopped
+	s.stoppedMutex.Unlock()
+	if stopped {
+		return errors.New("scheduler is stopped and cannot register " + job.Name)
+	}
 	if job.Name == "" {
 		return errors.New("scheduler job needs a name")
 	}
@@ -130,8 +140,12 @@ func (s *Service) Start() {
 
 // Stop cancels the job context and shuts the engine down, waiting for
 // in-flight runs to finish. A stopped Service is permanently done: it
-// cannot be restarted, and Register calls after Stop are silent no-ops.
+// cannot be restarted, and Register calls after Stop return an error.
 func (s *Service) Stop() {
+	s.stoppedMutex.Lock()
+	s.stopped = true
+	s.stoppedMutex.Unlock()
+
 	s.cancel()
 	if err := s.engine.Shutdown(); err != nil {
 		log.Errorf("error shutting down scheduler: %v", err)

--- a/services/scheduler/scheduler_test.go
+++ b/services/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -269,6 +270,34 @@ func TestRegisterAfterStart(t *testing.T) {
 
 	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 2 },
 		"job registered after Start to run at least twice")
+}
+
+func TestRegisterAfterStopErrors(t *testing.T) {
+	s := newService(t)
+	s.Start()
+	s.Stop()
+
+	var runs atomic.Int32
+	err := s.Register(Job{
+		Name:       "toolate",
+		Interval:   20 * time.Millisecond,
+		RunAtStart: true,
+		Run:        func(ctx context.Context) { runs.Add(1) },
+	})
+	if err == nil {
+		t.Fatal("Register after Stop returned nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "toolate") {
+		t.Errorf("Register after Stop error %q does not mention the job name", err)
+	}
+
+	// The rejected job must never actually run. RunAtStart plus a tiny
+	// interval means any incorrect scheduling would fire well within
+	// this window.
+	time.Sleep(200 * time.Millisecond)
+	if got := runs.Load(); got != 0 {
+		t.Errorf("job registered after Stop ran %d time(s), want 0", got)
+	}
 }
 
 func TestStatuses(t *testing.T) {

--- a/services/scheduler/scheduler_test.go
+++ b/services/scheduler/scheduler_test.go
@@ -1,0 +1,322 @@
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond until it returns true or the timeout elapses. Timing
+// assertions in this file are eventually-style so the suite stays
+// deterministic under CI load: delays can only make a condition take
+// longer, never flip a passing assertion.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %v waiting for %s", timeout, msg)
+}
+
+func newService(t *testing.T) *Service {
+	t.Helper()
+	s, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	return s
+}
+
+func TestRegisterValidation(t *testing.T) {
+	noop := func(ctx context.Context) {}
+
+	cases := []struct {
+		name    string
+		job     Job
+		wantErr bool
+	}{
+		{"empty name", Job{Name: "", Interval: time.Second, Run: noop}, true},
+		{"zero interval", Job{Name: "zero", Interval: 0, Run: noop}, true},
+		{"negative interval", Job{Name: "negative", Interval: -time.Second, Run: noop}, true},
+		{"nil run", Job{Name: "nilrun", Interval: time.Second, Run: nil}, true},
+		{"valid job", Job{Name: "valid", Interval: time.Second, Run: noop}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newService(t)
+			err := s.Register(tc.job)
+			if tc.wantErr && err == nil {
+				t.Errorf("Register(%+v) returned nil error, want error", tc.job)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Register(%+v) returned error %v, want nil", tc.job, err)
+			}
+		})
+	}
+
+	t.Run("duplicate name", func(t *testing.T) {
+		s := newService(t)
+		if err := s.Register(Job{Name: "dupe", Interval: time.Second, Run: noop}); err != nil {
+			t.Fatalf("first Register returned error: %v", err)
+		}
+		if err := s.Register(Job{Name: "dupe", Interval: time.Minute, Run: noop}); err == nil {
+			t.Errorf("second Register with duplicate name returned nil error, want error")
+		}
+	})
+}
+
+func TestJobFiresRepeatedly(t *testing.T) {
+	s := newService(t)
+	var runs atomic.Int32
+	err := s.Register(Job{
+		Name:     "repeat",
+		Interval: 50 * time.Millisecond,
+		Run:      func(ctx context.Context) { runs.Add(1) },
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 2 },
+		"job to run at least twice")
+}
+
+func TestRunAtStartFiresImmediately(t *testing.T) {
+	s := newService(t)
+	var runs atomic.Int32
+	// Interval far beyond the poll deadline: the only way this job fires
+	// within the deadline is the immediate run-at-start execution.
+	err := s.Register(Job{
+		Name:       "immediate",
+		Interval:   time.Hour,
+		RunAtStart: true,
+		Run:        func(ctx context.Context) { runs.Add(1) },
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	waitFor(t, 2*time.Second, func() bool { return runs.Load() >= 1 },
+		"run-at-start job to fire without waiting an interval")
+}
+
+func TestNoRunAtStartWaitsAnInterval(t *testing.T) {
+	s := newService(t)
+	const interval = 600 * time.Millisecond
+	var firstRunElapsed atomic.Int64
+	start := time.Now()
+	err := s.Register(Job{
+		Name:     "patient",
+		Interval: interval,
+		Run: func(ctx context.Context) {
+			// Record only the first run's elapsed time.
+			firstRunElapsed.CompareAndSwap(0, int64(time.Since(start)))
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	waitFor(t, 3*time.Second, func() bool { return firstRunElapsed.Load() != 0 },
+		"job to fire once")
+
+	// The scheduler never fires early, so load delays cannot flip this:
+	// the elapsed time only grows. Margin below the interval absorbs
+	// timer granularity.
+	if elapsed := time.Duration(firstRunElapsed.Load()); elapsed < 500*time.Millisecond {
+		t.Errorf("job without RunAtStart fired after %v, want at least ~one interval (%v)", elapsed, interval)
+	}
+}
+
+func TestOverlapProtection(t *testing.T) {
+	s := newService(t)
+	var current, maxConcurrent, completed atomic.Int32
+	err := s.Register(Job{
+		Name:       "slow",
+		Interval:   50 * time.Millisecond,
+		RunAtStart: true,
+		Run: func(ctx context.Context) {
+			c := current.Add(1)
+			for {
+				m := maxConcurrent.Load()
+				if c <= m || maxConcurrent.CompareAndSwap(m, c) {
+					break
+				}
+			}
+			// Outlive the interval 3x so ticks arrive mid-run.
+			time.Sleep(150 * time.Millisecond)
+			current.Add(-1)
+			completed.Add(1)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	// Two completions prove later ticks still fire after a long run.
+	waitFor(t, 3*time.Second, func() bool { return completed.Load() >= 2 },
+		"slow job to complete at least twice")
+
+	if got := maxConcurrent.Load(); got != 1 {
+		t.Errorf("max concurrent executions = %d, want 1 (overlap protection)", got)
+	}
+}
+
+func TestPanicRecovery(t *testing.T) {
+	s := newService(t)
+	var panicRuns, siblingRuns atomic.Int32
+	err := s.Register(Job{
+		Name:     "panics",
+		Interval: 50 * time.Millisecond,
+		Run: func(ctx context.Context) {
+			panicRuns.Add(1)
+			panic("job blew up")
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	err = s.Register(Job{
+		Name:     "sibling",
+		Interval: 50 * time.Millisecond,
+		Run:      func(ctx context.Context) { siblingRuns.Add(1) },
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	// The panicking job keeps getting rescheduled and the sibling keeps
+	// firing: a panic never takes the scheduler down.
+	waitFor(t, 3*time.Second, func() bool {
+		return panicRuns.Load() >= 2 && siblingRuns.Load() >= 2
+	}, "both the panicking job and its sibling to run at least twice")
+}
+
+func TestStopCancelsContextAndWaitsForInflight(t *testing.T) {
+	s := newService(t)
+	started := make(chan struct{})
+	var ctxCancelled, returned atomic.Bool
+	err := s.Register(Job{
+		Name:       "longrunner",
+		Interval:   time.Hour,
+		RunAtStart: true,
+		Run: func(ctx context.Context) {
+			close(started)
+			select {
+			case <-ctx.Done():
+				ctxCancelled.Store(true)
+			case <-time.After(2 * time.Second):
+				// Escape hatch so a broken Stop fails the test instead
+				// of hanging it.
+			}
+			// Simulate in-flight work after cancellation; Stop must wait
+			// for this to finish before returning.
+			time.Sleep(100 * time.Millisecond)
+			returned.Store(true)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	s.Start()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job never started running")
+	}
+
+	s.Stop()
+
+	if !ctxCancelled.Load() {
+		t.Error("Stop did not cancel the context passed to Run")
+	}
+	if !returned.Load() {
+		t.Error("Stop returned before the in-flight run finished")
+	}
+}
+
+func TestRegisterAfterStart(t *testing.T) {
+	s := newService(t)
+	s.Start()
+	defer s.Stop()
+
+	var runs atomic.Int32
+	err := s.Register(Job{
+		Name:     "latecomer",
+		Interval: 50 * time.Millisecond,
+		Run:      func(ctx context.Context) { runs.Add(1) },
+	})
+	if err != nil {
+		t.Fatalf("Register after Start returned error: %v", err)
+	}
+
+	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 2 },
+		"job registered after Start to run at least twice")
+}
+
+func TestStatuses(t *testing.T) {
+	s := newService(t)
+	var runs atomic.Int32
+	err := s.Register(Job{
+		Name:       "worker",
+		Interval:   250 * time.Millisecond,
+		RunAtStart: true,
+		Run:        func(ctx context.Context) { runs.Add(1) },
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	err = s.Register(Job{
+		Name:     "idler",
+		Interval: time.Hour,
+		Run:      func(ctx context.Context) {},
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+
+	byName := func() map[string]JobStatus {
+		m := make(map[string]JobStatus)
+		for _, st := range s.Statuses() {
+			m[st.Name] = st
+		}
+		return m
+	}
+
+	statuses := byName()
+	if len(statuses) != 2 {
+		t.Fatalf("Statuses() returned %d entries before Start, want 2: %v", len(statuses), statuses)
+	}
+	for _, name := range []string{"worker", "idler"} {
+		if _, ok := statuses[name]; !ok {
+			t.Errorf("Statuses() missing job %q", name)
+		}
+	}
+
+	s.Start()
+	defer s.Stop()
+
+	waitFor(t, 3*time.Second, func() bool {
+		m := byName()
+		return !m["worker"].NextRunAt.IsZero() &&
+			!m["idler"].NextRunAt.IsZero() &&
+			!m["worker"].LastRunAt.IsZero()
+	}, "Statuses to report NextRunAt for started jobs and LastRunAt for a job that ran")
+}

--- a/services/stalefeaturedcheckservice/service.go
+++ b/services/stalefeaturedcheckservice/service.go
@@ -1,7 +1,11 @@
+// Package stalefeaturedcheckservice marks featured federated servers
+// offline when they stop sending status updates, keeping the
+// featured-streams directory honest. It runs as a job on the central
+// scheduler.
 package stalefeaturedcheckservice
 
 import (
-	"sync"
+	"context"
 	"time"
 
 	"github.com/owncast/owncast/persistence/configrepository"
@@ -18,121 +22,58 @@ const (
 	// it offline.
 	staleThreshold = 2*outbox.StreamPingInterval + time.Minute
 
-	// checkInterval is how often we check for stale servers. Kept well below
-	// staleThreshold so a server is marked offline promptly after it crosses
-	// the threshold rather than up to a full check cycle later.
-	checkInterval = 1 * time.Minute
+	// CheckInterval is how often Run should execute, registered on the
+	// central scheduler by main.go. Kept well below staleThreshold so a
+	// server is marked offline promptly after it crosses the threshold
+	// rather than up to a full check cycle later.
+	CheckInterval = 1 * time.Minute
 )
 
-// Checker periodically marks stale federated servers as offline.
-// Dependencies are injected so the logic is testable without globals.
-type Checker struct {
-	config  configrepository.ConfigRepository
-	servers federatedserversrepository.FederatedServersRepository
-	now     func() time.Time
-	// ticks returns a tick channel plus a func that releases its resources.
-	ticks func() (<-chan time.Time, func())
-
-	mu         sync.Mutex
-	done       chan bool
-	stopTicker func()
-	// stopped is closed when the background goroutine exits; used by tests to
-	// prove there is no goroutine leak.
-	stopped chan struct{}
+// Service sweeps featured federated servers for staleness. Construct with
+// New in main.go and register Run on the scheduler.
+type Service struct {
+	configRepository           configrepository.ConfigRepository
+	federatedServersRepository federatedserversrepository.FederatedServersRepository
 }
 
-// New returns a Checker using the given dependencies. A nil now defaults to
-// time.Now; a nil ticks defaults to a real time.Ticker at checkInterval.
-func New(
-	config configrepository.ConfigRepository,
-	servers federatedserversrepository.FederatedServersRepository,
-	now func() time.Time,
-	ticks func() (<-chan time.Time, func()),
-) *Checker {
-	if now == nil {
-		now = time.Now
-	}
-	if ticks == nil {
-		ticks = func() (<-chan time.Time, func()) {
-			t := time.NewTicker(checkInterval)
-			return t.C, t.Stop
-		}
-	}
-	return &Checker{config: config, servers: servers, now: now, ticks: ticks}
+// Deps lists everything the service consumes.
+type Deps struct {
+	ConfigRepository           configrepository.ConfigRepository
+	FederatedServersRepository federatedserversrepository.FederatedServersRepository
 }
 
-// Start begins checking for stale federated servers in the background.
-func (c *Checker) Start() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// New constructs the stale featured server checker.
+func New(deps Deps) *Service {
+	return &Service{
+		configRepository:           deps.ConfigRepository,
+		federatedServersRepository: deps.FederatedServersRepository,
+	}
+}
 
-	if !c.config.GetFederationEnabled() {
+// Run is the scheduler job body. It no-ops while federation is disabled,
+// which also means enabling federation at runtime starts sweeping on the
+// next tick instead of requiring a restart like the old self-gating ticker
+// did.
+func (s *Service) Run(ctx context.Context) {
+	if !s.configRepository.GetFederationEnabled() {
 		return
 	}
 
-	// Don't start if already running
-	if c.done != nil {
-		log.Debugln("Stale featured server checker already running")
-		return
-	}
-
-	tickCh, stopTicker := c.ticks()
-	c.stopTicker = stopTicker
-	c.done = make(chan bool)
-	c.stopped = make(chan struct{})
-
-	// Capture in locals so a later Start/Stop cycle can't race this goroutine.
-	done := c.done
-	stopped := c.stopped
-
-	go func() {
-		defer close(stopped)
-
-		// Run immediately on start
-		c.check()
-
-		for {
-			select {
-			case <-tickCh:
-				c.check()
-			case <-done:
-				return
-			}
-		}
-	}()
-
-	log.Infof("Started stale featured server checker (%s interval, %s offline threshold)", checkInterval, staleThreshold)
-}
-
-// Stop halts the stale server checker if it is running.
-func (c *Checker) Stop() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.done == nil {
-		return
-	}
-
-	c.stopTicker()
-	close(c.done)
-	c.done = nil
-	c.stopTicker = nil
-	log.Infoln("Stopped stale featured server checker")
-}
-
-// check inspects all online federated servers and marks them as offline
-// if they haven't sent a status update within the stale threshold.
-func (c *Checker) check() {
-	servers, err := c.servers.GetFederatedServers()
+	servers, err := s.federatedServersRepository.GetFederatedServers()
 	if err != nil {
 		log.Errorf("Failed to get federated servers for staleness check: %v", err)
 		return
 	}
 
-	now := c.now()
+	now := time.Now()
 	markedOfflineCount := 0
 
 	for _, server := range servers {
+		// Shutdown cancels the context; stop sweeping promptly.
+		if ctx.Err() != nil {
+			return
+		}
+
 		// Only check servers that are currently marked as online
 		if !server.IsOnline {
 			continue
@@ -149,7 +90,7 @@ func (c *Checker) check() {
 			log.Infof("Marking federated server %s as offline due to staleness (%v since last update)",
 				server.IRI, timeSinceLastUpdate)
 
-			err := c.servers.UpdateServerStatus(server.IRI, false, nil)
+			err := s.federatedServersRepository.UpdateServerStatus(server.IRI, false, nil)
 			if err != nil {
 				log.Errorf("Failed to mark server %s as offline: %v", server.IRI, err)
 			} else {
@@ -160,31 +101,5 @@ func (c *Checker) check() {
 
 	if markedOfflineCount > 0 {
 		log.Infof("Marked %d federated server(s) as offline due to staleness", markedOfflineCount)
-	}
-}
-
-var (
-	defaultMu      sync.Mutex
-	defaultChecker *Checker
-)
-
-// Start begins the default background checker using the global repositories.
-func Start() {
-	defaultMu.Lock()
-	defer defaultMu.Unlock()
-
-	if defaultChecker == nil {
-		defaultChecker = New(configrepository.Get(), federatedserversrepository.Get(), nil, nil)
-	}
-	defaultChecker.Start()
-}
-
-// Stop halts the default background checker if it is running.
-func Stop() {
-	defaultMu.Lock()
-	defer defaultMu.Unlock()
-
-	if defaultChecker != nil {
-		defaultChecker.Stop()
 	}
 }

--- a/services/stalefeaturedcheckservice/service_test.go
+++ b/services/stalefeaturedcheckservice/service_test.go
@@ -1,6 +1,7 @@
 package stalefeaturedcheckservice
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -65,7 +66,7 @@ func (f *fakeServersRepo) marked() []string {
 }
 
 func TestCheckMarksOnlyStaleServers(t *testing.T) {
-	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	now := time.Now()
 
 	tests := []struct {
 		name       string
@@ -74,7 +75,7 @@ func TestCheckMarksOnlyStaleServers(t *testing.T) {
 		wantMarked bool
 	}{
 		{"stale online server is marked offline", true, new(now.Add(-staleThreshold - time.Hour)), true},
-		{"exactly at threshold is not stale", true, new(now.Add(-staleThreshold)), false},
+		{"inside threshold is not stale", true, new(now.Add(-staleThreshold + time.Second)), false},
 		{"one nanosecond past threshold is stale", true, new(now.Add(-staleThreshold - time.Nanosecond)), true},
 		{"fresh online server is untouched", true, new(now.Add(-time.Second)), false},
 		{"offline server is untouched even if stale", false, new(now.Add(-staleThreshold - time.Hour)), false},
@@ -86,9 +87,9 @@ func TestCheckMarksOnlyStaleServers(t *testing.T) {
 			repo := &fakeServersRepo{servers: []models.FederatedServer{
 				{IRI: "https://example.com/actor", IsOnline: tt.isOnline, LastStatusUpdate: tt.lastUpdate},
 			}}
-			c := New(&fakeConfigRepo{federationEnabled: true}, repo, func() time.Time { return now }, nil)
+			c := New(Deps{ConfigRepository: &fakeConfigRepo{federationEnabled: true}, FederatedServersRepository: repo})
 
-			c.check()
+			c.Run(context.Background())
 
 			marked := repo.marked()
 			if tt.wantMarked && len(marked) != 1 {
@@ -103,9 +104,9 @@ func TestCheckMarksOnlyStaleServers(t *testing.T) {
 
 func TestCheckGetErrorMarksNothing(t *testing.T) {
 	repo := &fakeServersRepo{getErr: errors.New("db closed")}
-	c := New(&fakeConfigRepo{federationEnabled: true}, repo, time.Now, nil)
+	c := New(Deps{ConfigRepository: &fakeConfigRepo{federationEnabled: true}, FederatedServersRepository: repo})
 
-	c.check()
+	c.Run(context.Background())
 
 	if marked := repo.marked(); len(marked) != 0 {
 		t.Fatalf("expected no updates after fetch error, marked = %v", marked)
@@ -121,67 +122,8 @@ func TestCheckUpdateErrorDoesNotPanic(t *testing.T) {
 			{IRI: "https://b.example.com", IsOnline: true, LastStatusUpdate: &stale},
 		},
 	}
-	c := New(&fakeConfigRepo{federationEnabled: true}, repo, time.Now, nil)
+	c := New(Deps{ConfigRepository: &fakeConfigRepo{federationEnabled: true}, FederatedServersRepository: repo})
 
 	// Must attempt both servers and not panic on per-server failure.
-	c.check()
-}
-
-func TestStartWithFederationDisabledDoesNothing(t *testing.T) {
-	repo := &fakeServersRepo{}
-	ticksCalled := false
-	c := New(&fakeConfigRepo{federationEnabled: false}, repo, time.Now, func() (<-chan time.Time, func()) {
-		ticksCalled = true
-		return make(chan time.Time), func() {}
-	})
-
-	c.Start()
-
-	if ticksCalled {
-		t.Fatal("Start must not create a ticker when federation is disabled")
-	}
-	if c.done != nil {
-		t.Fatal("Start must not begin the background loop when federation is disabled")
-	}
-	c.Stop() // Stop on a never-started checker must be a no-op.
-}
-
-func TestStartStopLifecycle(t *testing.T) {
-	tickCh := make(chan time.Time)
-	tickerStops := 0
-	repo := &fakeServersRepo{getCalls: make(chan struct{}, 16)}
-	c := New(&fakeConfigRepo{federationEnabled: true}, repo, time.Now, func() (<-chan time.Time, func()) {
-		tickerStops++
-		return tickCh, func() {}
-	})
-
-	c.Start()
-	<-repo.getCalls // immediate check on start
-
-	firstDone := c.done
-	c.Start() // second Start is a no-op, not a second goroutine
-	if c.done != firstDone {
-		t.Fatal("double Start must not restart the checker")
-	}
-	if tickerStops != 1 {
-		t.Fatalf("double Start created %d tickers, want 1", tickerStops)
-	}
-
-	tickCh <- time.Now()
-	<-repo.getCalls // tick-driven check
-
-	stopped := c.stopped
-	c.Stop()
-	<-stopped // goroutine exited: no leak
-	if c.done != nil {
-		t.Fatal("Stop must clear running state")
-	}
-	c.Stop() // idempotent
-
-	// Restart works after Stop.
-	c.Start()
-	<-repo.getCalls
-	stopped = c.stopped
-	c.Stop()
-	<-stopped
+	c.Run(context.Background())
 }


### PR DESCRIPTION
This adds a central scheduler service for recurring background work, so periodic internal tasks stop hand-rolling their own tickers, goroutines and shutdown channels. It's independent infrastructure and based directly on develop, so it can land regardless of the scheduled streams work. Once both are in, the scheduled streams materializer moves onto it as a small follow-up.

The engine is gocron v2, which is actively maintained and widely used, wrapped in a small `services/scheduler` facade so the rest of the codebase depends on one Owncast-shaped API instead of a third-party surface. Every registered job gets the same conventions for free:

- Overlap protection. A run that outlives its interval causes following ticks to be skipped, never stacked or run concurrently.
- Panic recovery. A panicking run is logged and the job runs again next tick, it can't take the process down.
- Cooperative shutdown. Jobs receive a context cancelled at Stop, and Stop waits for in-flight runs to finish.
- A name in the logs and a Statuses listing for a future admin or debug surface.

Adding a new job is a service method plus one registration line in main.go. Jobs are expected to be idempotent sweeps that read their own state, the same contract the old tickers had.

Two tickers migrate in this PR to prove the shape:

- The stale featured servers check. This one also moves off the deprecated package-global pattern to constructor injection (removing two persistence Get() callers), and its federation-enabled gate moves inside the job body, which fixes a small pre-existing quirk: enabling federation at runtime used to leave the checker dead until a restart.
- The chat message pruner.

Good follow-up candidates once this lands: the scheduled streams materializer (#5008), the hourly DB backup, stream stats saving, the expired auth request pruners, follower validation and the metrics polling loops. Lifecycle-bound loops (thumbnail generation, the live outbox ping, websocket keepalives) deliberately stay where they are, they're not periodic app maintenance.

The facade contract is pinned by unit tests covering registration validation, repeated firing, run-at-start, overlap protection, panic recovery, shutdown semantics and late registration.

```
go test ./services/scheduler/ ./services/chat/
ok  	github.com/owncast/owncast/services/scheduler	1.337s
ok  	github.com/owncast/owncast/services/chat	0.111s
```

Boot verified with both jobs registered and running.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
