### PR TITLE
ci: post before/after Storybook screenshots on UI PRs

### DIFF
--- a/.github/workflows/browser-testing.yml
+++ b/.github/workflows/browser-testing.yml
@@ -114,7 +114,7 @@ jobs:
           cache: true
 
       - name: Install Google Chrome
-        run: sudo apt-get update && sudo apt-get install google-chrome-stable
+        run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
 
       - name: Run Browser tests
         id: tests

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -1,0 +1,181 @@
+# This workflow posts before/after screenshots of Storybook stories
+# affected by a pull request.
+# Triggers:
+#   - Same-repo PRs touching web components, stories, or styles
+# How it works:
+#   - Builds Storybook from the PR branch
+#   - Maps changed files to their co-located stories via the build's
+#     index.json (see web/.storybook/tools/screenshot-changed-stories.mjs)
+#   - Screenshots each affected story from the published develop Storybook
+#     (https://ui.owncast.online, "before") and the local build ("after")
+#   - Uploads the PNGs to the repo's S3 storage and keeps one sticky PR
+#     comment with the side-by-side images (same pattern as the browser
+#     test videos in browser-testing.yml)
+
+name: Storybook Screenshots
+
+on:
+  pull_request:
+    paths:
+      - 'web/components/**'
+      - 'web/stories/**'
+      - 'web/.storybook/**'
+      - 'web/**/*.css'
+      - 'web/**/*.scss'
+      - 'web/i18n/**'
+      - '.github/workflows/storybook-screenshots.yml'
+
+jobs:
+  storybook-screenshots:
+    runs-on: ubuntu-latest
+    # Needs repo secrets (S3) and a token that can comment; fork PRs have
+    # neither. Renovate PRs are excluded like in chromatic.yml.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'renovate'
+    permissions:
+      contents: read
+      # The screenshot comment step below creates/updates a PR comment.
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: ./web
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content_newer'
+
+      - name: Check out pull request code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Fetch base branch for comparison
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          path: 'web'
+          files_yaml: |
+            src:
+              - '**/*'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.12.0'
+
+      - name: Cache node modules
+        uses: actions/cache@v6
+        env:
+          cache-name: cache-node-modules-storybook-screenshots
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('web/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Capture before/after screenshots
+        id: capture
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.src_all_changed_files }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 -m http.server 6006 --directory storybook-static >/dev/null 2>&1 &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID' EXIT
+          for _ in $(seq 1 50); do
+            curl -sf http://127.0.0.1:6006/index.json >/dev/null && break
+            sleep 0.2
+          done
+          export STATIC_URL=http://127.0.0.1:6006
+          export PUBLIC_BASE_URL="$S3_ENDPOINT/$S3_BUCKET/ci/storybook-screenshots/pr-$PR_NUMBER"
+          node .storybook/tools/screenshot-changed-stories.mjs
+
+      # Publish the PNGs as public URLs from the repo's S3 storage (same
+      # bucket the browser-test videos use). Per-PR prefix is wiped first,
+      # so a PR only ever holds its latest run's screenshots.
+      - name: Publish screenshots
+        id: publish
+        if: steps.capture.outputs.stories != '0'
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET: ${{ secrets.S3_SECRET }}
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_REGION: ${{ secrets.S3_REGION }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$S3_BUCKET" ] || [ -z "$S3_ENDPOINT" ]; then
+            echo "No S3 storage configured; skipping screenshot publishing."
+            exit 0
+          fi
+          export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" AWS_SECRET_ACCESS_KEY="$S3_SECRET"
+          export AWS_DEFAULT_REGION="${S3_REGION:-us-east-1}"
+          PREFIX="ci/storybook-screenshots/pr-$PR_NUMBER"
+          aws s3 rm "s3://$S3_BUCKET/$PREFIX" --recursive --endpoint-url "$S3_ENDPOINT" --quiet || true
+          aws s3 cp screenshot-diff/img "s3://$S3_BUCKET/$PREFIX" --recursive \
+            --acl public-read --content-type image/png --no-progress \
+            --endpoint-url "$S3_ENDPOINT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      # Keep one sticky comment on the PR with the before/after images
+      # (created once, updated in place). When a later push no longer maps
+      # to any story, an existing comment is updated to say so instead of
+      # lingering stale.
+      - name: Comment before/after on the PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STORIES: ${{ steps.capture.outputs.stories }}
+          PUBLISHED: ${{ steps.publish.outputs.published }}
+        run: |
+          MARKER='<!-- storybook-before-after-screenshots -->'
+          existing=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\")) | .id][0] // empty")
+          if [ "${STORIES:-0}" = "0" ]; then
+            if [ -z "$existing" ]; then
+              echo "No affected stories and no existing comment; nothing to do."
+              exit 0
+            fi
+            {
+              echo "$MARKER"
+              echo "## Storybook before/after"
+              echo
+              echo "No Storybook stories map to the changes at $HEAD_SHA."
+            } > /tmp/screenshot-comment.md
+          else
+            if [ "$PUBLISHED" != "true" ]; then
+              echo "Screenshots were not published; skipping comment."
+              exit 0
+            fi
+            {
+              echo "$MARKER"
+              echo "## Storybook before/after"
+              echo
+              echo "Stories affected by this PR at $HEAD_SHA. Left: [develop](https://ui.owncast.online). Right: this PR."
+              echo
+              cat screenshot-diff/comment-body.md
+            } > /tmp/screenshot-comment.md
+          fi
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" -F body=@/tmp/screenshot-comment.md >/dev/null
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" -F body=@/tmp/screenshot-comment.md >/dev/null
+          fi

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -83,7 +83,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Google Chrome
-        run: sudo apt-get update && sudo apt-get install google-chrome-stable
+        run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -82,6 +82,9 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Install Google Chrome
+        run: sudo apt-get update && sudo apt-get install google-chrome-stable
+
       - name: Install dependencies
         run: npm install
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -7,4 +7,5 @@ out
 
 lefthook.yml
 storybook-static
