### PR TITLE
Upgrade xstate to v5

### DIFF
--- a/web/components/stores/ClientConfigStore.tsx
+++ b/web/components/stores/ClientConfigStore.tsx
@@ -12,6 +12,7 @@ import appStateModel, {
   AppStateEvent,
   AppStateOptions,
   makeEmptyAppState,
+  metaForSnapshot,
 } from './application-state';
 import { setLocalStorage, getLocalStorage } from '../../utils/localStorage';
 import {
@@ -22,7 +23,6 @@ import {
   MessageVisibilityEvent,
   SocketEvent,
 } from '../../interfaces/socket-events';
-import { mergeMeta } from '../../utils/helpers';
 import { handleConnectedClientInfoMessage } from './eventhandlers/connected-client-info-handler';
 import { ServerStatusServiceContext } from '../../services/status-service';
 import { handleNameChangeEvent } from './eventhandlers/handleNameChangeEvent';
@@ -186,8 +186,8 @@ export const ClientConfigStore: FC = () => {
     });
   };
   const sendEvent = (events: string[]) => {
-    // console.debug('---- sending event:', event);
-    appStateSend(events);
+    // xstate v5 sends single event objects, so fan out the batch.
+    events.forEach(event => appStateSend({ type: event }));
   };
 
   const handleStatusChange = (status: ServerStatus) => {
@@ -204,7 +204,7 @@ export const ClientConfigStore: FC = () => {
 
     if (status.online && appState.matches('ready')) {
       sendEvent([AppStateEvent.Online]);
-    } else if (!status.online && !appState.matches('ready.offline')) {
+    } else if (!status.online && !appState.matches({ ready: 'offline' })) {
       sendEvent([AppStateEvent.Offline]);
     }
   };
@@ -453,14 +453,17 @@ export const ClientConfigStore: FC = () => {
   }, [accessToken]);
 
   useEffect(() => {
-    appStateService.onTransition(state => {
-      const metadata = mergeMeta(state.meta) as AppStateOptions;
-
-      // console.debug('--- APP STATE: ', state.value);
-      // console.debug('--- APP META: ', metadata);
-
-      setAppState(metadata);
-    });
+    const applySnapshot = state => {
+      setAppState(metaForSnapshot(state));
+    };
+    const subscription = appStateService.subscribe(applySnapshot);
+    // Sync the current snapshot too: the hydration effect above runs first
+    // and can transition the machine (e.g. straight to online) before this
+    // subscription attaches. xstate v4's onTransition also fired on every
+    // event, transition or not, which papered over that ordering; v5's
+    // subscribe only fires on real transitions.
+    applySnapshot(appStateService.getSnapshot());
+    return () => subscription.unsubscribe();
   }, []);
 
   return null;

--- a/web/components/stores/application-state.ts
+++ b/web/components/stores/application-state.ts
@@ -10,7 +10,7 @@ map or install the VS Code plugin:
 https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode
 */
 
