### PR TITLE
fix(web): update text wrapping and truncation for followers list. 

### DIFF
--- a/web/components/ui/followers/FollowerCollection/FollowerCollection.module.scss
+++ b/web/components/ui/followers/FollowerCollection/FollowerCollection.module.scss
@@ -23,24 +23,6 @@
       justify-content: center;
     }
   }
-
-  @media (640px <= width < 960px) {
-    .followerRow {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  @media (960px <= width < 1280px) {
-    .followerRow {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  @media (width >= 1280px) {
-    .followerRow {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
 }
 
 .noFollowers {

--- a/web/components/ui/followers/FollowerCollection/FollowerCollection.stories.tsx
+++ b/web/components/ui/followers/FollowerCollection/FollowerCollection.stories.tsx
@@ -7,6 +7,23 @@ const mockFollowersData = {
   total: 100,
   results: [
     {
+      link: 'https://fedi-test.example.social/users/feditestc21c4124',
+      name: '',
+      username: 'feditestc21c4124@fedi-test.example.social',
+      image: '',
+      timestamp: '2022-04-28T09:00:00Z',
+      disabledAt: null,
+    },
+    {
+      link: 'https://an-extremely-long-fediverse-server-hostname.example.technology/users/somebodywithareallylongusername',
+      name: 'Somebody With A Really Long Display Name',
+      username:
+        'somebodywithareallylongusername@an-extremely-long-fediverse-server-hostname.example.technology',
+      image: '',
+      timestamp: '2022-04-28T08:00:00Z',
+      disabledAt: null,
+    },
+    {
       link: 'https://sun.minuscule.space/users/mardijker',
       name: 'mardijker',
       username: 'mardijker@sun.minuscule.space',

--- a/web/components/ui/followers/SingleFollower/SingleFollower.module.scss
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.module.scss
@@ -50,9 +50,14 @@
     color: var(--theme-color-components-text-on-light);
     font-size: 1rem;
     line-height: 1.1;
+    max-lines: 2;
     padding-bottom: 5px;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+  }
+
+  .textColumn {
+    flex: 1;
+    min-width: 0;
   }
 }

--- a/web/components/ui/followers/SingleFollower/SingleFollower.module.scss
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.module.scss
@@ -44,16 +44,17 @@
   }
 
   .username {
-    display: block;
     font-family: var(--theme-text-display-font-family);
     font-weight: 600;
     color: var(--theme-color-components-text-on-light);
     font-size: 1rem;
     line-height: 1.1;
-    max-lines: 2;
-    padding-bottom: 5px;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    margin-bottom: 5px;
     overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .textColumn {

--- a/web/components/ui/followers/SingleFollower/SingleFollower.tsx
+++ b/web/components/ui/followers/SingleFollower/SingleFollower.tsx
@@ -22,7 +22,7 @@ export const SingleFollower: FC<SingleFollowerProps> = ({ follower }) => (
             {(follower.name || follower.username).charAt(0).toUpperCase()}
           </Avatar>
         </Col>
-        <Col>
+        <Col className={styles.textColumn}>
           <Row className={styles.username}>
             {follower.name || follower.username.split('@', 2)[0]}
           </Row>


### PR DESCRIPTION
Fixes #5055

Follower cards hard-clipped long names/handles at the card border (no ellipsis), and the follower grid used viewport-width media queries to pick a column count — wrong whenever the chat sidebar narrows the actual content column.

- The card's text column now shrinks properly (`flex: 1; min-width: 0`), so the existing ellipsis rules actually fire; display names wrap to at most 2 lines (line-clamp).
- The fixed-count media queries are removed; the container-driven `auto-fit minmax(280px, 1fr)` grid rule handles every width.
- Storybook mock data now includes long-name/long-handle followers to exercise this.

## Before

<img width="700" alt="before: hard-clipped follower card" src="https://github.com/user-attachments/assets/e9dc1e87-3abd-4388-b0ea-3598ed6a198c" />

## After (PR head, Chromatic build)

500px — single column, handles ellipsized:

<img width="500" alt="after at 500px" src="https://github.com/user-attachments/assets/93322501-4981-42b3-90ca-7da57d7a60e4" />

900px — 3 columns, long display name clamps to 2 lines with ellipsis:

<img width="700" alt="after at 900px" src="https://github.com/user-attachments/assets/de896c7c-ac48-40c8-8cd7-ab239d9771d2" />

Live Storybook for this PR (Chromatic): https://629132c6e23893003a9e89c5-pushcyuncl.chromatic.com/?path=/story/owncast-components-followers-followers-collection--example