+screenshot-diff
 tsconfig.tsbuildinfo

--- a/web/.knip.json
+++ b/web/.knip.json
@@ -28,6 +28,7 @@
 		"@types/prop-types",
 		"babel-loader",
 		"chromatic",
+		"puppeteer-core",
 		"cypress",
 		"handlebars",
 		"html-webpack-plugin",

--- a/web/.storybook/tools/screenshot-changed-stories.mjs
+++ b/web/.storybook/tools/screenshot-changed-stories.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Capture before/after screenshots of Storybook stories affected by a
+ * change set, for the PR comment posted by
+ * .github/workflows/storybook-screenshots.yml.
+ *
+ * "Before" comes from the published develop Storybook (BASELINE_URL);
+ * "after" from a locally served build of this branch (STATIC_URL). A story
+ * is affected when a changed file lives under the directory of the story's
+ * importPath in the build's index.json -- stories are co-located with
+ * their components in this repo, so a directory match is the whole mapping.
+ *
+ * Environment:
+ *   CHANGED_FILES    whitespace-separated paths relative to web/ (required)
+ *   STATIC_URL       URL serving this branch's storybook-static (required)
+ *   BASELINE_URL     published Storybook to diff against
+ *                    (default https://ui.owncast.online)
+ *   PUBLIC_BASE_URL  public URL prefix where the PNGs will be hosted
+ *   OUT_DIR          output directory (default screenshot-diff)
+ *   CHROME           chrome binary (default google-chrome)
+ *
+ * Writes OUT_DIR/img/<story-id>-{before,after}.png and
+ * OUT_DIR/comment-body.md, and appends stories=<n> to $GITHUB_OUTPUT.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import puppeteer from 'puppeteer-core';
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} is required`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const STATIC_URL = required('STATIC_URL');
+const BASELINE_URL = process.env.BASELINE_URL || 'https://ui.owncast.online';
+const PUBLIC_BASE_URL = process.env.PUBLIC_BASE_URL || '';
+const OUT_DIR = process.env.OUT_DIR || 'screenshot-diff';
+const CHROME = process.env.CHROME || 'google-chrome';
+
+// Keep the comment reviewable on sweeping changes; Chromatic covers the rest.
+const MAX_STORIES = 12;
+const WIDTH = 1000;
+const HEIGHT = 800;
+
+const changed = (process.env.CHANGED_FILES || '').split(/\s+/).filter(Boolean);
+
+async function loadIndex(base) {
+  const res = await fetch(`${base}/index.json`);
+  if (!res.ok) throw new Error(`${base}/index.json: HTTP ${res.status}`);
+  return res.json();
+}
+
+const [head, baseline] = await Promise.all([
+  loadIndex(STATIC_URL),
+  loadIndex(BASELINE_URL).catch(err => {
+    console.warn(`baseline index unavailable (${err.message}); treating all stories as new`);
+    return { entries: {} };
+  }),
+]);
+
+const affected = Object.values(head.entries)
+  .filter(entry => entry.type === 'story')
+  .filter(entry => {
+    const dir = path.posix.dirname(entry.importPath.replace(/^\.\//, ''));
+    return changed.some(file => file.startsWith(`${dir}/`));
+  })
+  .sort((a, b) => a.id.localeCompare(b.id));
+
+const shown = affected.slice(0, MAX_STORIES);
+const omitted = affected.slice(MAX_STORIES);
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true });
+fs.mkdirSync(path.join(OUT_DIR, 'img'), { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME,
+  args: ['--no-sandbox', '--disable-gpu', '--hide-scrollbars', '--force-device-scale-factor=1'],
+});
+
+async function capture(base, id, file) {
+  const url = `${base}/iframe.html?id=${id}&viewMode=story`;
+  const page = await browser.newPage();
+  try {
+    await page.setViewport({ width: WIDTH, height: HEIGHT });
+    for (let attempt = 1; ; attempt += 1) {
+      await page.goto(url, { waitUntil: 'networkidle0', timeout: 60_000 });
+      try {
+        // Storybook flips the body to sb-show-main and populates
+        // #storybook-root once the story (including msw-gated fetches) has
+        // rendered; an error lands on sb-show-errordisplay instead.
+        await page.waitForFunction(
+          () =>
+            document.body.classList.contains('sb-show-main') &&
+            document.getElementById('storybook-root')?.childElementCount > 0,
+          { timeout: 30_000 }
+        );
+        break;
+      } catch {
+        // Chunk loads from the hosted baseline occasionally fail
+        // transiently; reload once, then capture whatever is on screen
+        // (a Storybook error page is useful evidence too).
+        if (attempt >= 2) {
+          console.warn(`story never rendered for ${id} at ${base}; capturing current state`);
+          break;
+        }
+      }
+    }
+    await page.evaluate(() => document.fonts.ready);
+    // Brief settle for image decoding/paint after render is signaled.
+    await new Promise(resolve => setTimeout(resolve, 500));
+    await page.screenshot({ path: file, fullPage: true });
+    return true;
+  } catch (err) {
+    console.warn(`capture failed for ${id} at ${base}: ${err.message}`);
+    return false;
+  } finally {
+    await page.close();
+  }
+}
+
+const lines = [];
+for (const story of shown) {
+  const isNew = !baseline.entries?.[story.id];
+  const beforeName = `${story.id}-before.png`;
+  const afterName = `${story.id}-after.png`;
+  const hasBefore =
+    !isNew && (await capture(BASELINE_URL, story.id, path.join(OUT_DIR, 'img', beforeName)));
+  const hasAfter = await capture(STATIC_URL, story.id, path.join(OUT_DIR, 'img', afterName));
+
+  const img = (name, alt) => `<img src="${PUBLIC_BASE_URL}/${name}" alt="${alt}" width="420">`;
+  const beforeCell = isNew
+    ? '_new story_'
+    : hasBefore
+      ? img(beforeName, `${story.title} — ${story.name} on develop`)
+      : '_capture failed_';
+  const afterCell = hasAfter
+    ? img(afterName, `${story.title} — ${story.name} on this PR`)
+    : '_capture failed_';
+
+  lines.push(
+    `#### [${story.title} — ${story.name}](${BASELINE_URL}/?path=/story/${story.id})`,
+    '',
+    '| develop | this PR |',
+    '| --- | --- |',
+    `| ${beforeCell} | ${afterCell} |`,
+    ''
+  );
+}
+if (omitted.length) {
+  lines.push(`_+${omitted.length} more affected ${omitted.length === 1 ? 'story' : 'stories'} not shown._`, '');
+}
+fs.writeFileSync(path.join(OUT_DIR, 'comment-body.md'), lines.join('\n'));
+await browser.close();
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `stories=${affected.length}\n`);
+}
+console.log(`${affected.length} affected stories; captured ${shown.length}.`);

