### PR TITLE
ci(nightly): publish standalone install binaries to object storage

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,7 +1,8 @@
 # See https://docs.earthly.dev/ci-integration/vendor-specific-guides/gh-actions-integration
 # for details.
 
-# This workflow builds the development container image
+# This workflow builds the development container image and, on nightly and
+# manual runs, standalone install binaries published to object storage.
 # Triggers:
 #   - Nightly scheduled builds (2 AM UTC)
 #   - Manual runs from the Actions tab (workflow_dispatch)
@@ -89,3 +90,53 @@ jobs:
           timeout_minutes: 20
           max_attempts: 3
           command: ./build/develop/container.sh
+
+      - name: Build and publish standalone binaries
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET: ${{ secrets.S3_SECRET }}
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_REGION: ${{ secrets.S3_REGION }}
+        run: |
+          if [ -z "$S3_BUCKET" ] || [ -z "$S3_ENDPOINT" ]; then
+            echo "No S3 storage configured; skipping standalone binary publish."
+            exit 0
+          fi
+          VERSION="$(date +%Y%m%d)-nightly"
+          # No --ci here: it implies --no-output, which would suppress the
+          # SAVE ... AS LOCAL zips in dist/.
+          earthly -P +package-all --version="$VERSION"
+
+          export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" AWS_SECRET_ACCESS_KEY="$S3_SECRET"
+          export AWS_DEFAULT_REGION="${S3_REGION:-us-east-1}"
+          PREFIX="nightly"
+          aws s3 rm "s3://$S3_BUCKET/$PREFIX/" --recursive --endpoint-url "$S3_ENDPOINT" --quiet || true
+
+          {
+            printf '%s\n' \
+              '<!doctype html>' \
+              '<html lang="en">' \
+              '<head><meta charset="utf-8"><title>Owncast nightly builds</title></head>' \
+              '<body>' \
+              '<h1>Owncast nightly builds</h1>' \
+              "<p>Version $VERSION, built $(date -u +'%Y-%m-%d %H:%M UTC') from commit" \
+              "<a href=\"https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA\">${GITHUB_SHA:0:7}</a>.</p>" \
+              '<ul>'
+            for f in dist/*.zip; do
+              name=$(basename "$f")
+              size=$(du -h "$f" | cut -f1)
+              printf '<li><a href="%s/%s/%s/%s">%s</a> (%s)</li>\n' \
+                "$S3_ENDPOINT" "$S3_BUCKET" "$PREFIX" "$name" "$name" "$size"
+            done
+            printf '%s\n' '</ul>' '</body></html>'
+          } > dist/index.html
+
+          for f in dist/*.zip; do
+            aws s3 cp "$f" "s3://$S3_BUCKET/$PREFIX/$(basename "$f")" --endpoint-url "$S3_ENDPOINT" \
+              --acl public-read --content-type application/zip --no-progress
+          done
+          aws s3 cp dist/index.html "s3://$S3_BUCKET/$PREFIX/index.html" --endpoint-url "$S3_ENDPOINT" \
+            --acl public-read --content-type text/html --no-progress
+          echo "Published binaries: $S3_ENDPOINT/$S3_BUCKET/$PREFIX/index.html"

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -109,6 +109,12 @@ jobs:
           # SAVE ... AS LOCAL zips in dist/.
           earthly -P +package-all --version="$VERSION"
 
+          zips=(dist/*.zip)
+          if [ ! -e "${zips[0]}" ]; then
+            echo "Earthly produced no zips in dist/; refusing to publish."
+            exit 1
+          fi
+
           export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY" AWS_SECRET_ACCESS_KEY="$S3_SECRET"
           export AWS_DEFAULT_REGION="${S3_REGION:-us-east-1}"
           PREFIX="nightly"


### PR DESCRIPTION
## What

Extends the nightly build workflow (`container.yaml`) so scheduled and manually-dispatched runs also build standalone install binaries, not just the Docker image.

- Runs the existing Earthly `+package-all` target, cross-compiling all six supported platforms (linux 64/32-bit, arm64, arm7; macOS amd64/arm64). The `+build` layers are shared with `+docker-all`, so Earthly's cache makes the second invocation cheap in the same job.
- Uploads the resulting `owncast-YYYYMMDD-nightly-<platform>.zip` files to the `nightly/` prefix of the CI object storage bucket (same `S3_*` secrets and `aws` CLI pattern as the browser-test video publishing). The prefix is wiped each run so only the current nightly is listed.
- Generates and uploads an `index.html` listing download links (with sizes, build date, and source commit) so testers have one stable URL to pull from: `$S3_ENDPOINT/$S3_BUCKET/nightly/index.html`.

The step is gated to `schedule`/`workflow_dispatch` events and skips cleanly when the S3 secrets are absent (forks).

Note: `--ci` is intentionally omitted from this Earthly invocation — it implies `--no-output`, which would suppress the `SAVE ... AS LOCAL` zips in `dist/`.

## Testing

- `actionlint` passes on the workflow.
- The `index.html` generation script was exercised locally against a fake `dist/` of six zips; output verified.
- The publish path only runs on schedule/dispatch, so it can be verified end-to-end with a `workflow_dispatch` run after merge.