-import { createMachine } from 'xstate';
+import { createMachine, type AnyMachineSnapshot } from 'xstate';
 
 export interface AppStateOptions {
   chatAvailable: boolean;
@@ -70,8 +70,11 @@ const appStateModel =
   /** @xstate-layout N4IgpgJg5mDOIC5QEMAOqDKAXZWwDoAbAe2QgEsA7KAYgCUBRAcQEkMAVBxgEUVFWKxyWcsUp8QAD0QBGAGwz8ABgCscpUoDsAZgAcKgEwrtATgA0IAJ6zNS-CZMLtcuQBY9Jg5t0BfHxbRMHDwiUgpqGgA5BgZuDAB9RlYOLgkBIRExCWkEGRVFVXUtPUNjcytEAxNXfB0DbSNNORMG119-EEDsXAISMipaABkAeQBBbli0wWFRcSQpWQVlNQ0dfSNTC2tc+vwZVwMZWxNbA5kDAz8A9G6QvvDaADFRlkGpjNns2VcCleL1spbRDaA74FS6ORVfYHTSObRXTo3YIEABOYCg5FgeBRA3ozDYnB47xmWXmOQOKj22hUnl02iajjk2iBCCqdgO2n2VRcbQhCK6yPwaIxWLAOIiz1exMyc1A5KMVJpBjpDJczIqCG0enwXk0MiUENMjiUBjk-KRPSFYDIlnwYkIVDANGGj0egxY0WlnzJiF0TXwulU9LqWhMMl0LIM7ipmguIIObU85qClrRNrtADMMw7KE7hpF3Z75ukSbKFgg5Pp7PSQdTXBp9uVtlHtDG464E7okx0BanrRBbVBiMQIAAjSxOyRYy3IDPYgAU2g0y4AlDReyE0wP8EOR+OwF7SXLff7A8ZNCHYeGWedW3qlDIWkz61rLgjKCO4BIN70wgND2W8o3pyyjKrCdZ6q4sYqMmtyouimLYv+xbTDKXyakuyiuHI+QmCoJquCo2FyCyS52PURzqI+mgqIYpqwYKW62vajoAehsJyFS+paPhfoRhqUa6PgTIuLoRznComiEWaPYWpu-bMVmOYHihHxHuWRQ6pCJz0sqGgNMBBjCfohiEUoIJ0kyDF9umu5jhObE+rkqh2BCLS8XhYa6K4wGUuGtEviYZ5qNZ8k2o5x4IJJnGmlUOixoG5kGCy+G1JyXgHGJJhKByrihQQsBigAbmKjzIOQhAAK5ohF5YXJx+q2MYbieFB4KkW0yj6NBfr6vU3n5fglWFSiGblVVNWqaW6H5HY4bNFJbhKI4HV3k0rgnNlS6xm+1wpngtU5NeGoALQXDqbVBct+g5Qofh+EAA */
   createMachine({
     id: 'appState',
+    types: {} as {
+      events: { type: string };
+      meta: AppStateOptions;
+    },
     initial: 'loading',
-    predictableActionArguments: true,
     states: {
       loading: {
         meta: LOADING_STATE,
@@ -139,10 +142,22 @@ const appStateModel =
       serverFailure: {
         type: 'final',
       },
-      userfailure: {
-        type: 'final',
-      },
     },
   });
+
+// The runtime surface of a machine snapshot that the app consumes. xstate's
+// own declared getMeta() type recurses infinitely (TS2589 at every consumer,
+// even through AnyMachineSnapshot), so the usable contract is named once
+// here instead.
+interface MetaCarryingSnapshot {
+  getMeta(): Record<string, AppStateOptions>;
+}
+
+// Flattens a snapshot's per-state meta into the single AppStateOptions the
+// app consumes (nested states contribute one meta entry per active node).
+export function metaForSnapshot(snapshot: AnyMachineSnapshot): AppStateOptions {
+  const metaSnapshot = snapshot as unknown as MetaCarryingSnapshot;
+  return Object.assign({}, ...Object.values(metaSnapshot.getMeta()));
+}
 
 export default appStateModel;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,7 @@
         "@testing-library/react": "^16.3.0",
         "@uiw/codemirror-theme-bbedit": "4.25.10",
         "@uiw/react-codemirror": "4.25.10",
-        "@xstate/react": "3.2.2",
+        "@xstate/react": "^6.1.0",
         "antd": "6.5.0",
         "autoprefixer": "^10.4.14",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -56,7 +56,7 @@
         "sharp": "0.34.5",
         "ua-parser-js": "1.0.41",
         "video.js": "^8.3.0",
-        "xstate": "4.38.3",
+        "xstate": "^5.32.4",
         "yaml": "2.9.0"
       },
       "devDependencies": {
@@ -3835,9 +3835,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3853,9 +3850,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3873,9 +3867,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3892,9 +3883,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3910,9 +3898,6 @@
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3944,9 +3929,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3977,9 +3959,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4001,9 +3980,6 @@
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4027,9 +4003,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4052,9 +4025,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4076,9 +4046,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4121,9 +4088,6 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5753,9 +5717,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5771,9 +5732,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6030,9 +5988,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6050,9 +6005,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6070,9 +6022,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6090,9 +6039,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6110,9 +6056,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6130,9 +6073,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6373,9 +6313,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6390,9 +6327,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6407,9 +6341,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6424,9 +6355,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6441,9 +6369,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6458,9 +6383,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6696,9 +6618,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6718,9 +6637,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6742,9 +6658,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6764,9 +6677,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7892,9 +7802,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7909,9 +7816,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7926,9 +7830,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7943,9 +7844,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7960,9 +7858,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7977,9 +7872,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7994,9 +7886,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8011,9 +7900,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8028,9 +7914,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8045,9 +7928,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8062,9 +7942,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10188,9 +10065,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10205,9 +10079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10222,9 +10093,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10239,9 +10107,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10256,9 +10121,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10273,9 +10135,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10290,9 +10149,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10307,9 +10163,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10683,21 +10536,19 @@
       }
     },
     "node_modules/@xstate/react": {
-      "version": "3.2.2",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.1.0.tgz",
+      "integrity": "sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==",
       "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.2",
-        "use-sync-external-store": "^1.0.0"
+        "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
-        "@xstate/fsm": "^2.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "xstate": "^4.37.2"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "xstate": "^5.28.0"
       },
       "peerDependenciesMeta": {
-        "@xstate/fsm": {
-          "optional": true
-        },
         "xstate": {
           "optional": true
         }
@@ -30847,7 +30698,9 @@
       "license": "MIT"
     },
     "node_modules/xstate": {
-      "version": "4.38.3",
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.32.4.tgz",
+      "integrity": "sha512-E5WtDB8DBs2ZWliz2Ry9XfbSZTbBRcK/cwefBot04qQ/L5SLP16xpnTDU4/ZFXuXFhNxi7JP2RhuoGwBnM+S4A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,7 @@
     "@testing-library/react": "^16.3.0",
     "@uiw/codemirror-theme-bbedit": "4.25.10",
     "@uiw/react-codemirror": "4.25.10",
-    "@xstate/react": "3.2.2",
+    "@xstate/react": "^6.1.0",
     "antd": "6.5.0",
     "autoprefixer": "^10.4.14",
     "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -75,7 +75,7 @@
     "sharp": "0.34.5",
     "ua-parser-js": "1.0.41",
     "video.js": "^8.3.0",
-    "xstate": "4.38.3",
+    "xstate": "^5.32.4",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/web/tests/applicationState.test.ts
+++ b/web/tests/applicationState.test.ts
@@ -1,0 +1,186 @@
+/*
+ Pins the externally observable contract of the application state machine
+ (components/stores/application-state.ts) after the xstate v4 -> v5 port, so a
+ future refactor (or replacement of xstate entirely) can prove parity against
+ this suite.
+
+ Meta is asserted through metaForSnapshot(), the same function the app
+ consumes it with (it flattens Object.values(snapshot.getMeta()) into one
+ object).
+*/
+
+import { createActor, SimulatedClock, type AnyActorRef } from 'xstate';
+import appStateModel, {
+  AppStateEvent,
+  metaForSnapshot,
+} from '../components/stores/application-state';
+
+const mergedMeta = metaForSnapshot;
+
+// Expected merged meta per state, spelled out as field values (the meta
+// constants for loading/goodbye are not exported from the module).
+const LOADING_META = {
+  chatAvailable: false,
+  chatLoading: false,
+  videoAvailable: false,
+  appLoading: true,
+};
+const OFFLINE_META = {
+  chatAvailable: false,
+  chatLoading: false,
+  videoAvailable: false,
+  appLoading: false,
+};
+const ONLINE_META = {
+  chatAvailable: true,
+  chatLoading: false,
+  videoAvailable: true,
+  appLoading: false,
+};
+const GOODBYE_META = {
+  chatAvailable: true,
+  chatLoading: false,
+  videoAvailable: false,
+  appLoading: false,
+};
+const CHAT_USER_DISABLED_META = { ...ONLINE_META, chatAvailable: false };
+
+const GOODBYE_TIMEOUT_MS = 300000;
+
+const actors: AnyActorRef[] = [];
+const startActor = (clock?: SimulatedClock) => {
+  const actor = createActor(appStateModel, clock ? { clock } : undefined);
+  actors.push(actor);
+  actor.start();
+  return actor;
+};
+
+afterEach(() => {
+  // Stop every actor so a goodbye-state 'after' timer never outlives a test.
+  actors.forEach(actor => actor.stop());
+  actors.length = 0;
+});
+
+describe('application state machine', () => {
+  test('starts in loading with the loading meta', () => {
+    const actor = startActor();
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('loading');
+    expect(snapshot.matches('loading')).toBe(true);
+    expect(snapshot.status).toBe('active');
+    expect(mergedMeta(snapshot)).toEqual(LOADING_META);
+  });
+
+  test('NEEDS_REGISTER while loading stays in loading', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.NeedsRegister });
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('loading');
+    expect(mergedMeta(snapshot)).toEqual(LOADING_META);
+  });
+
+  test('LOADED moves to ready.offline with the offline meta, and both matches() forms agree', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.Loaded });
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toEqual({ ready: 'offline' });
+    expect(snapshot.matches('ready')).toBe(true);
+    expect(snapshot.matches({ ready: 'offline' })).toBe(true);
+    expect(snapshot.matches('loading')).toBe(false);
+    expect(mergedMeta(snapshot)).toEqual(OFFLINE_META);
+  });
+
+  test('full online walk: offline -> online -> goodbye -> back online', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.Loaded });
+
+    actor.send({ type: AppStateEvent.Online });
+    let snapshot = actor.getSnapshot();
+    expect(snapshot.matches({ ready: 'online' })).toBe(true);
+    expect(mergedMeta(snapshot)).toEqual(ONLINE_META);
+
+    actor.send({ type: AppStateEvent.Offline });
+    snapshot = actor.getSnapshot();
+    expect(snapshot.matches({ ready: 'goodbye' })).toBe(true);
+    expect(snapshot.matches('ready')).toBe(true);
+    expect(mergedMeta(snapshot)).toEqual(GOODBYE_META);
+
+    actor.send({ type: AppStateEvent.Online });
+    snapshot = actor.getSnapshot();
+    expect(snapshot.matches({ ready: 'online' })).toBe(true);
+    expect(mergedMeta(snapshot)).toEqual(ONLINE_META);
+  });
+
+  test('CHAT_USER_DISABLED while online keeps the online meta except chatAvailable', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.Loaded });
+    actor.send({ type: AppStateEvent.Online });
+    actor.send({ type: AppStateEvent.ChatUserDisabled });
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.matches({ ready: 'chatUserDisabled' })).toBe(true);
+    expect(mergedMeta(snapshot)).toEqual(CHAT_USER_DISABLED_META);
+  });
+
+  test('FAIL while loading reaches serverFailure and the machine is done', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.Fail });
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.matches('serverFailure')).toBe(true);
+    expect(snapshot.status).toBe('done');
+  });
+
+  test('ONLINE while loading is ignored without error', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.Online });
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.value).toBe('loading');
+    expect(snapshot.status).toBe('active');
+    expect(mergedMeta(snapshot)).toEqual(LOADING_META);
+  });
+
+  test('OFFLINE while ready.offline is ignored without error', () => {
+    const actor = startActor();
+    actor.send({ type: AppStateEvent.Loaded });
+    actor.send({ type: AppStateEvent.Offline });
+    const snapshot = actor.getSnapshot();
+
+    expect(snapshot.matches({ ready: 'offline' })).toBe(true);
+    expect(snapshot.status).toBe('active');
+    expect(mergedMeta(snapshot)).toEqual(OFFLINE_META);
+  });
+
+  test('goodbye falls back to offline after exactly 300000ms', () => {
+    const clock = new SimulatedClock();
+    const actor = startActor(clock);
+    actor.send({ type: AppStateEvent.Loaded });
+    actor.send({ type: AppStateEvent.Online });
+    actor.send({ type: AppStateEvent.Offline });
+    expect(actor.getSnapshot().matches({ ready: 'goodbye' })).toBe(true);
+
+    clock.increment(GOODBYE_TIMEOUT_MS - 1);
+    expect(actor.getSnapshot().matches({ ready: 'goodbye' })).toBe(true);
+
+    clock.increment(1);
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.matches({ ready: 'offline' })).toBe(true);
+    expect(mergedMeta(snapshot)).toEqual(OFFLINE_META);
+  });
+
+  test('leaving goodbye via ONLINE cancels the delayed fallback', () => {
+    const clock = new SimulatedClock();
+    const actor = startActor(clock);
+    actor.send({ type: AppStateEvent.Loaded });
+    actor.send({ type: AppStateEvent.Online });
+    actor.send({ type: AppStateEvent.Offline });
+    actor.send({ type: AppStateEvent.Online });
+
+    clock.increment(GOODBYE_TIMEOUT_MS * 2);
+    expect(actor.getSnapshot().matches({ ready: 'online' })).toBe(true);
+  });
+});

