### PR TITLE
Update security reporting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 	·
 	<a href="https://github.com/owncast/owncast/issues">Report Bug</a>
 	·
-	<a href="https://owncast.online/security">Report Security Issue</a>
+	<a href="docs/SECURITY.md">Report Security Issue</a>
 </p>
 
 <!-- TABLE OF CONTENTS -->
@@ -151,7 +151,7 @@ Thank you to all our donors who help keep Owncast running by donating on OpenCol
 
 Report suspected security vulnerabilities privately to [security@owncast.online](mailto:security@owncast.online). Do not open a public GitHub issue.
 
-See the repository [security policy](docs/SECURITY.md) and the [Owncast security page](https://owncast.online/security) for scope, disclosure, and credit details.
+See the repository [security policy](docs/SECURITY.md) for scope, disclosure, and credit details.
 
 <!-- LICENSE -->
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 	<a href="https://owncast.online/faq/">FAQ</a>
 	·
 	<a href="https://github.com/owncast/owncast/issues">Report Bug</a>
+	·
+	<a href="https://owncast.online/security">Report Security Issue</a>
 </p>
 
 <!-- TABLE OF CONTENTS -->
@@ -41,6 +43,7 @@
   - ⚛️ [Frontend](#frontend)
 - 👏 [Contributing](#contributing)
   - 💵 [Donors](#donors)
+- [Security](#security)
 - 📝 [License](#license)
 - [Contact](#contact)
 
@@ -141,7 +144,15 @@ Thank you to all our donors who help keep Owncast running by donating on OpenCol
 		<img alt="GitHub issues by-label" src="https://opencollective.com/owncast/tiers/backers.svg?avatarHeight=36&width=600" alt="Backer button">
 	</a>
 </div>
-	
+
+<!-- SECURITY -->
+
+## Security
+
+Report suspected security vulnerabilities privately to [security@owncast.online](mailto:security@owncast.online). Do not open a public GitHub issue.
+
+See the repository [security policy](docs/SECURITY.md) and the [Owncast security page](https://owncast.online/security) for scope, disclosure, and credit details.
+
 <!-- LICENSE -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Thank you to all our donors who help keep Owncast running by donating on OpenCol
 
 ## Security
 
-Report suspected security vulnerabilities privately to [security@owncast.online](mailto:security@owncast.online). Do not open a public GitHub issue.
+Report suspected security vulnerabilities privately to [security@owncast.online](mailto:security@owncast.online). This is the security-reporting address. The personal contact information in the Support section is for general contact, not vulnerability reports.
 
 See the repository [security policy](docs/SECURITY.md) for scope, disclosure, and credit details.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,13 +6,17 @@ Owncast appreciates good-faith efforts to improve the security of the project.
 
 The latest stable Owncast release is the supported version. Reports that affect the current `develop` branch are also welcome. Previous releases are not supported, so Owncast operators should stay up to date.
 
+## Scope
+
+Reports are in scope when they affect the latest stable Owncast release, the current `develop` branch, an Owncast-operated service under `owncast.online`, or a third-party dependency that can be exploited through Owncast.
+
+Expected actions by an authorized server administrator, issues already fixed in the latest release, self-XSS, automated scanner output without reproducible security impact, social engineering, and third-party vulnerabilities that cannot be exploited through Owncast are out of scope.
+
 ## Reporting a vulnerability
 
 Report suspected security vulnerabilities privately to [security@owncast.online](mailto:security@owncast.online). Do not open a public GitHub issue or discussion.
 
 Include the affected Owncast version or commit, steps to reproduce the issue, its potential impact, and any proof of concept that helps explain the report.
-
-The [Owncast security page](https://owncast.online/security) documents what is in scope, what is out of scope, and how reports receive public credit.
 
 ## Disclosure and credit
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,19 +1,23 @@
-# Security Policy
+# Security policy
 
-Owncast appreciates efforts to improve the security of the software
-and follow the [GitHub coordinated disclosure of security vulnerabilities](https://docs.github.com/en/code-security/security-advisories/about-coordinated-disclosure-of-security-vulnerabilities#about-reporting-and-disclosing-vulnerabilities-in-projects-on-github)
-for responsible disclosure and prompt mitigation.
+Owncast appreciates good-faith efforts to improve the security of the project.
 
-## Supported Versions
+## Supported versions
 
-The latest version of Owncast is seen as the supported version. As a small project we are unable to support previous versions and urge users of the software to stay up to date.
+The latest stable Owncast release is the supported version. Reports that affect the current `develop` branch are also welcome. Previous releases are not supported, so Owncast operators should stay up to date.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-To report a security issue with Owncast, [open an issue](https://github.com/owncast/owncast/issues/new
-) on the Owncast GitHub repository and *do not* mention vulnerability details in the issue. If you have a preferred next step on where to discuss the details of the disclosure, please mention that in the issue if it's appropriate for those details to be public.
+Report suspected security vulnerabilities privately to [security@owncast.online](mailto:security@owncast.online). Do not open a public GitHub issue or discussion.
 
-You may optionally [email Gabe](mailto:gabek@real-ity.com) to alert him directly and provide specifics on how you wish to disclose the details of the issue.
+Include the affected Owncast version or commit, steps to reproduce the issue, its potential impact, and any proof of concept that helps explain the report.
 
-Owncast may open a draft [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/creating-a-security-advisory)
-  to discuss the vulnerability details in private if it is warranted.
+The [Owncast security page](https://owncast.online/security) documents what is in scope, what is out of scope, and how reports receive public credit.
+
+## Disclosure and credit
+
+Please allow time for the issue to be investigated and fixed before sharing it publicly. Reports made in good faith and within the published scope are welcome.
+
+With the reporter's permission, Owncast credits valid reports after a fix is available. Credit can include the reporter's chosen name and one link. Reporters may remain anonymous.
+
+Owncast handles new reports by email and does not publish new GitHub Security Advisories as part of this process. CVEs may be requested when the severity and impact warrant one, at the project's discretion.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,9 +8,21 @@ The latest stable Owncast release is the supported version. Reports that affect 
 
 ## Scope
 
-Reports are in scope when they affect the latest stable Owncast release, the current `develop` branch, an Owncast-operated service under `owncast.online`, or a third-party dependency that can be exploited through Owncast.
+### In scope
 
-Expected actions by an authorized server administrator, issues already fixed in the latest release, self-XSS, automated scanner output without reproducible security impact, social engineering, and third-party vulnerabilities that cannot be exploited through Owncast are out of scope.
+- Security vulnerabilities in the latest stable Owncast release or the current `develop` branch.
+- The Owncast server, viewer and admin interfaces, bundled APIs, chat, federation, authentication, and streaming features.
+- Vulnerabilities in third-party dependencies that can be exploited through Owncast.
+- Owncast-operated services under `owncast.online` when tested without disrupting the service or accessing other people's data.
+
+### Out of scope
+
+- Independently operated Owncast instances and the content they stream. Contact that server's operator instead.
+- Issues that only affect an outdated Owncast version and are already fixed in the latest release.
+- Expected actions available to an authorized server administrator that do not cross a security boundary.
+- Self-XSS, best-practice suggestions, or automated scanner output without a reproducible security impact.
+- Vulnerabilities in third-party software that cannot be exploited through Owncast.
+- Social engineering, phishing, physical attacks, denial-of-service testing, and high-volume automated scanning.
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
This updates the repository's security guidance to use the new private email reporting process.

- Add a README link and security section for private reports.
- Replace the old public issue, personal email, and GitHub advisory instructions with `security@owncast.online`.
- Make the repository policy self-contained with supported versions, scope, report details, disclosure, credit, and CVE guidance.

I ran Prettier and focused checks for the reporting address, local policy links, section order, stale contact paths, and the final wording.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