--- a/web/.storybook/tools/screenshot-changed-stories.mjs
+++ b/web/.storybook/tools/screenshot-changed-stories.mjs
@@ -22,6 +22,7 @@
  * Writes OUT_DIR/img/<story-id>-{before,after}.png and
  * OUT_DIR/comment-body.md, and appends stories=<n> to $GITHUB_OUTPUT.
  */
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import puppeteer from 'puppeteer-core';
@@ -39,7 +40,12 @@ const STATIC_URL = required('STATIC_URL');
 const BASELINE_URL = process.env.BASELINE_URL || 'https://ui.owncast.online';
 const PUBLIC_BASE_URL = process.env.PUBLIC_BASE_URL || '';
 const OUT_DIR = process.env.OUT_DIR || 'screenshot-diff';
-const CHROME = process.env.CHROME || 'google-chrome';
+// puppeteer-core stats executablePath literally, so resolve bare command
+// names (e.g. the runner's google-chrome) through PATH first.
+const chromeEnv = process.env.CHROME || 'google-chrome';
+const CHROME = chromeEnv.includes('/')
+  ? chromeEnv
+  : execFileSync('/bin/sh', ['-c', `command -v ${chromeEnv}`], { encoding: 'utf8' }).trim();
 
 // Keep the comment reviewable on sweeping changes; Chromatic covers the rest.
 const MAX_STORIES = 12;

