### PR TITLE
fix(web): giant logo flash at first paint of the web interface

### DIFF
--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -9,8 +9,12 @@ import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 import _ from 'lodash';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import React from 'react';
-import { Provider } from 'jotai';
+import { Provider, useSetAtom } from 'jotai';
 import { AntdProvider } from '../components/theme/AntdProvider';
+import { Theme } from '../components/theme/Theme';
+import { clientConfigStateAtom } from '../components/stores/ClientConfigStore';
+import { makeEmptyClientConfig } from '../interfaces/client-config.model';
+import THEMES from '../stories/themePresets';
 
 /**
  * Takes an entry of a viewport (from Object.entries()) and converts it
@@ -116,16 +120,60 @@ export const parameters = {
 
 export const loaders = [mswLoader];
 
+// Toolbar switcher for the appearance-theme presets (stories/themePresets).
+// Applies the selected preset through the two real theming paths — the
+// clientConfig atom (AntdProvider maps it onto antd design tokens) and the
+// Theme component (emits the --theme-* CSS variables) — so any story can be
+// checked against custom themes, not just the Theme playground.
+export const globalTypes = {
+  owncastTheme: {
+    description: 'Owncast appearance theme preset',
+    toolbar: {
+      title: 'Theme',
+      icon: 'paintbrush',
+      items: Object.entries(THEMES).map(([value, t]) => ({ value, title: t.label })),
+      dynamicTitle: true,
+    },
+  },
+};
+
+export const initialGlobals = { owncastTheme: 'default' };
+
+const ApplyStorybookTheme = ({ theme, children }) => {
+  const setClientConfig = useSetAtom(clientConfigStateAtom);
+  const preset = theme !== 'default' && THEMES[theme];
+  React.useEffect(() => {
+    if (preset) {
+      setClientConfig({
+        ...makeEmptyClientConfig(),
+        appearanceVariables: preset.variables,
+      });
+    }
+  }, [preset, setClientConfig]);
+  if (!preset) {
+    return children;
+  }
+  return (
+    <>
+      <Theme />
+      {children}
+    </>
+  );
+};
+
 // Mirror the app-wide providers from pages/_app.tsx: antd components rely on
 // AntdProvider for the Owncast theme tokens. Without this decorator those
 // stories would render unthemed. AntdProvider reads jotai atoms, so a
 // Provider wraps it (stories with their own Provider simply nest; that
-// is supported).
+// is supported). The Provider is keyed by the selected toolbar theme so
+// switching themes starts from a fresh store instead of layering presets.
 export const decorators = [
-  Story => (
-    <Provider>
+  (Story, context) => (
+    <Provider key={context.globals.owncastTheme || 'default'}>
       <AntdProvider>
-        <Story />
+        <ApplyStorybookTheme theme={context.globals.owncastTheme}>
+          <Story />
+        </ApplyStorybookTheme>
       </AntdProvider>
     </Provider>
   ),

--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -123,8 +123,9 @@ export const loaders = [mswLoader];
 // Toolbar switcher for the appearance-theme presets (stories/themePresets).
 // Applies the selected preset through the two real theming paths — the
 // clientConfig atom (AntdProvider maps it onto antd design tokens) and the
-// Theme component (emits the --theme-* CSS variables) — so any story can be
-// checked against custom themes, not just the Theme playground.
+// Theme component (emits the --theme-* CSS variables) — so any end-user
+// story can be checked against custom themes, not just the Theme
+// playground. Admin stories are exempt: the admin UI is not themed.
 export const globalTypes = {
   owncastTheme: {
     description: 'Owncast appearance theme preset',
@@ -168,13 +169,19 @@ const ApplyStorybookTheme = ({ theme, children }) => {
 // is supported). The Provider is keyed by the selected toolbar theme so
 // switching themes starts from a fresh store instead of layering presets.
 export const decorators = [
-  (Story, context) => (
-    <Provider key={context.globals.owncastTheme || 'default'}>
-      <AntdProvider>
-        <ApplyStorybookTheme theme={context.globals.owncastTheme}>
-          <Story />
-        </ApplyStorybookTheme>
-      </AntdProvider>
-    </Provider>
-  ),
+  (Story, context) => {
+    // Appearance themes only apply to the end-user experience; the admin
+    // interface never receives appearanceVariables.
+    const isAdminStory = context.id.startsWith('owncast-admin');
+    const theme = isAdminStory ? 'default' : context.globals.owncastTheme;
+    return (
+      <Provider key={theme || 'default'}>
+        <AntdProvider>
+          <ApplyStorybookTheme theme={theme}>
+            <Story />
+          </ApplyStorybookTheme>
+        </AntdProvider>
+      </Provider>
+    );
+  },
 ];

--- a/web/build-scripts/extract-antd-styles.js
+++ b/web/build-scripts/extract-antd-styles.js
@@ -181,6 +181,15 @@ const allComponents = h(
 // so the extracted selectors match the classes components render with.
 // zeroRuntime must NOT be set during extraction: it is the flag that
 // suppresses exactly the rule generation being captured here.
+//
+// cssVar.key must be a stable explicit value: without it antd derives the
+// css-variable scope class from React useId, which differs between this
+// script, the Next build render, and the browser — the pre-extracted
+// variable values then never match the exported HTML and var()-sized
+// components (e.g. the header Avatar) flash unstyled at first paint.
+if (!defaultTheme.cssVar || !defaultTheme.cssVar.key) {
+  throw new Error('antd-default-theme.json must set cssVar.key (stable css-var scope class)');
+}
 const cache = createCache();
 renderToString(
   h(

--- a/web/components/theme/AntdProvider.tsx
+++ b/web/components/theme/AntdProvider.tsx
@@ -100,15 +100,27 @@ function buildTheme(appearanceVariables: Record<string, string>): ThemeConfig {
     tabs.colorBorderSecondary = vars['theme-color-components-menu-item-focus-bg'];
   }
 
+  // Whether any admin appearance customization is in play. The pre-extracted
+  // antd.css bakes the DEFAULT token values under the stable cssVar key so
+  // the static export is fully styled at first paint. Those static value
+  // blocks have the same specificity as the runtime-injected ones, so a
+  // customized theme must live under a DIFFERENT scope key: otherwise the
+  // static defaults can win the cascade and admin theming silently reverts
+  // to default (a stuck-purple primary button).
+  const hasCustomizations = Object.keys(vars).length > 0;
+
   return {
     token,
     components: { Modal: modal, Tabs: tabs, Dropdown: dropdown, Menu: menu },
-    // Stable css-var scope key. Without it antd derives the key from React
-    // useId, so the class baked into the static export (e.g. css-var-R16)
-    // never matches the selectors in the pre-extracted antd.css and
+    // Stable css-var scope key. Without an explicit key antd derives it from
+    // React useId, which differs between the extraction script, the Next
+    // build render, and the browser, so the class baked into the static
+    // export never matches the selectors in the pre-extracted antd.css and
     // var()-sized components (like the header Avatar) render unconstrained
     // until hydration injects the runtime values.
-    cssVar: defaultTheme.cssVar,
+    cssVar: hasCustomizations
+      ? { ...defaultTheme.cssVar, key: `${defaultTheme.cssVar.key}-custom` }
+      : defaultTheme.cssVar,
     // Component style RULES come from the pre-extracted styles/antd.css
     // (see build-scripts/extract-antd-styles.js); the runtime only injects
     // the CSS-variable VALUES derived from the tokens above, which is what

--- a/web/components/theme/AntdProvider.tsx
+++ b/web/components/theme/AntdProvider.tsx
@@ -103,6 +103,12 @@ function buildTheme(appearanceVariables: Record<string, string>): ThemeConfig {
   return {
     token,
     components: { Modal: modal, Tabs: tabs, Dropdown: dropdown, Menu: menu },
+    // Stable css-var scope key. Without it antd derives the key from React
+    // useId, so the class baked into the static export (e.g. css-var-R16)
+    // never matches the selectors in the pre-extracted antd.css and
+    // var()-sized components (like the header Avatar) render unconstrained
+    // until hydration injects the runtime values.
+    cssVar: defaultTheme.cssVar,
     // Component style RULES come from the pre-extracted styles/antd.css
     // (see build-scripts/extract-antd-styles.js); the runtime only injects
     // the CSS-variable VALUES derived from the tokens above, which is what

--- a/web/components/theme/antd-default-theme.json
+++ b/web/components/theme/antd-default-theme.json
@@ -1,4 +1,5 @@
 {
+  "cssVar": { "key": "owncast" },
   "token": {
     "colorPrimary": "#6544e9",
     "colorLink": "#6544e9",

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "stylelint:changed": "files=$(git diff --name-only origin/develop... | grep '^web/.*\\.s\\?css$' | grep -vE '^web/(public/styles/plugin.css|styles/variables.css)$' | sed 's|^web/||'); [ -z \"$files\" ] || echo \"$files\" | xargs stylelint --fix",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "build-styles": "cd ./style-definitions && style-dictionary build && ./build.sh && cd -",
+    "build-styles": "cd ./style-definitions && style-dictionary build && ./build.sh && cd - && npm run antd:extract",
     "test": "jest",
     "licenses": "node ../build/generate-licenses.mjs",
     "format": "prettier --write **/*.{js,ts,jsx,tsx,css,md,scss}",

--- a/web/public/styles/plugin.css
+++ b/web/public/styles/plugin.css
@@ -88,7 +88,9 @@
   --theme-color-components-primary-button-text-disabled: var(
     --theme-color-palette-10
   ); /** Neutral gray light */
-  --theme-color-components-primary-button-border: var(--theme-color-action); /** Light secondary */
+  --theme-color-components-primary-button-border: var(
+    --theme-color-action
+  ); /** Text link/secondary light text */
   --theme-color-components-primary-button-border-disabled: var(
     --theme-color-action-disabled
   ); /** Disabled background */
@@ -108,7 +110,7 @@
   --theme-color-components-secondary-button-border-disabled: var(
     --theme-color-action-disabled
   ); /** Disabled background */