--- a/web/utils/helpers.js
+++ b/web/utils/helpers.js
@@ -5,17 +5,6 @@ export function getDiffInDaysFromNow(timestamp) {
   return (new Date() - time) / (24 * 3600 * 1000);
 }
 
-// Take a nested object of state metadata and merge it into
-// a single flattened node.
-export function mergeMeta(meta) {
-  return Object.keys(meta).reduce((acc, key) => {
-    const value = meta[key];
-    Object.assign(acc, value);
-
-    return acc;
-  }, {});
-}
-
 export const isMobileSafariIos = () => {
   try {
     const ua = navigator.userAgent;
@@ -32,7 +21,7 @@ export const isMobileSafariIos = () => {
     }
 
     return browser.name === 'Mobile Safari' || browser.name === 'Safari';
-  } catch (e) {
+  } catch {
     return false;
   }
 };


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

---

This upgrades xstate from 4.38 to 5.32 and @xstate/react from 3.2 to 6.1. @xstate/react 3.x was the last dependency with a React 18 peer cap, so after this the React 19 upgrade is just the version bump.

We have exactly one state machine, the app state model in ClientConfigStore, so the port is small:

- The machine config is nearly unchanged. predictableActionArguments doesn't exist in v5, and I removed the userfailure final state that has been unreachable since the v4 days (nothing ever targeted it).
- Event arrays can't be sent in v5, so sendEvent fans the batch out as single event objects.
- onTransition becomes an actor subscription, and the nested offline check uses the object form of matches.
- getMeta()'s declared type in v5 recurses infinitely and breaks type checking at every consumer, so the meta merge now lives next to the machine behind a small named snapshot interface. The old generic mergeMeta helper is gone with it.

One real behavioral catch: v4's onTransition fired on every event, even ignored ones, while v5's subscribe only fires on actual transitions. A page loaded while the stream is already live transitions to online from the hydration effect before the subscription attaches, and with v5 semantics nothing ever re-delivered the state, so chat never became available. The browser test suite caught it on the fediverse specs. The subscription now also applies the current snapshot when it attaches.

There's a new ten test parity suite for the machine using xstate's simulated clock, covering every transition, the ignored event cases, the goodbye timeout at its exact 300000ms boundary, and that leaving goodbye cancels the delayed fallback. If we ever want to replace xstate with something smaller, that suite is the contract to prove parity against.

## Testing

- The full browser test suite passes locally, all groups, after the fix described above.
- jest passes (288 tests including the new machine suite), tsc is clean, storybook builds.
- Walked the machine live against a local instance: page load while offline, stream start flipping the open page to online, playback, stream stop into the goodbye state. Also the failure case, loading the page with the stream already live, which now correctly shows chat and the user menu.

## Notes

Stacked on #5013. No screenshots since nothing visual changes, the live walk above and the parity suite are the demonstration.