--- a/web/components/ui/followers/FollowerCollection/FollowerCollection.module.scss
+++ b/web/components/ui/followers/FollowerCollection/FollowerCollection.module.scss
@@ -52,5 +52,3 @@
 .pagination {
   margin: 1rem;
 }
-
-/* temp: exercise storybook-screenshots workflow (reverted next commit) */

--- a/web/components/ui/followers/FollowerCollection/FollowerCollection.module.scss
+++ b/web/components/ui/followers/FollowerCollection/FollowerCollection.module.scss
@@ -52,3 +52,5 @@
 .pagination {
   margin: 1rem;
 }
+
+/* temp: exercise storybook-screenshots workflow (reverted next commit) */

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -107,6 +107,7 @@
         "npm": "^11.0.0",
         "postcss": "^8.4.31",
         "prettier": "3.9.5",
+        "puppeteer-core": "^22.15.0",
         "sass": "1.100.0",
         "storybook": "^10.4.6",
         "style-dictionary": "5.5.0",
@@ -7516,7 +7517,6 @@
       "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "debug": "^4.3.5",
         "extract-zip": "^2.0.1",
@@ -7540,7 +7540,6 @@
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -7556,7 +7555,6 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7575,7 +7573,6 @@
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -9840,8 +9837,7 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
@@ -12306,7 +12302,6 @@
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -12695,7 +12690,6 @@
       "integrity": "sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -12721,7 +12715,6 @@
       "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -12732,7 +12725,6 @@
       "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -12743,7 +12735,6 @@
       "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "b4a": "^1.8.1",
         "streamx": "^2.25.0",