-  --theme-color-components-chat-background: var(--theme-color-palette-1); /** Dark primary */
+  --theme-color-components-chat-background: var(--theme-color-palette-1); /** Dark secondary */
   --theme-color-components-chat-text: var(--theme-color-palette-15); /** Lighter background */
   --theme-color-components-content-background: var(
     --theme-color-palette-15

--- a/web/public/styles/plugin.css
+++ b/web/public/styles/plugin.css
@@ -19,28 +19,28 @@
   --border-radius-base: var(--theme-rounded-corners);
   --background-color-light: var(--theme-color-background-main);
   --modal-close-color: var(--theme-color-components-modal-header-text);
-  --primary-color: #6544e9; /* Text link/secondary light text */
-  --primary-color-hover: #2386e2; /* Fun color 1 */
-  --primary-color-active: #7a5cf3; /* Text link hover */
-  --primary-1: #6544e9; /* Text link/secondary light text */
-  --primary-2: #2386e2; /* Fun color 1 */
-  --primary-3: #7a5cf3; /* Text link hover */
-  --primary-4: #da9eff; /* Fun color 2 */
-  --primary-5: #6544e9; /* Text link/secondary light text */
-  --primary-6: #2386e2; /* Fun color 1 */
-  --primary-7: #7a5cf3; /* Text link hover */
-  --primary-8: #da9eff; /* Fun color 2 */
-  --component-background: #e2e8f0; /* Light primary */
-  --body-background: #e2e8f0; /* Light primary */
-  --theme-rounded-corners: 9px; /* How much corners are rounded in places in the UI. */
-  --theme-unknown-1: green; /* This should never be used and it means something is wrong. */
-  --theme-unknown-2: red; /* This should never be used and it means something is wrong. */
+  --primary-color: #6544e9; /** Text link/secondary light text */
+  --primary-color-hover: #2386e2; /** Fun color 1 */
+  --primary-color-active: #7a5cf3; /** Text link hover */
+  --primary-1: #6544e9; /** Text link/secondary light text */
+  --primary-2: #2386e2; /** Fun color 1 */
+  --primary-3: #7a5cf3; /** Text link hover */
+  --primary-4: #da9eff; /** Fun color 2 */
+  --primary-5: #6544e9; /** Text link/secondary light text */
+  --primary-6: #2386e2; /** Fun color 1 */
+  --primary-7: #7a5cf3; /** Text link hover */
+  --primary-8: #da9eff; /** Fun color 2 */
+  --component-background: #e2e8f0; /** Light primary */
+  --body-background: #e2e8f0; /** Light primary */
+  --theme-rounded-corners: 9px; /** How much corners are rounded in places in the UI. */
+  --theme-unknown-1: green; /** This should never be used and it means something is wrong. */
+  --theme-unknown-2: red; /** This should never be used and it means something is wrong. */
   --theme-text-body-font-family: var(
     --font-owncast-body
-  ); /* The font family used for the body text. */
+  ); /** The font family used for the body text. */
   --theme-text-display-font-family: var(
     --font-owncast-display
-  ); /* The font family used for the display/header text. */
+  ); /** The font family used for the display/header text. */
   --theme-color-users-0: var(--color-owncast-user-0);
   --theme-color-users-1: var(--color-owncast-user-1);
   --theme-color-users-2: var(--color-owncast-user-2);
@@ -49,105 +49,105 @@
   --theme-color-users-5: var(--color-owncast-user-5);
   --theme-color-users-6: var(--color-owncast-user-6);
   --theme-color-users-7: var(--color-owncast-user-7);
-  --theme-color-palette-0: var(--color-owncast-palette-0); /* Dark primary */
-  --theme-color-palette-1: var(--color-owncast-palette-1); /* Dark secondary */
-  --theme-color-palette-2: var(--color-owncast-palette-2); /* Dark alternate */
-  --theme-color-palette-3: var(--color-owncast-palette-3); /* Light primary */
-  --theme-color-palette-4: var(--color-owncast-palette-4); /* Light secondary */
-  --theme-color-palette-5: var(--color-owncast-palette-5); /* Light alternate */
-  --theme-color-palette-6: var(--color-owncast-palette-6); /* Text link/secondary light text */
-  --theme-color-palette-7: var(--color-owncast-palette-7); /* Text link hover */
-  --theme-color-palette-8: var(--color-owncast-palette-8); /* Disabled background */
-  --theme-color-palette-9: var(--color-owncast-palette-9); /* Neutral dark */
-  --theme-color-palette-10: var(--color-owncast-palette-10); /* Neutral gray light */
-  --theme-color-palette-11: var(--color-owncast-palette-11); /* Fun color 1 */
-  --theme-color-palette-12: var(--color-owncast-palette-12); /* Fun color 2 */
-  --theme-color-palette-13: var(--color-owncast-palette-13); /* Fun color 3 */
-  --theme-color-palette-14: var(--color-owncast-palette-14); /* Light background */
-  --theme-color-palette-15: var(--color-owncast-palette-15); /* Lighter background */
-  --theme-color-palette-error: var(--color-owncast-palette-error); /* Error */
-  --theme-color-palette-warning: var(--color-owncast-palette-warning); /* Warning */
-  --theme-color-background-main: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-background-light: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-background-header: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-background-secondary: var(--theme-color-palette-1); /* Dark secondary */
-  --theme-color-action: var(--theme-color-palette-6); /* Text link/secondary light text */
-  --theme-color-action-hover: var(--theme-color-palette-7); /* Text link hover */
-  --theme-color-action-disabled: var(--theme-color-palette-8); /* Disabled background */
-  --theme-color-error: var(--theme-color-palette-error); /* Error */
-  --theme-color-warning: var(--theme-color-palette-warning); /* Warning */
-  --theme-color-components-text-on-light: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-components-text-on-dark: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-palette-0: var(--color-owncast-palette-0); /** Dark primary */
+  --theme-color-palette-1: var(--color-owncast-palette-1); /** Dark secondary */
+  --theme-color-palette-2: var(--color-owncast-palette-2); /** Dark alternate */
+  --theme-color-palette-3: var(--color-owncast-palette-3); /** Light primary */
+  --theme-color-palette-4: var(--color-owncast-palette-4); /** Light secondary */
+  --theme-color-palette-5: var(--color-owncast-palette-5); /** Light alternate */
+  --theme-color-palette-6: var(--color-owncast-palette-6); /** Text link/secondary light text */
+  --theme-color-palette-7: var(--color-owncast-palette-7); /** Text link hover */
+  --theme-color-palette-8: var(--color-owncast-palette-8); /** Disabled background */
+  --theme-color-palette-9: var(--color-owncast-palette-9); /** Neutral dark */
+  --theme-color-palette-10: var(--color-owncast-palette-10); /** Neutral gray light */
+  --theme-color-palette-11: var(--color-owncast-palette-11); /** Fun color 1 */
+  --theme-color-palette-12: var(--color-owncast-palette-12); /** Fun color 2 */
+  --theme-color-palette-13: var(--color-owncast-palette-13); /** Fun color 3 */
+  --theme-color-palette-14: var(--color-owncast-palette-14); /** Light background */
+  --theme-color-palette-15: var(--color-owncast-palette-15); /** Lighter background */
+  --theme-color-palette-error: var(--color-owncast-palette-error); /** Error */
+  --theme-color-palette-warning: var(--color-owncast-palette-warning); /** Warning */
+  --theme-color-background-main: var(--theme-color-palette-3); /** Light primary */
+  --theme-color-background-light: var(--theme-color-palette-3); /** Light primary */
+  --theme-color-background-header: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-background-secondary: var(--theme-color-palette-1); /** Dark secondary */
+  --theme-color-action: var(--theme-color-palette-6); /** Text link/secondary light text */
+  --theme-color-action-hover: var(--theme-color-palette-7); /** Text link hover */
+  --theme-color-action-disabled: var(--theme-color-palette-8); /** Disabled background */
+  --theme-color-error: var(--theme-color-palette-error); /** Error */
+  --theme-color-warning: var(--theme-color-palette-warning); /** Warning */
+  --theme-color-components-text-on-light: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-components-text-on-dark: var(--theme-color-palette-3); /** Light primary */
   --theme-color-components-primary-button-background: var(
     --theme-color-action
-  ); /* Text link/secondary light text */
+  ); /** Text link/secondary light text */
   --theme-color-components-primary-button-background-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
-  --theme-color-components-primary-button-text: var(--theme-color-palette-4); /* Light secondary */
+  ); /** Disabled background */
+  --theme-color-components-primary-button-text: var(--theme-color-palette-4); /** Light secondary */
   --theme-color-components-primary-button-text-disabled: var(
     --theme-color-palette-10
-  ); /* Neutral gray light */
-  --theme-color-components-primary-button-border: var(--theme-color-action); /* Light secondary */
+  ); /** Neutral gray light */
+  --theme-color-components-primary-button-border: var(--theme-color-action); /** Light secondary */
   --theme-color-components-primary-button-border-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
+  ); /** Disabled background */
   --theme-color-components-secondary-button-background: var(
     --theme-color-palette-4
-  ); /* Light secondary */
+  ); /** Light secondary */
   --theme-color-components-secondary-button-background-disabled: transparent;
   --theme-color-components-secondary-button-text: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
+  ); /** Disabled background */
   --theme-color-components-secondary-button-text-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
+  ); /** Disabled background */
   --theme-color-components-secondary-button-border: var(
     --theme-color-action
-  ); /* Text link/secondary light text */
+  ); /** Text link/secondary light text */
   --theme-color-components-secondary-button-border-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
-  --theme-color-components-chat-background: var(--theme-color-palette-1); /* Dark primary */
-  --theme-color-components-chat-text: var(--theme-color-palette-15); /* Lighter background */
+  ); /** Disabled background */
+  --theme-color-components-chat-background: var(--theme-color-palette-1); /** Dark primary */
+  --theme-color-components-chat-text: var(--theme-color-palette-15); /** Lighter background */
   --theme-color-components-content-background: var(
     --theme-color-palette-15
-  ); /* Lighter background */
+  ); /** Lighter background */
   --theme-color-components-modal-header-background: var(
     --theme-color-background-secondary
-  ); /* Dark secondary */
+  ); /** Dark secondary */
   --theme-color-components-modal-header-text: var(
     --theme-color-components-text-on-dark
-  ); /* Light primary */
+  ); /** Light primary */
   --theme-color-components-modal-content-background: var(
     --theme-color-components-content-background
-  ); /* Lighter background */
+  ); /** Lighter background */
   --theme-color-components-modal-content-text: var(
     --theme-color-components-text-on-light
-  ); /* Dark primary */
-  --theme-color-components-menu-background: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-components-menu-item-text: var(--theme-color-palette-0); /* Dark primary */
+  ); /** Dark primary */
+  --theme-color-components-menu-background: var(--theme-color-palette-3); /** Light primary */
+  --theme-color-components-menu-item-text: var(--theme-color-palette-0); /** Dark primary */
   --theme-color-components-menu-item-bg: transparent;
   --theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
   --theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
   --theme-color-components-form-field-background: var(
     --theme-color-palette-4
-  ); /* Light secondary */
+  ); /** Light secondary */
   --theme-color-components-form-field-placeholder: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
-  --theme-color-components-form-field-text: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-components-form-field-border: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-components-video-background: var(--theme-color-palette-2); /* Dark alternate */
+  ); /** Disabled background */
+  --theme-color-components-form-field-text: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-components-form-field-border: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-components-video-background: var(--theme-color-palette-2); /** Dark alternate */
   --theme-color-components-video-live-indicator: var(
     --theme-color-action
-  ); /* The Live dot indicator in the control bar of the video player */
+  ); /** The Live dot indicator in the control bar of the video player */
   --theme-color-components-video-status-bar-background: var(
     --theme-color-palette-2
-  ); /* The background color of the video status bar */
+  ); /** The background color of the video status bar */
   --theme-color-components-video-status-bar-foreground: var(
     --theme-color-palette-4
-  ); /* The foreground color of the video status bar */
+  ); /** The foreground color of the video status bar */
   --color-unknown: #7a5cf3;
   --color-unknown-2: #fffffe;
   --color-owncast-user-0: #ff717b;
@@ -158,24 +158,24 @@
   --color-owncast-user-5: #16a8f7;
   --color-owncast-user-6: #9a92ff;
   --color-owncast-user-7: #ff53ff;
-  --color-owncast-palette-0: #12161d; /* Dark primary */
-  --color-owncast-palette-1: #2d3748; /* Dark secondary */
-  --color-owncast-palette-2: #000000; /* Dark alternate */
-  --color-owncast-palette-3: #e2e8f0; /* Light primary */
-  --color-owncast-palette-4: #ffffff; /* Light secondary */
-  --color-owncast-palette-5: #c3dafe; /* Light alternate */
-  --color-owncast-palette-6: #6544e9; /* Text link/secondary light text */
-  --color-owncast-palette-7: #7a5cf3; /* Text link hover */
-  --color-owncast-palette-8: #b6b3c6; /* Disabled background */
-  --color-owncast-palette-9: #39373d; /* Neutral dark */
-  --color-owncast-palette-10: #5d5f72; /* Neutral gray light */
-  --color-owncast-palette-11: #2386e2; /* Fun color 1 */
-  --color-owncast-palette-12: #da9eff; /* Fun color 2 */
-  --color-owncast-palette-13: #42bea6; /* Fun color 3 */
-  --color-owncast-palette-14: #f0f3f8; /* Light background */
-  --color-owncast-palette-15: #eff1f4; /* Lighter background */
-  --color-owncast-palette-error: #ff4b39; /* Error */
-  --color-owncast-palette-warning: #ffc655; /* Warning */
+  --color-owncast-palette-0: #12161d; /** Dark primary */
+  --color-owncast-palette-1: #2d3748; /** Dark secondary */
+  --color-owncast-palette-2: #000000; /** Dark alternate */
+  --color-owncast-palette-3: #e2e8f0; /** Light primary */
+  --color-owncast-palette-4: #ffffff; /** Light secondary */
+  --color-owncast-palette-5: #c3dafe; /** Light alternate */
+  --color-owncast-palette-6: #6544e9; /** Text link/secondary light text */
+  --color-owncast-palette-7: #7a5cf3; /** Text link hover */
+  --color-owncast-palette-8: #b6b3c6; /** Disabled background */
+  --color-owncast-palette-9: #39373d; /** Neutral dark */
+  --color-owncast-palette-10: #5d5f72; /** Neutral gray light */
+  --color-owncast-palette-11: #2386e2; /** Fun color 1 */
+  --color-owncast-palette-12: #da9eff; /** Fun color 2 */
+  --color-owncast-palette-13: #42bea6; /** Fun color 3 */
+  --color-owncast-palette-14: #f0f3f8; /** Light background */
+  --color-owncast-palette-15: #eff1f4; /** Lighter background */
+  --color-owncast-palette-error: #ff4b39; /** Error */
+  --color-owncast-palette-warning: #ffc655; /** Warning */
   --font-owncast-body:
     'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',