@@ -12772,7 +12763,6 @@
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -12788,7 +12778,6 @@
       "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -12831,7 +12820,6 @@
       "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -13192,7 +13180,6 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -13587,7 +13574,6 @@
       "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
@@ -13603,7 +13589,6 @@
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -15190,7 +15175,6 @@
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -15438,7 +15422,6 @@
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -15526,8 +15509,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.2.2",
@@ -16209,7 +16191,6 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -17285,7 +17266,6 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -17307,7 +17287,6 @@
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -17484,7 +17463,6 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -18148,7 +18126,6 @@
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -20187,7 +20164,6 @@
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -24583,8 +24559,7 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/mpd-parser": {
       "version": "1.4.0",
@@ -24876,7 +24851,6 @@
       "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -27481,7 +27455,6 @@
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -27502,7 +27475,6 @@
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -28292,7 +28264,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -28334,7 +28305,6 @@
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -28355,7 +28325,6 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -28365,8 +28334,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
@@ -28446,7 +28414,6 @@
       "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@puppeteer/browsers": "2.3.0",
         "chromium-bidi": "0.6.3",
@@ -30882,7 +30849,6 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -30928,7 +30894,6 @@
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
@@ -30944,7 +30909,6 @@
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -32715,7 +32679,6 @@
       "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -32731,7 +32694,6 @@
       "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "bare-fs": "^4.5.5",
@@ -32745,7 +32707,6 @@
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -33073,8 +33034,7 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -33688,7 +33648,6 @@
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -34091,8 +34050,7 @@
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
       "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -128,6 +128,7 @@
     "npm": "^11.0.0",
     "postcss": "^8.4.31",
     "prettier": "3.9.5",
+    "puppeteer-core": "^22.15.0",
     "sass": "1.100.0",
     "storybook": "^10.4.6",
     "style-dictionary": "5.5.0",


### PR DESCRIPTION
When a PR touches web components, stories, or styles, CI now posts a sticky comment with side-by-side before/after screenshots of the affected Storybook stories — "before" from the published develop Storybook at https://ui.owncast.online, "after" from a build of the PR branch.

## How it works

- A new `storybook-screenshots.yml` workflow (same path filters as chromatic.yml, same-repo PRs only, renovate excluded) builds Storybook from the PR branch.
- `web/.storybook/tools/screenshot-changed-stories.mjs` maps changed files to stories via the build's `index.json`: a story is affected when a changed file lives under its `importPath` directory (stories are co-located with their components). Capped at 12 stories per comment.
- Each affected story is screenshotted at `iframe.html?id=<story>` on both sides with puppeteer-core driving the system Chrome, waiting for Storybook's rendered signal (`body.sb-show-main` + populated `#storybook-root`) so msw-backed stories capture actual data instead of a loading spinner. New stories are labeled instead of diffed.
- PNGs are published to the repo's S3 storage under `ci/storybook-screenshots/pr-<n>/` (prefix wiped per run) and one sticky marker comment shows the images — the same publish/comment pattern as the browser-test videos in browser-testing.yml. If a later push no longer maps to any story, the comment is updated to say so.

`puppeteer-core` is added as an explicit devDependency (already present transitively via mdx-mermaid, same version, no browser download — it uses the runner's Chrome).

## Verification

- Ran the full pipeline locally: built Storybook, served it, ran the script with the followers-component change set as fixture — 3 stories mapped, all 6 captures render real content (follower grids with msw mock data, pagination), verified by inspecting the PNGs.
- Negative control: a change set touching no story directory maps to 0 stories and produces no comment.
- All five comment-step branches (create/update, zero-story update, unpublished skip) exercised with a stubbed `gh`.
- actionlint (with shellcheck), prettier, eslint, and knip all clean; `npx npm@latest ci --dry-run` confirms the lockfile stays npm-ci-valid.

Since this workflow only runs on `pull_request`, this PR itself exercises it end to end — it touches `web/.storybook/**`, so the comment below (if the mapping finds affected stories) or the "no stories" behavior is live evidence.