--- a/web/stories/ThemePlayground.stories.tsx
+++ b/web/stories/ThemePlayground.stories.tsx
@@ -26,66 +26,9 @@ import {
 import { Theme } from '../components/theme/Theme';
 import { clientConfigStateAtom } from '../components/stores/ClientConfigStore';
 import { makeEmptyClientConfig } from '../interfaces/client-config.model';
+import THEMES from './themePresets';
 
 const { Title, Text } = Typography;
-
-// Each preset is a set of the same appearance variables an admin can set
-// from the Appearance config page. They flow through the two real theming
-// paths at once: the Theme component turns them into --theme-* CSS
-// variables, and AntdProvider maps them onto Ant Design design tokens.
-const THEMES: Record<string, { label: string; variables: Record<string, string> }> = {
-  default: {
-    label: 'Owncast default',
-    variables: {},
-  },
-  midnight: {
-    label: 'Midnight',
-    variables: {
-      'theme-color-action': '#22d3ee',
-      'theme-color-action-hover': '#67e8f9',
-      'theme-color-background-main': '#1f2937',
-      'theme-color-background-header': '#0b1220',
-      'theme-color-components-text-on-light': '#e5e7eb',
-      'theme-color-components-form-field-background': '#111827',
-      'theme-color-components-modal-header-background': '#0b1220',
-      'theme-color-components-modal-header-text': '#f9fafb',
-      'theme-color-components-modal-content-background': '#1f2937',
-      'theme-color-components-menu-background': '#111827',
-      'theme-color-components-menu-item-text': '#e5e7eb',
-      'theme-rounded-corners': '4px',
-    },
-  },
-  forest: {
-    label: 'Forest',
-    variables: {
-      'theme-color-action': '#15803d',
-      'theme-color-action-hover': '#22c55e',
-      'theme-color-background-main': '#f0fdf4',
-      'theme-color-background-header': '#14532d',
-      'theme-color-components-text-on-light': '#14532d',
-      'theme-color-components-form-field-background': '#dcfce7',
-      'theme-color-components-modal-header-background': '#14532d',
-      'theme-color-components-modal-header-text': '#f0fdf4',
-      'theme-color-components-modal-content-background': '#f0fdf4',
-      'theme-rounded-corners': '12px',
-    },
-  },
-  terminal: {
-    label: 'Terminal',
-    variables: {
-      'theme-color-action': '#00ff41',
-      'theme-color-action-hover': '#7dff9b',
-      'theme-color-background-main': '#0a0a0a',
-      'theme-color-background-header': '#000000',
-      'theme-color-components-text-on-light': '#00ff41',
-      'theme-color-components-form-field-background': '#001a06',
-      'theme-color-components-modal-header-background': '#000000',
-      'theme-color-components-modal-header-text': '#00ff41',
-      'theme-color-components-modal-content-background': '#0a0a0a',
-      'theme-rounded-corners': '0px',
-    },
-  },
-};
 
 const SWATCH_VARS = [
   'theme-color-action',

--- a/web/stories/themePresets.ts
+++ b/web/stories/themePresets.ts
@@ -1,0 +1,61 @@
+// Appearance-theme presets shared by the Theme playground story and the
+// Storybook toolbar theme switcher (.storybook/preview.js). Each preset is a
+// set of the same appearance variables an admin can set from the Appearance
+// config page. They flow through the two real theming paths at once: the
+// Theme component turns them into --theme-* CSS variables, and AntdProvider
+// maps them onto Ant Design design tokens.
+const THEMES: Record<string, { label: string; variables: Record<string, string> }> = {
+  default: {
+    label: 'Owncast default',
+    variables: {},
+  },
+  midnight: {
+    label: 'Midnight',
+    variables: {
+      'theme-color-action': '#22d3ee',
+      'theme-color-action-hover': '#67e8f9',
+      'theme-color-background-main': '#1f2937',
+      'theme-color-background-header': '#0b1220',
+      'theme-color-components-text-on-light': '#e5e7eb',
+      'theme-color-components-form-field-background': '#111827',
+      'theme-color-components-modal-header-background': '#0b1220',
+      'theme-color-components-modal-header-text': '#f9fafb',
+      'theme-color-components-modal-content-background': '#1f2937',
+      'theme-color-components-menu-background': '#111827',
+      'theme-color-components-menu-item-text': '#e5e7eb',
+      'theme-rounded-corners': '4px',
+    },
+  },
+  forest: {
+    label: 'Forest',
+    variables: {
+      'theme-color-action': '#15803d',
+      'theme-color-action-hover': '#22c55e',
+      'theme-color-background-main': '#f0fdf4',
+      'theme-color-background-header': '#14532d',
+      'theme-color-components-text-on-light': '#14532d',
+      'theme-color-components-form-field-background': '#dcfce7',
+      'theme-color-components-modal-header-background': '#14532d',
+      'theme-color-components-modal-header-text': '#f0fdf4',
+      'theme-color-components-modal-content-background': '#f0fdf4',
+      'theme-rounded-corners': '12px',
+    },
+  },
+  terminal: {
+    label: 'Terminal',
+    variables: {
+      'theme-color-action': '#00ff41',
+      'theme-color-action-hover': '#7dff9b',
+      'theme-color-background-main': '#0a0a0a',
+      'theme-color-background-header': '#000000',
+      'theme-color-components-text-on-light': '#00ff41',
+      'theme-color-components-form-field-background': '#001a06',
+      'theme-color-components-modal-header-background': '#000000',
+      'theme-color-components-modal-header-text': '#00ff41',
+      'theme-color-components-modal-content-background': '#0a0a0a',
+      'theme-rounded-corners': '0px',
+    },
+  },
+};
+
+export default THEMES;

--- a/web/style-definitions/build.sh
+++ b/web/style-definitions/build.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 mv build/variables.css ../styles/variables.css
-mv build/variables.less ../styles/theme.less
 
 # Served plugin stylesheet: the generated :root token block (build/plugin.css)
 # followed by the hand-authored element baseline. One file authors <link>,
@@ -16,5 +15,4 @@ mv build/plugin.css ../public/styles/plugin.css
 # listed in .prettierignore).
 (cd .. && npx --yes prettier --write \
   styles/variables.css \
-  styles/theme.less \
   public/styles/plugin.css)

--- a/web/style-definitions/config.js
+++ b/web/style-definitions/config.js
@@ -1,34 +1,32 @@
 const yaml = require('yaml');
-const StyleDictionary = require('style-dictionary');
-
-StyleDictionary.registerFileHeader({
-  name: 'myCustomHeader',
-  // Intentionally omit Style Dictionary's default "Generated on <timestamp>"
-  // line. The timestamp made every regeneration produce a diff, so the
-  // committed outputs could never be reproduced byte-for-byte from the source.
-  fileHeader: () => [
-    `Do not edit directly`,
-    `This file is generated from the token sources under style-definitions/.`,
-    ``,
-    `How to edit these values:`,
-    `Edit the corresponding token file under the style-definitions directory`,
-    `in the Owncast web project.`,
-  ],
-});
 
 module.exports = {
-  parsers: [
-    {
-      // A custom parser will only run against filenames that match the pattern
-      // This pattern will match any file with the .yaml extension.
-      // This allows you to mix different types of files in your token source
-      pattern: /\.yaml$/,
-      // the parse function takes a single argument, which is an object with
-      // a `contents` string (the file contents) and a `filePath`. We only
-      // need contents. The function is expected to return a plain object.
-      parse: ({ contents }) => yaml.parse(contents),
+  hooks: {
+    parsers: {
+      // A custom parser will only run against filenames that match the pattern.
+      // This pattern will match any file with the .yaml extension, which
+      // allows you to mix different types of files in your token source.
+      'yaml-parser': {
+        pattern: /\.yaml$/,
+        parser: ({ contents }) => yaml.parse(contents),
+      },
     },
-  ],
+    fileHeaders: {
+      // Intentionally omit Style Dictionary's default "Generated on <timestamp>"
+      // line. The timestamp made every regeneration produce a diff, so the
+      // committed outputs could never be reproduced byte-for-byte from the
+      // source.
+      myCustomHeader: () => [
+        `Do not edit directly`,
+        `This file is generated from the token sources under style-definitions/.`,
+        ``,
+        `How to edit these values:`,
+        `Edit the corresponding token file under the style-definitions directory`,
+        `in the Owncast web project.`,
+      ],
+    },
+  },
+  parsers: ['yaml-parser'],
   source: [`tokens/**/*.yaml`],
   platforms: {
     css: {
@@ -51,43 +49,6 @@ module.exports = {
           format: 'css/variables',
           options: {
             fileHeader: 'myCustomHeader',
-          },
-        },
-      ],
-    },
-    less: {
-      transformGroup: 'less',
-      buildPath: 'build/',
-      files: [
-        {
-          destination: 'variables.less',
-          format: 'less/variables',
-          options: {
-            fileHeader: 'myCustomHeader',
-          },
-        },
-      ],
-    },
-    'ios-swift': {
-      transforms: [
-        'attribute/cti',
-        'name/ti/camel',
-        'color/ColorSwiftUI',
-        'content/swift/literal',
-        'asset/swift/literal',
-        'size/swift/remToCGFloat',
-        'font/swift/literal',
-      ],
-      buildPath: 'build/',
-      files: [
-        {
-          format: 'ios-swift/class.swift',
-          className: 'PlatformColor',
-          destination: 'Colors.swift',
-          filter: {
-            attributes: {
-              category: 'color',
-            },
           },
         },
       ],

--- a/web/style-definitions/tokens/color/antd-overrides.yaml
+++ b/web/style-definitions/tokens/color/antd-overrides.yaml
@@ -28,44 +28,44 @@ modal-close-color:
 # This values need to be statically assigned at build time and cannot be
 # overridden by the user at runtime.
 primary-color:
-  value: '{color.owncast.palette.6.value}'
-  comment: '{color.owncast.palette.6.comment}'
+  value: '{color.owncast.palette.6}'
+  comment: 'Text link/secondary light text'
 primary-color-hover:
-  value: '{color.owncast.palette.11.value}'
-  comment: '{color.owncast.palette.11.comment}'
+  value: '{color.owncast.palette.11}'
+  comment: 'Fun color 1'
 primary-color-active:
-  value: '{color.owncast.palette.7.value}'
-  comment: '{color.owncast.palette.7.comment}'
+  value: '{color.owncast.palette.7}'
+  comment: 'Text link hover'
 
 primary-1:
-  value: '{color.owncast.palette.6.value}'
-  comment: '{color.owncast.palette.6.comment}'
+  value: '{color.owncast.palette.6}'
+  comment: 'Text link/secondary light text'
 primary-2:
-  value: '{color.owncast.palette.11.value}'
-  comment: '{color.owncast.palette.11.comment}'
+  value: '{color.owncast.palette.11}'
+  comment: 'Fun color 1'
 primary-3:
-  value: '{color.owncast.palette.7.value}'
-  comment: '{color.owncast.palette.7.comment}'
+  value: '{color.owncast.palette.7}'
+  comment: 'Text link hover'
 primary-4:
-  value: '{color.owncast.palette.12.value}'
-  comment: '{color.owncast.palette.12.comment}'
+  value: '{color.owncast.palette.12}'
+  comment: 'Fun color 2'
 primary-5:
-  value: '{color.owncast.palette.6.value}'
-  comment: '{color.owncast.palette.6.comment}'
+  value: '{color.owncast.palette.6}'
+  comment: 'Text link/secondary light text'
 primary-6:
-  value: '{color.owncast.palette.11.value}'
-  comment: '{color.owncast.palette.11.comment}'
+  value: '{color.owncast.palette.11}'
+  comment: 'Fun color 1'
 primary-7:
-  value: '{color.owncast.palette.7.value}'
-  comment: '{color.owncast.palette.7.comment}'
+  value: '{color.owncast.palette.7}'
+  comment: 'Text link hover'
 primary-8:
-  value: '{color.owncast.palette.12.value}'
-  comment: '{color.owncast.palette.12.comment}'
+  value: '{color.owncast.palette.12}'
+  comment: 'Fun color 2'
 
 component-background:
-  value: '{color.owncast.palette.3.value}'
-  comment: '{color.owncast.palette.3.comment}'
+  value: '{color.owncast.palette.3}'
+  comment: 'Light primary'
 
 body-background:
-  value: '{color.owncast.palette.3.value}'
-  comment: '{color.owncast.palette.3.comment}'
+  value: '{color.owncast.palette.3}'
+  comment: 'Light primary'

--- a/web/style-definitions/tokens/color/default-theme.yaml
+++ b/web/style-definitions/tokens/color/default-theme.yaml
@@ -154,7 +154,7 @@ theme:
           comment: 'Neutral gray light'
         border:
           value: 'var(--theme-color-action)'
-          comment: 'Light secondary'
+          comment: 'Text link/secondary light text'
         border-disabled:
           value: 'var(--theme-color-action-disabled)'
           comment: 'Disabled background'
@@ -181,7 +181,7 @@ theme:
       chat:
         background:
           value: 'var(--theme-color-palette-1)'
-          comment: 'Dark primary'
+          comment: 'Dark secondary'
         text:
           value: 'var(--theme-color-palette-15)'
           comment: 'Lighter background'

--- a/web/style-definitions/tokens/color/default-theme.yaml
+++ b/web/style-definitions/tokens/color/default-theme.yaml
@@ -44,152 +44,152 @@ theme:
       comment: 'Colors used in the user interface for the default theme.'
       0:
         value: 'var(--color-owncast-palette-0)'
-        comment: '{color.owncast.palette.0.comment}'
+        comment: 'Dark primary'
       1:
         value: 'var(--color-owncast-palette-1)'
-        comment: '{color.owncast.palette.1.comment}'
+        comment: 'Dark secondary'
       2:
         value: 'var(--color-owncast-palette-2)'
-        comment: '{color.owncast.palette.2.comment}'
+        comment: 'Dark alternate'
       3:
         value: 'var(--color-owncast-palette-3)'
-        comment: '{color.owncast.palette.3.comment}'
+        comment: 'Light primary'
       4:
         value: 'var(--color-owncast-palette-4)'
-        comment: '{color.owncast.palette.4.comment}'
+        comment: 'Light secondary'
       5:
         value: 'var(--color-owncast-palette-5)'
-        comment: '{color.owncast.palette.5.comment}'
+        comment: 'Light alternate'
       6:
         value: 'var(--color-owncast-palette-6)'
-        comment: '{color.owncast.palette.6.comment}'
+        comment: 'Text link/secondary light text'
       7:
         value: 'var(--color-owncast-palette-7)'
-        comment: '{color.owncast.palette.7.comment}'
+        comment: 'Text link hover'
       8:
         value: 'var(--color-owncast-palette-8)'
-        comment: '{color.owncast.palette.8.comment}'
+        comment: 'Disabled background'
       9:
         value: 'var(--color-owncast-palette-9)'
-        comment: '{color.owncast.palette.9.comment}'
+        comment: 'Neutral dark'
       10:
         value: 'var(--color-owncast-palette-10)'
-        comment: '{color.owncast.palette.10.comment}'
+        comment: 'Neutral gray light'
       11:
         value: 'var(--color-owncast-palette-11)'
-        comment: '{color.owncast.palette.11.comment}'
+        comment: 'Fun color 1'
       12:
         value: 'var(--color-owncast-palette-12)'
-        comment: '{color.owncast.palette.12.comment}'
+        comment: 'Fun color 2'
       13:
         value: 'var(--color-owncast-palette-13)'
-        comment: '{color.owncast.palette.13.comment}'
+        comment: 'Fun color 3'
       14:
         value: 'var(--color-owncast-palette-14)'
-        comment: '{color.owncast.palette.14.comment}'
+        comment: 'Light background'
       15:
         value: 'var(--color-owncast-palette-15)'
-        comment: '{color.owncast.palette.15.comment}'
+        comment: 'Lighter background'
       error:
         value: 'var(--color-owncast-palette-error)'
-        comment: '{color.owncast.palette.error.comment}'
+        comment: 'Error'
       warning:
         value: 'var(--color-owncast-palette-warning)'
-        comment: '{color.owncast.palette.warning.comment}'
+        comment: 'Warning'
 
     background:
       main:
         value: 'var(--theme-color-palette-3)'
-        comment: '{theme.color.palette.3.comment}'
+        comment: 'Light primary'
       light:
         value: 'var(--theme-color-palette-3)'
-        comment: '{theme.color.palette.3.comment}'
+        comment: 'Light primary'
       header:
         value: 'var(--theme-color-palette-0)'
-        comment: '{theme.color.palette.0.comment}'
+        comment: 'Dark primary'
       # Secondary dark surface, a lighter dark blue than the near-black
       # header/footer. Used by surfaces that sit on top of the page rather than
       # framing it, such as the modal header.
       secondary:
         value: 'var(--theme-color-palette-1)'
-        comment: '{theme.color.palette.1.comment}'
+        comment: 'Dark secondary'
 
     action:
       value: 'var(--theme-color-palette-6)'
-      comment: '{theme.color.palette.6.comment}'
+      comment: 'Text link/secondary light text'
     action-hover:
       value: 'var(--theme-color-palette-7)'
-      comment: '{theme.color.palette.7.comment}'
+      comment: 'Text link hover'
     action-disabled:
       value: 'var(--theme-color-palette-8)'
-      comment: '{theme.color.palette.8.comment}'
+      comment: 'Disabled background'
 
     error:
       value: 'var(--theme-color-palette-error)'
-      comment: '{theme.color.palette.error.comment}'
+      comment: 'Error'
     warning:
       value: 'var(--theme-color-palette-warning)'
-      comment: '{theme.color.palette.warning.comment}'
+      comment: 'Warning'
 
     components:
       text-on-light:
         value: 'var(--theme-color-palette-0)'
-        comment: '{theme.color.palette.0.comment}'
+        comment: 'Dark primary'
       text-on-dark:
         value: 'var(--theme-color-palette-3)'
-        comment: '{theme.color.palette.3.comment}'
+        comment: 'Light primary'
 
       primary-button:
         background:
           value: 'var(--theme-color-action)'
-          comment: '{theme.color.action.comment}'
+          comment: 'Text link/secondary light text'
         background-disabled:
           value: 'var(--theme-color-action-disabled)'
-          comment: '{theme.color.action-disabled.comment}'
+          comment: 'Disabled background'
         text:
           value: 'var(--theme-color-palette-4)'
-          comment: '{theme.color.palette.4.comment}'
+          comment: 'Light secondary'
         text-disabled:
           value: 'var(--theme-color-palette-10)'
-          comment: '{theme.color.palette.10.comment}'
+          comment: 'Neutral gray light'
         border:
           value: 'var(--theme-color-action)'
-          comment: '{theme.color.palette.4.comment}'
+          comment: 'Light secondary'
         border-disabled:
           value: 'var(--theme-color-action-disabled)'
-          comment: '{theme.color.action-disabled.comment}'
+          comment: 'Disabled background'
 
       secondary-button:
         background:
           value: 'var(--theme-color-palette-4)'
-          comment: '{theme.color.palette.4.comment}'
+          comment: 'Light secondary'
         background-disabled:
           value: 'transparent'
         text:
           value: 'var(--theme-color-action-disabled)'
-          comment: '{theme.color.action-disabled.comment}'
+          comment: 'Disabled background'
         text-disabled:
           value: 'var(--theme-color-action-disabled)'
-          comment: '{theme.color.action-disabled.comment}'
+          comment: 'Disabled background'
         border:
           value: 'var(--theme-color-action)'
-          comment: '{theme.color.action.comment}'
+          comment: 'Text link/secondary light text'
         border-disabled:
           value: 'var(--theme-color-action-disabled)'
-          comment: '{theme.color.action-disabled.comment}'
+          comment: 'Disabled background'
 
       chat:
         background:
           value: 'var(--theme-color-palette-1)'
-          comment: '{theme.color.palette.0.comment}'
+          comment: 'Dark primary'
         text:
           value: 'var(--theme-color-palette-15)'
-          comment: '{theme.color.palette.15.comment}'
+          comment: 'Lighter background'
 
       content:
         background:
           value: 'var(--theme-color-palette-15)'
-          comment: '{theme.color.palette.15.comment}'
+          comment: 'Lighter background'
 
       # Modal colors follow the admin-configurable theme rather than fixed
       # palette entries so modals respect a custom appearance. The header is the
@@ -200,26 +200,26 @@ theme:
         header:
           background:
             value: 'var(--theme-color-background-secondary)'
-            comment: '{theme.color.palette.1.comment}'
+            comment: 'Dark secondary'
           text:
             value: 'var(--theme-color-components-text-on-dark)'
-            comment: '{theme.color.palette.3.comment}'
+            comment: 'Light primary'
         content:
           background:
             value: 'var(--theme-color-components-content-background)'
-            comment: '{theme.color.palette.15.comment}'
+            comment: 'Lighter background'
           text:
             value: 'var(--theme-color-components-text-on-light)'
-            comment: '{theme.color.palette.0.comment}'
+            comment: 'Dark primary'
 
       menu:
         background:
           value: 'var(--theme-color-palette-3)'
-          comment: '{theme.color.palette.3.comment}'
+          comment: 'Light primary'
         item:
           text:
             value: 'var(--theme-color-palette-0)'
-            comment: '{theme.color.palette.0.comment}'
+            comment: 'Dark primary'
           bg:
             value: 'transparent'
           hover-bg:
@@ -230,21 +230,21 @@ theme:
       form-field:
         background:
           value: 'var(--theme-color-palette-4)'
-          comment: '{theme.color.palette.4.comment}'
+          comment: 'Light secondary'
         placeholder:
           value: 'var(--theme-color-action-disabled)'
-          comment: '{theme.color.action-disabled.comment}'
+          comment: 'Disabled background'
         text:
           value: 'var(--theme-color-palette-0)'
-          comment: '{theme.color.palette.0.comment}'
+          comment: 'Dark primary'
         border:
           value: 'var(--theme-color-palette-0)'
-          comment: '{theme.color.palette.0.comment}'
+          comment: 'Dark primary'
 
       video:
         background:
           value: 'var(--theme-color-palette-2)'
-          comment: '{theme.color.palette.2.comment}'
+          comment: 'Dark alternate'
         live-indicator:
           value: 'var(--theme-color-action)'
           comment: 'The Live dot indicator in the control bar of the video player'

--- a/web/styles/antd.css
+++ b/web/styles/antd.css
@@ -1036,7 +1036,7 @@ span.ant-typography-ellipsis-single-line {
 .ant-typography-rtl {
   direction: rtl;
 }
-.css-var-R0.ant-typography {
+.owncast.ant-typography {
   --ant-typography-title-margin-top: 1.2em;
   --ant-typography-title-margin-bottom: 0.5em;
 }
@@ -5166,7 +5166,7 @@ span.ant-typography-ellipsis-single-line {
     flex: var(--ant-col-xxxl-flex);
   }
 }
-.css-var-R0.ant-modal-css-var {
+.owncast.ant-modal-css-var {
   --ant-modal-footer-bg: transparent;
   --ant-modal-header-bg: #2d3748;
   --ant-modal-title-line-height: 1.5;
@@ -6594,7 +6594,7 @@ span.ant-typography-ellipsis-single-line {
     )
   );
 }
-.css-var-R0.ant-input-search {
+.owncast.ant-input-search {
   --ant-input-padding-block: 4px;
   --ant-input-padding-block-sm: 0px;
   --ant-input-padding-block-lg: 7px;
@@ -7189,7 +7189,7 @@ span.ant-typography-ellipsis-single-line {
 .ant-btn-group > .ant-btn-danger:not(:first-child) > .ant-btn-danger:not(:disabled) {
   border-inline-start-color: var(--ant-color-error-hover);
 }
-.css-var-R0.ant-btn {
+.owncast.ant-btn {
   --ant-button-blue-shadow-color: 0 2px 0 rgba(5, 145, 255, 0.1);
   --ant-button-purple-shadow-color: 0 2px 0 rgba(155, 5, 255, 0.06);
   --ant-button-cyan-shadow-color: 0 2px 0 rgba(5, 255, 215, 0.1);
@@ -7410,7 +7410,7 @@ textarea.ant-input.ant-input-mouse-active {
 .ant-otp.ant-otp-lg .ant-otp-input {
   padding-inline: var(--ant-padding-xs);
 }
-.css-var-R0.ant-otp {
+.owncast.ant-otp {
   --ant-input-padding-block: 4px;
   --ant-input-padding-block-sm: 0px;
   --ant-input-padding-block-lg: 7px;
@@ -7967,7 +7967,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
 .ant-input-affix-wrapper-disabled .ant-input-password-icon:hover {
   color: var(--ant-color-icon);
 }
-.css-var-R0.ant-input {
+.owncast.ant-input {
   --ant-input-padding-block: 4px;
   --ant-input-padding-block-sm: 0px;
   --ant-input-padding-block-lg: 7px;
@@ -8399,7 +8399,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
   border-start-start-radius: 0;
   border-end-start-radius: 0;
 }
-.css-var-R0.ant-input-css-var {
+.owncast.ant-input-css-var {
   --ant-input-padding-block: 4px;
   --ant-input-padding-block-sm: 0px;
   --ant-input-padding-block-lg: 7px;
@@ -8591,7 +8591,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
 .ant-alert-close-text:hover {
   color: var(--ant-color-icon-hover);
 }
-.css-var-R0.ant-alert {
+.owncast.ant-alert {
   --ant-alert-with-description-icon-size: 24px;
   --ant-alert-default-padding: 8px 12px;
   --ant-alert-with-description-padding: 20px 24px;
@@ -9459,7 +9459,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
     opacity: 0;
   }
 }
-.css-var-R0.ant-tabs-css-var {
+.owncast.ant-tabs-css-var {
   --ant-color-border-secondary: rgba(0, 0, 0, 0.1);
   --ant-tabs-z-index-popup: 1050;
   --ant-tabs-card-bg: rgba(0, 0, 0, 0.02);
@@ -9708,7 +9708,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
     height var(--ant-motion-duration-mid) var(--ant-motion-ease-in-out),
     opacity var(--ant-motion-duration-mid) var(--ant-motion-ease-in-out) !important;
 }
-.css-var-R0.ant-collapse {
+.owncast.ant-collapse {
   --ant-collapse-header-padding: 12px 16px;
   --ant-collapse-header-padding-sm: 8px 12px 8px 8px;
   --ant-collapse-header-padding-lg: 16px 24px 16px 16px;
@@ -10595,7 +10595,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
     opacity: 0;
   }
 }
-.css-var-R0.ant-dropdown-css-var {
+.owncast.ant-dropdown-css-var {
   --ant-font-size: 13px;
   --ant-dropdown-z-index-popup: 1050;
   --ant-dropdown-padding-block: 5px;
@@ -12053,7 +12053,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
 .ant-zoom-big-leave {
   animation-timing-function: var(--ant-motion-ease-in-out-circ);
 }
-.css-var-R0.ant-menu-css-var {
+.owncast.ant-menu-css-var {
   --ant-menu-dropdown-width: 160px;
   --ant-menu-z-index-popup: 1050;
   --ant-menu-radius-item: 11px;
@@ -12134,7 +12134,7 @@ textarea.ant-input-filled.ant-input-status-warning:not(.ant-input-disabled),
   --ant-menu-dark-danger-item-active-bg: #ff4b39;
   --ant-menu-item-width: calc(100% + 1px);
 }
-.css-var-R0.ant-form-css-var {
+.owncast.ant-form-css-var {
   --ant-form-label-required-mark-color: #ff4b39;
   --ant-form-label-color: #12161d;
   --ant-form-label-font-size: 14px;
@@ -12838,7 +12838,7 @@ textarea.ant-input-number-filled.ant-input-number-status-warning:not(.ant-input-
   border-start-start-radius: 0;
   border-end-start-radius: 0;
 }
-.css-var-R0.ant-input-number-css-var {
+.owncast.ant-input-number-css-var {
   --ant-input-number-padding-block: 4px;
   --ant-input-number-padding-block-sm: 0px;
   --ant-input-number-padding-block-lg: 7px;
@@ -13148,7 +13148,7 @@ textarea.ant-input-number-filled.ant-input-number-status-warning:not(.ant-input-
   margin-inline-start: calc(var(--ant-margin-xxs) * -1 / 2);
   margin-inline-end: calc(var(--ant-margin-xxs) / 2);
 }
-.css-var-R0.ant-switch {
+.owncast.ant-switch {
   --ant-switch-track-height: 22px;
   --ant-switch-track-height-sm: 16px;
   --ant-switch-track-min-width: 44px;
@@ -14143,7 +14143,7 @@ textarea.ant-input-number-filled.ant-input-number-status-warning:not(.ant-input-
 .ant-select.ant-select-customize.ant-select-disabled .ant-select-content textarea[disabled] {
   background: transparent;
 }
-.css-var-R0.ant-select-css-var {
+.owncast.ant-select-css-var {
   --ant-select-internal_fixed_item_margin: 2px;
   --ant-select-z-index-popup: 1050;
   --ant-select-option-selected-color: #12161d;
@@ -14475,7 +14475,7 @@ textarea.ant-input-number-filled.ant-input-number-status-warning:not(.ant-input-
   position: absolute;
   inset-inline-start: calc((var(--ant-slider-rail-size) - var(--ant-slider-dot-size)) / 2);
 }
-.css-var-R0.ant-slider {
+.owncast.ant-slider {
   --ant-slider-control-size: 10px;
   --ant-slider-rail-size: 4px;
   --ant-slider-handle-size: 10px;
@@ -14655,7 +14655,7 @@ a.ant-tag-disabled:active {
 .ant-tag-disabled .ant-tag-close-icon:hover {
   color: var(--ant-color-text-disabled);
 }
-.css-var-R0.ant-tag {
+.owncast.ant-tag {
   --ant-tag-default-bg: #f5f5f5;
   --ant-tag-default-color: #12161d;
   --ant-tag-solid-text-color: #fff;
@@ -14698,7 +14698,7 @@ a.ant-tag-disabled:active {
 .ant-popconfirm .ant-popconfirm-buttons button {
   margin-inline-start: var(--ant-margin-xs);
 }
-.css-var-R0.ant-popconfirm {
+.owncast.ant-popconfirm {
   --ant-popconfirm-z-index-popup: 1060;
 }
 .ant-layout-sider {
@@ -14801,7 +14801,7 @@ a.ant-tag-disabled:active {
   border: 1px solid var(--ant-layout-body-bg);
   border-inline-start: 0;
 }
-.css-var-R0.ant-layout-sider {
+.owncast.ant-layout-sider {
   --ant-layout-color-bg-header: #001529;
   --ant-layout-color-bg-body: #e2e8f0;
   --ant-layout-color-bg-trigger: #002140;
@@ -14887,7 +14887,7 @@ a.ant-tag-disabled:active {
   color: var(--ant-color-text);
   min-height: 0;
 }
-.css-var-R0.ant-layout {
+.owncast.ant-layout {
   --ant-layout-color-bg-header: #001529;
   --ant-layout-color-bg-body: #e2e8f0;
   --ant-layout-color-bg-trigger: #002140;
@@ -15296,7 +15296,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
     opacity: 0;
   }
 }
-.css-var-R0.ant-badge {
+.owncast.ant-badge {
   --ant-badge-indicator-z-index: auto;
   --ant-badge-indicator-height: 20px;
   --ant-badge-indicator-height-sm: 14px;
@@ -15431,7 +15431,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-ribbon-rtl {
   direction: rtl;
 }
-.css-var-R0.ant-ribbon-wrapper {
+.owncast.ant-ribbon-wrapper {
   --ant-badge-indicator-z-index: auto;
   --ant-badge-indicator-height: 20px;
   --ant-badge-indicator-height-sm: 14px;
@@ -15785,7 +15785,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-zoom-big-fast-leave {
   animation-timing-function: var(--ant-motion-ease-in-out-circ);
 }
-.css-var-R0.ant-tooltip-css-var {
+.owncast.ant-tooltip-css-var {
   --ant-tooltip-z-index-popup: 1070;
   --ant-tooltip-max-width: 250px;
   --ant-tooltip-arrow-offset-horizontal: 12px;
@@ -16092,7 +16092,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
   display: flex;
   align-items: center;
 }
-.css-var-R0.ant-card {
+.owncast.ant-card {
   --ant-card-header-bg: transparent;
   --ant-card-header-font-size: 16px;
   --ant-card-header-font-size-sm: 14px;
@@ -16165,7 +16165,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-statistic .ant-statistic-content .ant-statistic-content-suffix {
   margin-inline-start: var(--ant-margin-xxs);
 }
-.css-var-R0.ant-statistic {
+.owncast.ant-statistic {
   --ant-statistic-title-font-size: 14px;
   --ant-statistic-content-font-size: 24px;
 }
@@ -16274,7 +16274,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-avatar-group-popover .ant-avatar + .ant-avatar {
   margin-inline-start: var(--ant-avatar-group-space);
 }
-.css-var-R0.ant-avatar-css-var {
+.owncast.ant-avatar-css-var {
   --ant-avatar-container-size: 32px;
   --ant-avatar-container-size-lg: 40px;
   --ant-avatar-container-size-sm: 24px;
@@ -16549,7 +16549,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
     background-position: 0 50%;
   }
 }
-.css-var-R0.ant-skeleton {
+.owncast.ant-skeleton {
   --ant-skeleton-color: rgba(0, 0, 0, 0.06);
   --ant-skeleton-color-gradient-end: rgba(0, 0, 0, 0.15);
   --ant-skeleton-gradient-from-color: rgba(0, 0, 0, 0.06);
@@ -16718,7 +16718,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-divider-horizontal.ant-divider-md {
   margin-block: var(--ant-margin);
 }
-.css-var-R0.ant-divider {
+.owncast.ant-divider {
   --ant-divider-text-padding-inline: 1em;
   --ant-divider-orientation-margin: 0.05;
   --ant-divider-vertical-margin-inline: 8px;
@@ -16800,7 +16800,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-result-warning .ant-result-icon {
   color: var(--ant-color-warning);
 }
-.css-var-R0.ant-result {
+.owncast.ant-result {
   --ant-result-title-font-size: 24px;
   --ant-result-subtitle-font-size: 14px;
   --ant-result-icon-font-size: 72px;
@@ -17017,7 +17017,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
     opacity: 0;
   }
 }
-.css-var-R0.ant-progress {
+.owncast.ant-progress {
   --ant-progress-circle-text-color: #12161d;
   --ant-progress-default-color: #1677ff;
   --ant-progress-remaining-color: rgba(0, 0, 0, 0.06);
@@ -17829,7 +17829,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
-.css-var-R0.ant-message-css-var {
+.owncast.ant-message-css-var {
   --ant-message-z-index-popup: 2010;
   --ant-message-content-bg: #ffffff;
   --ant-message-content-padding: 9px 12px;
@@ -18477,7 +18477,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
       calc(var(--ant-margin-xxl) * -1) calc(var(--ant-margin-xxl) * -1)
   );
 }
-.css-var-R0.ant-notification-css-var {
+.owncast.ant-notification-css-var {
   --ant-notification-z-index-popup: 2050;
   --ant-notification-width: 384px;
   --ant-notification-progress-bg: linear-gradient(90deg, #b69cff, #6544e9);
@@ -20178,7 +20178,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
   border-inline-end: var(--ant-line-width) var(--ant-line-type) var(--ant-table-border-color);
   border-bottom: var(--ant-line-width) var(--ant-line-type) var(--ant-table-border-color);
 }
-.css-var-R0.ant-table-css-var {
+.owncast.ant-table-css-var {
   --ant-table-header-bg: #fafafa;
   --ant-table-header-color: #12161d;
   --ant-table-header-sort-active-bg: #f0f0f0;
@@ -20428,7 +20428,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
     opacity: 1;
   }
 }
-.css-var-R0.ant-spin {
+.owncast.ant-spin {
   --ant-spin-content-height: 400px;
   --ant-spin-dot-size: 20px;
   --ant-spin-dot-size-sm: 14px;
@@ -21143,7 +21143,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
     outline-offset 0s,
     outline 0s;
 }
-.css-var-R0.ant-pagination {
+.owncast.ant-pagination {
   --ant-pagination-item-bg: #ffffff;
   --ant-pagination-item-size: 32px;
   --ant-pagination-item-size-sm: 24px;
@@ -22165,7 +22165,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
     margin: calc(var(--ant-margin-xs) / -2);
   }
 }
-.css-var-R0.ant-upload-wrapper {
+.owncast.ant-upload-wrapper {
   --ant-upload-actions-color: rgba(0, 0, 0, 0.45);
   --ant-upload-picture-card-size: 102px;
 }
@@ -22487,7 +22487,7 @@ a:hover .ant-badge.ant-badge .ant-badge-color-gold {
 .ant-zoom-big-leave {
   animation-timing-function: var(--ant-motion-ease-in-out-circ);
 }
-.css-var-R0.ant-popover {
+.owncast.ant-popover {
   --ant-popover-title-min-width: 177px;
   --ant-popover-z-index-popup: 1030;
   --ant-popover-arrow-shadow-width: 7.7989898732233325px;
@@ -22606,7 +22606,7 @@ a[disabled] {
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 }
-.css-var-R0.ant-popover-css-var {
+.owncast.ant-popover-css-var {
   --ant-tooltip-z-index-popup: 1070;
   --ant-tooltip-max-width: 250px;
   --ant-tooltip-arrow-offset-horizontal: 12px;
@@ -22622,7 +22622,7 @@ a[disabled] {
     1.6568542494923806px 100%
   );
 }
-.css-var-R0 {
+.owncast {
   --ant-blue: #1677ff;
   --ant-purple: #722ed1;
   --ant-cyan: #13c2c2;

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -88,7 +88,9 @@
   --theme-color-components-primary-button-text-disabled: var(
     --theme-color-palette-10
   ); /** Neutral gray light */
-  --theme-color-components-primary-button-border: var(--theme-color-action); /** Light secondary */
+  --theme-color-components-primary-button-border: var(
+    --theme-color-action
+  ); /** Text link/secondary light text */
   --theme-color-components-primary-button-border-disabled: var(
     --theme-color-action-disabled
   ); /** Disabled background */
@@ -108,7 +110,7 @@
   --theme-color-components-secondary-button-border-disabled: var(
     --theme-color-action-disabled
   ); /** Disabled background */
-  --theme-color-components-chat-background: var(--theme-color-palette-1); /** Dark primary */
+  --theme-color-components-chat-background: var(--theme-color-palette-1); /** Dark secondary */
   --theme-color-components-chat-text: var(--theme-color-palette-15); /** Lighter background */
   --theme-color-components-content-background: var(
     --theme-color-palette-15

--- a/web/styles/variables.css
+++ b/web/styles/variables.css
@@ -19,28 +19,28 @@
   --border-radius-base: var(--theme-rounded-corners);
   --background-color-light: var(--theme-color-background-main);
   --modal-close-color: var(--theme-color-components-modal-header-text);
-  --primary-color: #6544e9; /* Text link/secondary light text */
-  --primary-color-hover: #2386e2; /* Fun color 1 */
-  --primary-color-active: #7a5cf3; /* Text link hover */
-  --primary-1: #6544e9; /* Text link/secondary light text */
-  --primary-2: #2386e2; /* Fun color 1 */
-  --primary-3: #7a5cf3; /* Text link hover */
-  --primary-4: #da9eff; /* Fun color 2 */
-  --primary-5: #6544e9; /* Text link/secondary light text */
-  --primary-6: #2386e2; /* Fun color 1 */
-  --primary-7: #7a5cf3; /* Text link hover */
-  --primary-8: #da9eff; /* Fun color 2 */
-  --component-background: #e2e8f0; /* Light primary */
-  --body-background: #e2e8f0; /* Light primary */
-  --theme-rounded-corners: 9px; /* How much corners are rounded in places in the UI. */
-  --theme-unknown-1: green; /* This should never be used and it means something is wrong. */
-  --theme-unknown-2: red; /* This should never be used and it means something is wrong. */
+  --primary-color: #6544e9; /** Text link/secondary light text */
+  --primary-color-hover: #2386e2; /** Fun color 1 */
+  --primary-color-active: #7a5cf3; /** Text link hover */
+  --primary-1: #6544e9; /** Text link/secondary light text */
+  --primary-2: #2386e2; /** Fun color 1 */
+  --primary-3: #7a5cf3; /** Text link hover */
+  --primary-4: #da9eff; /** Fun color 2 */
+  --primary-5: #6544e9; /** Text link/secondary light text */
+  --primary-6: #2386e2; /** Fun color 1 */
+  --primary-7: #7a5cf3; /** Text link hover */
+  --primary-8: #da9eff; /** Fun color 2 */
+  --component-background: #e2e8f0; /** Light primary */
+  --body-background: #e2e8f0; /** Light primary */
+  --theme-rounded-corners: 9px; /** How much corners are rounded in places in the UI. */
+  --theme-unknown-1: green; /** This should never be used and it means something is wrong. */
+  --theme-unknown-2: red; /** This should never be used and it means something is wrong. */
   --theme-text-body-font-family: var(
     --font-owncast-body
-  ); /* The font family used for the body text. */
+  ); /** The font family used for the body text. */
   --theme-text-display-font-family: var(
     --font-owncast-display
-  ); /* The font family used for the display/header text. */
+  ); /** The font family used for the display/header text. */
   --theme-color-users-0: var(--color-owncast-user-0);
   --theme-color-users-1: var(--color-owncast-user-1);
   --theme-color-users-2: var(--color-owncast-user-2);
@@ -49,105 +49,105 @@
   --theme-color-users-5: var(--color-owncast-user-5);
   --theme-color-users-6: var(--color-owncast-user-6);
   --theme-color-users-7: var(--color-owncast-user-7);
-  --theme-color-palette-0: var(--color-owncast-palette-0); /* Dark primary */
-  --theme-color-palette-1: var(--color-owncast-palette-1); /* Dark secondary */
-  --theme-color-palette-2: var(--color-owncast-palette-2); /* Dark alternate */
-  --theme-color-palette-3: var(--color-owncast-palette-3); /* Light primary */
-  --theme-color-palette-4: var(--color-owncast-palette-4); /* Light secondary */
-  --theme-color-palette-5: var(--color-owncast-palette-5); /* Light alternate */
-  --theme-color-palette-6: var(--color-owncast-palette-6); /* Text link/secondary light text */
-  --theme-color-palette-7: var(--color-owncast-palette-7); /* Text link hover */
-  --theme-color-palette-8: var(--color-owncast-palette-8); /* Disabled background */
-  --theme-color-palette-9: var(--color-owncast-palette-9); /* Neutral dark */
-  --theme-color-palette-10: var(--color-owncast-palette-10); /* Neutral gray light */
-  --theme-color-palette-11: var(--color-owncast-palette-11); /* Fun color 1 */
-  --theme-color-palette-12: var(--color-owncast-palette-12); /* Fun color 2 */
-  --theme-color-palette-13: var(--color-owncast-palette-13); /* Fun color 3 */
-  --theme-color-palette-14: var(--color-owncast-palette-14); /* Light background */
-  --theme-color-palette-15: var(--color-owncast-palette-15); /* Lighter background */
-  --theme-color-palette-error: var(--color-owncast-palette-error); /* Error */
-  --theme-color-palette-warning: var(--color-owncast-palette-warning); /* Warning */
-  --theme-color-background-main: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-background-light: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-background-header: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-background-secondary: var(--theme-color-palette-1); /* Dark secondary */
-  --theme-color-action: var(--theme-color-palette-6); /* Text link/secondary light text */
-  --theme-color-action-hover: var(--theme-color-palette-7); /* Text link hover */
-  --theme-color-action-disabled: var(--theme-color-palette-8); /* Disabled background */
-  --theme-color-error: var(--theme-color-palette-error); /* Error */
-  --theme-color-warning: var(--theme-color-palette-warning); /* Warning */
-  --theme-color-components-text-on-light: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-components-text-on-dark: var(--theme-color-palette-3); /* Light primary */
+  --theme-color-palette-0: var(--color-owncast-palette-0); /** Dark primary */
+  --theme-color-palette-1: var(--color-owncast-palette-1); /** Dark secondary */
+  --theme-color-palette-2: var(--color-owncast-palette-2); /** Dark alternate */
+  --theme-color-palette-3: var(--color-owncast-palette-3); /** Light primary */
+  --theme-color-palette-4: var(--color-owncast-palette-4); /** Light secondary */
+  --theme-color-palette-5: var(--color-owncast-palette-5); /** Light alternate */
+  --theme-color-palette-6: var(--color-owncast-palette-6); /** Text link/secondary light text */
+  --theme-color-palette-7: var(--color-owncast-palette-7); /** Text link hover */
+  --theme-color-palette-8: var(--color-owncast-palette-8); /** Disabled background */
+  --theme-color-palette-9: var(--color-owncast-palette-9); /** Neutral dark */
+  --theme-color-palette-10: var(--color-owncast-palette-10); /** Neutral gray light */
+  --theme-color-palette-11: var(--color-owncast-palette-11); /** Fun color 1 */
+  --theme-color-palette-12: var(--color-owncast-palette-12); /** Fun color 2 */
+  --theme-color-palette-13: var(--color-owncast-palette-13); /** Fun color 3 */
+  --theme-color-palette-14: var(--color-owncast-palette-14); /** Light background */
+  --theme-color-palette-15: var(--color-owncast-palette-15); /** Lighter background */
+  --theme-color-palette-error: var(--color-owncast-palette-error); /** Error */
+  --theme-color-palette-warning: var(--color-owncast-palette-warning); /** Warning */
+  --theme-color-background-main: var(--theme-color-palette-3); /** Light primary */
+  --theme-color-background-light: var(--theme-color-palette-3); /** Light primary */
+  --theme-color-background-header: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-background-secondary: var(--theme-color-palette-1); /** Dark secondary */
+  --theme-color-action: var(--theme-color-palette-6); /** Text link/secondary light text */
+  --theme-color-action-hover: var(--theme-color-palette-7); /** Text link hover */
+  --theme-color-action-disabled: var(--theme-color-palette-8); /** Disabled background */
+  --theme-color-error: var(--theme-color-palette-error); /** Error */
+  --theme-color-warning: var(--theme-color-palette-warning); /** Warning */
+  --theme-color-components-text-on-light: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-components-text-on-dark: var(--theme-color-palette-3); /** Light primary */
   --theme-color-components-primary-button-background: var(
     --theme-color-action
-  ); /* Text link/secondary light text */
+  ); /** Text link/secondary light text */
   --theme-color-components-primary-button-background-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
-  --theme-color-components-primary-button-text: var(--theme-color-palette-4); /* Light secondary */
+  ); /** Disabled background */
+  --theme-color-components-primary-button-text: var(--theme-color-palette-4); /** Light secondary */
   --theme-color-components-primary-button-text-disabled: var(
     --theme-color-palette-10
-  ); /* Neutral gray light */
-  --theme-color-components-primary-button-border: var(--theme-color-action); /* Light secondary */
+  ); /** Neutral gray light */
+  --theme-color-components-primary-button-border: var(--theme-color-action); /** Light secondary */
   --theme-color-components-primary-button-border-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
+  ); /** Disabled background */
   --theme-color-components-secondary-button-background: var(
     --theme-color-palette-4
-  ); /* Light secondary */
+  ); /** Light secondary */
   --theme-color-components-secondary-button-background-disabled: transparent;
   --theme-color-components-secondary-button-text: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
+  ); /** Disabled background */
   --theme-color-components-secondary-button-text-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
+  ); /** Disabled background */
   --theme-color-components-secondary-button-border: var(
     --theme-color-action
-  ); /* Text link/secondary light text */
+  ); /** Text link/secondary light text */
   --theme-color-components-secondary-button-border-disabled: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
-  --theme-color-components-chat-background: var(--theme-color-palette-1); /* Dark primary */
-  --theme-color-components-chat-text: var(--theme-color-palette-15); /* Lighter background */
+  ); /** Disabled background */
+  --theme-color-components-chat-background: var(--theme-color-palette-1); /** Dark primary */
+  --theme-color-components-chat-text: var(--theme-color-palette-15); /** Lighter background */
   --theme-color-components-content-background: var(
     --theme-color-palette-15
-  ); /* Lighter background */
+  ); /** Lighter background */
   --theme-color-components-modal-header-background: var(
     --theme-color-background-secondary
-  ); /* Dark secondary */
+  ); /** Dark secondary */
   --theme-color-components-modal-header-text: var(
     --theme-color-components-text-on-dark
-  ); /* Light primary */
+  ); /** Light primary */
   --theme-color-components-modal-content-background: var(
     --theme-color-components-content-background
-  ); /* Lighter background */
+  ); /** Lighter background */
   --theme-color-components-modal-content-text: var(
     --theme-color-components-text-on-light
-  ); /* Dark primary */
-  --theme-color-components-menu-background: var(--theme-color-palette-3); /* Light primary */
-  --theme-color-components-menu-item-text: var(--theme-color-palette-0); /* Dark primary */
+  ); /** Dark primary */
+  --theme-color-components-menu-background: var(--theme-color-palette-3); /** Light primary */
+  --theme-color-components-menu-item-text: var(--theme-color-palette-0); /** Dark primary */
   --theme-color-components-menu-item-bg: transparent;
   --theme-color-components-menu-item-hover-bg: rgba(0, 0, 0, 0.05);
   --theme-color-components-menu-item-focus-bg: rgba(0, 0, 0, 0.1);
   --theme-color-components-form-field-background: var(
     --theme-color-palette-4
-  ); /* Light secondary */
+  ); /** Light secondary */
   --theme-color-components-form-field-placeholder: var(
     --theme-color-action-disabled
-  ); /* Disabled background */
-  --theme-color-components-form-field-text: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-components-form-field-border: var(--theme-color-palette-0); /* Dark primary */
-  --theme-color-components-video-background: var(--theme-color-palette-2); /* Dark alternate */
+  ); /** Disabled background */
+  --theme-color-components-form-field-text: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-components-form-field-border: var(--theme-color-palette-0); /** Dark primary */
+  --theme-color-components-video-background: var(--theme-color-palette-2); /** Dark alternate */
   --theme-color-components-video-live-indicator: var(
     --theme-color-action
-  ); /* The Live dot indicator in the control bar of the video player */
+  ); /** The Live dot indicator in the control bar of the video player */
   --theme-color-components-video-status-bar-background: var(
     --theme-color-palette-2
-  ); /* The background color of the video status bar */
+  ); /** The background color of the video status bar */
   --theme-color-components-video-status-bar-foreground: var(
     --theme-color-palette-4
-  ); /* The foreground color of the video status bar */
+  ); /** The foreground color of the video status bar */
   --color-unknown: #7a5cf3;
   --color-unknown-2: #fffffe;
   --color-owncast-user-0: #ff717b;
@@ -158,24 +158,24 @@
   --color-owncast-user-5: #16a8f7;
   --color-owncast-user-6: #9a92ff;
   --color-owncast-user-7: #ff53ff;
-  --color-owncast-palette-0: #12161d; /* Dark primary */
-  --color-owncast-palette-1: #2d3748; /* Dark secondary */
-  --color-owncast-palette-2: #000000; /* Dark alternate */
-  --color-owncast-palette-3: #e2e8f0; /* Light primary */
-  --color-owncast-palette-4: #ffffff; /* Light secondary */
-  --color-owncast-palette-5: #c3dafe; /* Light alternate */
-  --color-owncast-palette-6: #6544e9; /* Text link/secondary light text */
-  --color-owncast-palette-7: #7a5cf3; /* Text link hover */
-  --color-owncast-palette-8: #b6b3c6; /* Disabled background */
-  --color-owncast-palette-9: #39373d; /* Neutral dark */
-  --color-owncast-palette-10: #5d5f72; /* Neutral gray light */
-  --color-owncast-palette-11: #2386e2; /* Fun color 1 */
-  --color-owncast-palette-12: #da9eff; /* Fun color 2 */
-  --color-owncast-palette-13: #42bea6; /* Fun color 3 */
-  --color-owncast-palette-14: #f0f3f8; /* Light background */
-  --color-owncast-palette-15: #eff1f4; /* Lighter background */
-  --color-owncast-palette-error: #ff4b39; /* Error */
-  --color-owncast-palette-warning: #ffc655; /* Warning */
+  --color-owncast-palette-0: #12161d; /** Dark primary */
+  --color-owncast-palette-1: #2d3748; /** Dark secondary */
+  --color-owncast-palette-2: #000000; /** Dark alternate */
+  --color-owncast-palette-3: #e2e8f0; /** Light primary */
+  --color-owncast-palette-4: #ffffff; /** Light secondary */
+  --color-owncast-palette-5: #c3dafe; /** Light alternate */
+  --color-owncast-palette-6: #6544e9; /** Text link/secondary light text */
+  --color-owncast-palette-7: #7a5cf3; /** Text link hover */
+  --color-owncast-palette-8: #b6b3c6; /** Disabled background */
+  --color-owncast-palette-9: #39373d; /** Neutral dark */
+  --color-owncast-palette-10: #5d5f72; /** Neutral gray light */
+  --color-owncast-palette-11: #2386e2; /** Fun color 1 */
+  --color-owncast-palette-12: #da9eff; /** Fun color 2 */
+  --color-owncast-palette-13: #42bea6; /** Fun color 3 */
+  --color-owncast-palette-14: #f0f3f8; /** Light background */
+  --color-owncast-palette-15: #eff1f4; /** Lighter background */
+  --color-owncast-palette-error: #ff4b39; /** Error */
+  --color-owncast-palette-warning: #ffc655; /** Warning */
   --font-owncast-body:
     'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',

--- a/web/tests/staticsTheming.test.tsx
+++ b/web/tests/staticsTheming.test.tsx
@@ -33,16 +33,17 @@ const ApplyTheme: React.FC<{ apply: boolean }> = ({ apply }) => {
 };
 
 // The css variable VALUES for a component land in a style rule keyed by the
-// scope class its provider assigns (the stable cssVar key from
-// antd-default-theme.json), so the message holder's rule is identifiable.
-const messageHolderCss = () => {
+// scope class its provider assigns: the stable cssVar key from
+// antd-default-theme.json for the default theme, and a distinct "-custom"
+// key once appearance customizations exist (so the pre-extracted default
+// values in antd.css cannot win the cascade over the customized ones).
+const messageHolderCss = (expectedKey: string) => {
   const holder = document.querySelector('.ant-message');
   expect(holder).not.toBeNull();
-  const varClass = antdDefaultTheme.cssVar.key;
-  expect(holder.classList).toContain(varClass);
+  expect(holder.classList).toContain(expectedKey);
   return Array.from(document.querySelectorAll('style'))
     .map(s => s.textContent || '')
-    .filter(cssText => cssText.includes(`.${varClass}`))
+    .filter(cssText => cssText.includes(`.${expectedKey}`))
     .join('\n');
 };
 
@@ -62,7 +63,7 @@ describe('static API theming', () => {
     await act(async () => {
       message.open({ content: 'before theme change' });
     });
-    expect(messageHolderCss()).not.toContain(ACTION_COLOR);
+    expect(messageHolderCss(antdDefaultTheme.cssVar.key)).not.toContain(ACTION_COLOR);
 
     // Admin changes the appearance.
     await act(async () => {
@@ -75,10 +76,11 @@ describe('static API theming', () => {
       );
     });
 
-    // A static opened after the change renders with the new primary color.
+    // A static opened after the change renders with the new primary color,
+    // under the customized scope key.
     await act(async () => {
       message.open({ content: 'after theme change' });
     });
-    expect(messageHolderCss()).toContain(ACTION_COLOR);
+    expect(messageHolderCss(`${antdDefaultTheme.cssVar.key}-custom`)).toContain(ACTION_COLOR);
   });
 });

--- a/web/tests/staticsTheming.test.tsx
+++ b/web/tests/staticsTheming.test.tsx
@@ -5,6 +5,7 @@ import { Provider, useSetAtom } from 'jotai';
 import { AntdProvider } from '../components/theme/AntdProvider';
 import { clientConfigStateAtom } from '../components/stores/ClientConfigStore';
 import { makeEmptyClientConfig } from '../interfaces/client-config.model';
+import antdDefaultTheme from '../components/theme/antd-default-theme.json';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({ query: {}, pathname: '/', asPath: '/', push: jest.fn(), replace: jest.fn() }),
@@ -32,13 +33,13 @@ const ApplyTheme: React.FC<{ apply: boolean }> = ({ apply }) => {
 };
 
 // The css variable VALUES for a component land in a style rule keyed by the
-// css-var-* scope class its provider assigns, so the message holder's rule
-// is distinguishable from the main provider tree's.
+// scope class its provider assigns (the stable cssVar key from
+// antd-default-theme.json), so the message holder's rule is identifiable.
 const messageHolderCss = () => {
   const holder = document.querySelector('.ant-message');
   expect(holder).not.toBeNull();
-  const varClass = Array.from(holder.classList).find(c => /^css-var-/.test(c));
-  expect(varClass).toBeDefined();
+  const varClass = antdDefaultTheme.cssVar.key;
+  expect(holder.classList).toContain(varClass);
   return Array.from(document.querySelectorAll('style'))
     .map(s => s.textContent || '')
     .filter(cssText => cssText.includes(`.${varClass}`))


### PR DESCRIPTION
## Problem

On first load of the web interface the header logo briefly renders at its natural image size, covering most of the viewport, before snapping to its normal 40px avatar size. Visible in CI browser-test videos, e.g. [this desktop-online run](https://nyc3.digitaloceanspaces.com/owncast-nightly/ci/browser-test-videos/pr-5050/desktop-online/01_online_live.cy.js.mp4) (~3.6s in).

## Root cause

The antd v6 zeroRuntime setup scopes css-variable *values* with a class derived from React `useId` when `theme.cssVar.key` is unset. That id differs in every render context:

| render context | scope class |
|---|---|
| `extract-antd-styles.js` (generates `styles/antd.css`) | `css-var-R0` |
| Next static-export build (baked into the HTML) | `css-var-R16` |
| browser hydration | its own id |

So at first paint of the static export, `--ant-avatar-container-size-lg` never resolves, `width: var(...)` collapses to `auto`, and the header Avatar renders `/logo` at natural size until hydration injects the runtime values. Every var()-sized antd component was affected; the avatar was the visible casualty.

## Fix

- Pin `cssVar: { key: "owncast" }` in `antd-default-theme.json`, shared by the extraction script and the runtime `AntdProvider`, so the pre-extracted CSS matches the exported HTML at first paint.
- The extraction script now fails loudly if the key is ever removed.
- `styles/antd.css` regenerated: pure rename of the same 40 selectors, `.css-var-R0` -> `.owncast`.

### Before/after (first paint, JS disabled, 1280px viewport, 1200px logo)

| | avatar scope class | header avatar size at first paint |
|---|---|---|
| before | `css-var-R16` (matches nothing) | **1157 x 1157 px** |
| after | `owncast` (matches antd.css) | **42 x 42 px** |

Measured with headless Chrome against the exported HTML with JavaScript disabled (frozen pre-hydration paint). No steady-state visual change: after hydration the page looks identical to before, this only removes the transient flash, which a static screenshot cannot capture.

## Also: repair `npm run build-styles` and chain antd extraction

While wiring `antd:extract` to run automatically with style generation, it turned out `build-styles` has been silently broken since the renovate bump from style-dictionary 3.9.2 to v5 (#4516) — nothing in CI runs it, and v5 removed the `registerFileHeader` API and the `{token.value}` / `{token.comment}` reference suffixes. Second commit:

- Ports `config.js` to the v5 hooks API.
- Migrates token references to the bare `{a.b}` form and inlines cross-referenced comment texts (v5 cannot reference comments).
- Drops dead outputs: the `less` platform / `theme.less` steps (consumer deleted by the antd v6 migration #5011) and the unreferenced ios-swift `Colors.swift` platform.
- `build-styles` now ends with `npm run antd:extract`, so `antd.css` regenerates together with the token-derived stylesheets.

Regenerated `variables.css` / `plugin.css` are **value-identical** (128 variables, equal names, values, and order — verified programmatically). A full comment-text audit against the pre-migration generated output found the inlining introduced zero drift; the only differences are v5 emitting `/** */` doc comments where v3 emitted `/* */`, plus two comments that were already wrong in the old generated output and are deliberately corrected in this PR (flagged by Copilot review).

## Follow-up: customized-theme cascade regression (caught on Chromatic)

The [Theme playground Midnight story](https://629132c6e23893003a9e89c5-mxzaqlumpp.chromatic.com/?path=/story/owncast-style-guide-theme-playground--midnight) showed antd components stuck on the default theme while custom appearance variables applied everywhere else: with the runtime provider using the same `owncast` scope key as the pre-extracted defaults in `antd.css`, the static default values tied with the runtime-injected customized values in the cascade and could win. Fixed by scoping customized themes under a distinct `owncast-custom` key — the default first paint keeps the static key, customized values never collide with the baked-in defaults. Verified in the built storybook: the Midnight primary button renders the preset action color (`#22d3ee`) instead of default purple.

## New: Storybook toolbar theme switcher

That regression was only caught because one story exercised a custom theme. The Theme playground presets now live in a shared module and a Storybook toolbar item (paintbrush) applies any preset to **any** story through the two real theming paths (clientConfig atom → antd tokens, Theme component → `--theme-*` CSS variables), so future theme regressions surface across the whole storybook (and Chromatic snapshots) instead of one story.

## Verification

- Headless-Chrome first-paint measurement above (before/after).
- `npm run build-styles` runs end to end and is deterministic (md5-identical outputs across consecutive runs).
- `jest` (318 tests, includes updating `staticsTheming.test.tsx` to the stable scope key), `tsc --noEmit`, eslint, prettier, shellcheck, and `build-storybook` all pass.

## Screenshots (frozen pre-hydration first paint, JS disabled, 1200px logo)

| Before | After |
|---|---|
| <img width="480" alt="before: giant logo flash" src="https://github.com/user-attachments/assets/185de796-792f-4a98-9366-8f10c5e83520" /> | <img width="480" alt="after: normal 40px header avatar" src="https://github.com/user-attachments/assets/17a1dc6f-e080-42db-99cc-b514bcaea825" /> |

