### PR TITLE
feat(web): filter the plugin browse tab by permission, author, and category

### DIFF
--- a/web/components/admin/plugins/BrowseRegistry.module.scss
+++ b/web/components/admin/plugins/BrowseRegistry.module.scss
@@ -12,6 +12,22 @@
   padding: 32px 0;
 }
 
+// Filter bar (permissions / author / category Selects) above the
+// plugin cards.
+.filters {
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.filterSelect {
+  min-width: 200px;
+}
+
+// Category tag rendered in the card title line, after the version.
+.categoryTag {
+  margin-left: 8px;
+}
+
 .list {
   width: 100%;
 }

--- a/web/components/admin/plugins/BrowseRegistry.stories.tsx
+++ b/web/components/admin/plugins/BrowseRegistry.stories.tsx
@@ -27,6 +27,9 @@ const plugins: RegistryPlugin[] = [
     // Plugin homepage: rendered as a hostname link under the summary.
     homepage: 'https://github.com/owncast/welcome-bot',
     tags: ['chat', 'moderation'],
+    // Category slug from the canonical taxonomy; rendered as a Tag on
+    // the card and drives the category filter in the filter bar.
+    category: 'chat-bots',
     latest: {
       version: '1.2.0',
       sizeBytes: 48 * 1024,
@@ -40,6 +43,7 @@ const plugins: RegistryPlugin[] = [
     authorName: 'Owncast Community',
     summary: 'Shows the currently playing track pulled from an external music service.',
     tags: ['overlay'],
+    category: 'overlays',
     latest: {
       version: '0.4.1',
       sizeBytes: 120 * 1024,
@@ -55,6 +59,21 @@ const plugins: RegistryPlugin[] = [
     latest: {
       version: '2.0.0',
       sizeBytes: 256 * 1024,
+    },
+  },
+  {
+    // Same author as Welcome Bot so the author filter matches more
+    // than one card; distinct category/permissions for those filters.
+    slug: 'stream-stats',
+    name: 'Stream Stats',
+    authorName: 'Gabe Kangas',
+    authorURL: 'https://gabekangas.com',
+    summary: 'Tracks viewer counts over time and charts them in the admin.',
+    category: 'analytics',
+    latest: {
+      version: '0.9.0',
+      sizeBytes: 64 * 1024,
+      manifest: { permissions: ['server.read', 'storage.kv'] },
     },
   },
 ];

--- a/web/components/admin/plugins/BrowseRegistry.tsx
+++ b/web/components/admin/plugins/BrowseRegistry.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Alert, Button, Card, Empty, Space, Spin, Tag, Tooltip, Typography } from 'antd';
+import React, { useMemo, useState } from 'react';
+import { Alert, Button, Card, Empty, Select, Space, Spin, Tag, Tooltip, Typography } from 'antd';
 import { useTranslation } from 'next-export-i18n';
 import { Localization } from '../../../types/localization';
 import { isPluginUpdateAvailable } from '../../../utils/apis';
@@ -18,6 +18,8 @@ const { Text, Paragraph } = Typography;
 // fields without breaking the page.
 export type RegistryManifest = {
   permissions?: string[];
+  // Canonical category slug (e.g. "chat-bots"); see categoryNameKey.
+  category?: string;
 };
 
 // One published plugin in the registry's browse payload. Mirrors the
@@ -38,6 +40,10 @@ export type RegistryPlugin = {
   // Optional public link for the author (personal site, GitHub
   // profile). When present the "by ..." line links to it.
   authorURL?: string;
+  // Canonical category slug from the taxonomy below. The registry
+  // surfaces it top-level (mirrored from the manifest) so the Browse
+  // tab can filter without digging into `latest`.
+  category?: string;
   latest?: {
     version: string;
     sizeBytes?: number;
@@ -48,6 +54,26 @@ export type RegistryPlugin = {
     manifest?: RegistryManifest;
   };
   versions?: { version: string }[];
+};
+
+// Canonical plugin category taxonomy (slug -> label i18n key). Keep in
+// lock-step with the registry's category list and
+// Localization.Admin.Plugins.Categories.
+const categoryNameKey: Record<string, string> = {
+  'chat-bots': Localization.Admin.Plugins.Categories.chatBots,
+  'chat-filters': Localization.Admin.Plugins.Categories.chatFilters,
+  moderation: Localization.Admin.Plugins.Categories.moderation,
+  authentication: Localization.Admin.Plugins.Categories.authentication,
+  themes: Localization.Admin.Plugins.Categories.themes,
+  overlays: Localization.Admin.Plugins.Categories.overlays,
+  notifications: Localization.Admin.Plugins.Categories.notifications,
+  integrations: Localization.Admin.Plugins.Categories.integrations,
+  video: Localization.Admin.Plugins.Categories.video,
+  analytics: Localization.Admin.Plugins.Categories.analytics,
+  games: Localization.Admin.Plugins.Categories.games,
+  'admin-utilities': Localization.Admin.Plugins.Categories.adminUtilities,
+  examples: Localization.Admin.Plugins.Categories.examples,
+  other: Localization.Admin.Plugins.Categories.other,
 };
 
 export type BrowseRegistryProps = {
@@ -91,6 +117,64 @@ export const BrowseRegistry = ({
   // Names whose install POST is in flight; per-card spinner state so
   // multiple installs don't lock the whole list.
   const [installing, setInstalling] = useState<Set<string>>(new Set());
+  // Client-side filters over the loaded registry payload. Options are
+  // derived from what's actually present so the controls never offer a
+  // choice that matches nothing.
+  const [permissionFilter, setPermissionFilter] = useState<string[]>([]);
+  const [authorFilter, setAuthorFilter] = useState<string>();
+  const [categoryFilter, setCategoryFilter] = useState<string>();
+
+  // Unknown slug falls back to the raw value so a newer registry
+  // doesn't render blank labels.
+  const categoryLabel = (slug: string) => (categoryNameKey[slug] ? t(categoryNameKey[slug]) : slug);
+
+  const permissionOptions = useMemo(() => {
+    const perms = new Set<string>();
+    registry.forEach(p => p.latest?.manifest?.permissions?.forEach(perm => perms.add(perm)));
+    return [...perms]
+      .map(perm => ({
+        value: perm,
+        label: permissionNameKey[perm] ? t(permissionNameKey[perm]) : perm,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [registry, t]);
+
+  const authorOptions = useMemo(() => {
+    const authors = new Set<string>();
+    registry.forEach(p => p.authorName && authors.add(p.authorName));
+    return [...authors].sort().map(name => ({ value: name, label: name }));
+  }, [registry]);
+
+  // Empty until the registry starts publishing categories; the whole
+  // category Select is hidden in that case.
+  const categoryOptions = useMemo(() => {
+    const categories = new Set<string>();
+    registry.forEach(p => p.category && categories.add(p.category));
+    return [...categories]
+      .map(slug => ({
+        value: slug,
+        label: categoryNameKey[slug] ? t(categoryNameKey[slug]) : slug,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [registry, t]);
+
+  const filteredRegistry = useMemo(
+    () =>
+      registry.filter(p => {
+        if (authorFilter && p.authorName !== authorFilter) return false;
+        if (categoryFilter && p.category !== categoryFilter) return false;
+        const perms = p.latest?.manifest?.permissions ?? [];
+        // A plugin matches when it declares ALL selected permissions.
+        return permissionFilter.every(perm => perms.includes(perm));
+      }),
+    [registry, permissionFilter, authorFilter, categoryFilter],
+  );
+
+  const clearFilters = () => {
+    setPermissionFilter([]);
+    setAuthorFilter(undefined);
+    setCategoryFilter(undefined);
+  };
 
   const triggerInstall = async (plugin: RegistryPlugin) => {
     if (!plugin.latest) return;
@@ -146,128 +230,184 @@ export const BrowseRegistry = ({
     return <Empty description={t(Localization.Admin.Plugins.browseEmpty)} />;
   }
 
+  const filterBar = (
+    <Space wrap className={s.filters}>
+      <Select
+        mode="multiple"
+        allowClear
+        className={s.filterSelect}
+        placeholder={t(Localization.Admin.Plugins.browseFilterPermissions)}
+        value={permissionFilter}
+        onChange={setPermissionFilter}
+        options={permissionOptions}
+      />
+      <Select
+        allowClear
+        className={s.filterSelect}
+        placeholder={t(Localization.Admin.Plugins.browseFilterAuthor)}
+        value={authorFilter}
+        onChange={setAuthorFilter}
+        options={authorOptions}
+      />
+      {categoryOptions.length > 0 && (
+        <Select
+          allowClear
+          className={s.filterSelect}
+          placeholder={t(Localization.Admin.Plugins.browseFilterCategory)}
+          value={categoryFilter}
+          onChange={setCategoryFilter}
+          options={categoryOptions}
+        />
+      )}
+    </Space>
+  );
+
+  // Filters excluded everything: keep the bar visible so the admin can
+  // adjust, and offer a one-click reset.
+  if (filteredRegistry.length === 0) {
+    return (
+      <>
+        {filterBar}
+        <Empty description={t(Localization.Admin.Plugins.browseFilteredEmpty)}>
+          <Button onClick={clearFilters}>{t(Localization.Admin.Plugins.browseClearFilters)}</Button>
+        </Empty>
+      </>
+    );
+  }
+
   return (
-    <Space direction="vertical" size="middle" className={s.list}>
-      {registry.map(plugin => {
-        const installedVersion = installedVersions.get(plugin.slug);
-        const latestVersion = plugin.latest?.version;
-        const isInstalled = installedVersion !== undefined;
-        const hasUpdate = isInstalled && isPluginUpdateAvailable(installedVersion, latestVersion);
+    <>
+      {filterBar}
+      <Space direction="vertical" size="middle" className={s.list}>
+        {filteredRegistry.map(plugin => {
+          const installedVersion = installedVersions.get(plugin.slug);
+          const latestVersion = plugin.latest?.version;
+          const isInstalled = installedVersion !== undefined;
+          const hasUpdate = isInstalled && isPluginUpdateAvailable(installedVersion, latestVersion);
 
-        let actionButton: React.ReactNode;
-        if (!plugin.latest) {
-          actionButton = <Button disabled>{t(Localization.Admin.Plugins.browseInstall)}</Button>;
-        } else if (hasUpdate) {
-          actionButton = (
-            <Button
-              type="primary"
-              loading={installing.has(plugin.slug)}
-              onClick={() => triggerInstall(plugin)}
-            >
-              {t(Localization.Admin.Plugins.browseUpdate, { version: latestVersion })}
-            </Button>
-          );
-        } else if (isInstalled) {
-          actionButton = <Button disabled>{t(Localization.Admin.Plugins.browseInstalled)}</Button>;
-        } else {
-          actionButton = (
-            <Button
-              type="primary"
-              loading={installing.has(plugin.slug)}
-              onClick={() => triggerInstall(plugin)}
-            >
-              {t(Localization.Admin.Plugins.browseInstall)}
-            </Button>
-          );
-        }
+          let actionButton: React.ReactNode;
+          if (!plugin.latest) {
+            actionButton = <Button disabled>{t(Localization.Admin.Plugins.browseInstall)}</Button>;
+          } else if (hasUpdate) {
+            actionButton = (
+              <Button
+                type="primary"
+                loading={installing.has(plugin.slug)}
+                onClick={() => triggerInstall(plugin)}
+              >
+                {t(Localization.Admin.Plugins.browseUpdate, { version: latestVersion })}
+              </Button>
+            );
+          } else if (isInstalled) {
+            actionButton = (
+              <Button disabled>{t(Localization.Admin.Plugins.browseInstalled)}</Button>
+            );
+          } else {
+            actionButton = (
+              <Button
+                type="primary"
+                loading={installing.has(plugin.slug)}
+                onClick={() => triggerInstall(plugin)}
+              >
+                {t(Localization.Admin.Plugins.browseInstall)}
+              </Button>
+            );
+          }
 
-        return (
-          <Card key={plugin.slug} size="small">
-            <div className={s.row}>
-              <div className={s.icon}>
-                {plugin.iconURL ? (
-                  <img src={plugin.iconURL} alt="" />
-                ) : (
-                  <PuzzlePiece className={s.iconFallback} />
-                )}
-              </div>
-              <div className={s.body}>
-                <div className={s.title}>
-                  <strong>{plugin.name}</strong>
-                  {plugin.latest && <Text type="secondary"> v{plugin.latest.version}</Text>}
-                  {plugin.latest?.sizeBytes ? (
-                    <Text type="secondary"> &middot; {readableBytes(plugin.latest.sizeBytes)}</Text>
-                  ) : null}
+          return (
+            <Card key={plugin.slug} size="small">
+              <div className={s.row}>
+                <div className={s.icon}>
+                  {plugin.iconURL ? (
+                    <img src={plugin.iconURL} alt="" />
+                  ) : (
+                    <PuzzlePiece className={s.iconFallback} />
+                  )}
                 </div>
-                {plugin.authorName &&
-                  (plugin.authorURL ? (
+                <div className={s.body}>
+                  <div className={s.title}>
+                    <strong>{plugin.name}</strong>
+                    {plugin.latest && <Text type="secondary"> v{plugin.latest.version}</Text>}
+                    {plugin.latest?.sizeBytes ? (
+                      <Text type="secondary">
+                        {' '}
+                        &middot; {readableBytes(plugin.latest.sizeBytes)}
+                      </Text>
+                    ) : null}
+                    {plugin.category && (
+                      <Tag className={s.categoryTag}>{categoryLabel(plugin.category)}</Tag>
+                    )}
+                  </div>
+                  {plugin.authorName &&
+                    (plugin.authorURL ? (
+                      <Typography.Link
+                        href={plugin.authorURL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={s.author}
+                      >
+                        {t(Localization.Admin.Plugins.browseAuthor, { name: plugin.authorName })}
+                      </Typography.Link>
+                    ) : (
+                      <Text type="secondary" className={s.author}>
+                        {t(Localization.Admin.Plugins.browseAuthor, { name: plugin.authorName })}
+                      </Text>
+                    ))}
+                  {plugin.summary && <Paragraph className={s.summary}>{plugin.summary}</Paragraph>}
+                  {plugin.homepage && (
                     <Typography.Link
-                      href={plugin.authorURL}
+                      href={plugin.homepage}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={s.author}
+                      className={s.homepage}
                     >
-                      {t(Localization.Admin.Plugins.browseAuthor, { name: plugin.authorName })}
+                      {formatLinkHostname(plugin.homepage)}
                     </Typography.Link>
-                  ) : (
-                    <Text type="secondary" className={s.author}>
-                      {t(Localization.Admin.Plugins.browseAuthor, { name: plugin.authorName })}
-                    </Text>
-                  ))}
-                {plugin.summary && <Paragraph className={s.summary}>{plugin.summary}</Paragraph>}
-                {plugin.homepage && (
-                  <Typography.Link
-                    href={plugin.homepage}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={s.homepage}
-                  >
-                    {formatLinkHostname(plugin.homepage)}
-                  </Typography.Link>
-                )}
-                {plugin.previewURL && (
-                  <img
-                    className={s.preview}
-                    src={plugin.previewURL}
-                    alt={t(Localization.Admin.Plugins.browsePreviewAlt, { name: plugin.name })}
-                    loading="lazy"
-                  />
-                )}
-                {plugin.latest?.manifest?.permissions &&
-                  plugin.latest.manifest.permissions.length > 0 && (
-                    // Permissions the plugin's manifest declares, so the
-                    // admin sees the scope they'd be granting before
-                    // clicking Install. Each tag shows the short label;
-                    // the tooltip carries the full plain-language
-                    // description. Same maps as the Installed tab so the
-                    // copy stays in lock-step between views.
-                    <Space size={[4, 4]} wrap className={s.permissions}>
-                      {plugin.latest.manifest.permissions.map(perm => {
-                        const nameKey = permissionNameKey[perm];
-                        const descKey = permissionDescriptionKey[perm];
-                        const label = nameKey ? t(nameKey) : perm;
-                        const description = descKey ? t(descKey) : perm;
-                        return (
-                          <Tooltip key={perm} title={description}>
-                            <Tag>{label}</Tag>
-                          </Tooltip>
-                        );
-                      })}
+                  )}
+                  {plugin.previewURL && (
+                    <img
+                      className={s.preview}
+                      src={plugin.previewURL}
+                      alt={t(Localization.Admin.Plugins.browsePreviewAlt, { name: plugin.name })}
+                      loading="lazy"
+                    />
+                  )}
+                  {plugin.latest?.manifest?.permissions &&
+                    plugin.latest.manifest.permissions.length > 0 && (
+                      // Permissions the plugin's manifest declares, so the
+                      // admin sees the scope they'd be granting before
+                      // clicking Install. Each tag shows the short label;
+                      // the tooltip carries the full plain-language
+                      // description. Same maps as the Installed tab so the
+                      // copy stays in lock-step between views.
+                      <Space size={[4, 4]} wrap className={s.permissions}>
+                        {plugin.latest.manifest.permissions.map(perm => {
+                          const nameKey = permissionNameKey[perm];
+                          const descKey = permissionDescriptionKey[perm];
+                          const label = nameKey ? t(nameKey) : perm;
+                          const description = descKey ? t(descKey) : perm;
+                          return (
+                            <Tooltip key={perm} title={description}>
+                              <Tag>{label}</Tag>
+                            </Tooltip>
+                          );
+                        })}
+                      </Space>
+                    )}
+                  {plugin.tags && plugin.tags.length > 0 && (
+                    <Space size={[4, 4]} wrap>
+                      {plugin.tags.map(tag => (
+                        <Tag key={tag}>{tag}</Tag>
+                      ))}
                     </Space>
                   )}
-                {plugin.tags && plugin.tags.length > 0 && (
-                  <Space size={[4, 4]} wrap>
-                    {plugin.tags.map(tag => (
-                      <Tag key={tag}>{tag}</Tag>
-                    ))}
-                  </Space>
-                )}
+                </div>
+                <div className={s.actions}>{actionButton}</div>
               </div>
-              <div className={s.actions}>{actionButton}</div>
-            </div>
-          </Card>
-        );
-      })}
-    </Space>
+            </Card>
+          );
+        })}
+      </Space>
+    </>
   );
 };

--- a/web/components/admin/plugins/BrowseRegistry.tsx
+++ b/web/components/admin/plugins/BrowseRegistry.tsx
@@ -41,8 +41,8 @@ export type RegistryPlugin = {
   // profile). When present the "by ..." line links to it.
   authorURL?: string;
   // Canonical category slug from the taxonomy below. The registry
-  // surfaces it top-level (mirrored from the manifest) so the Browse
-  // tab can filter without digging into `latest`.
+  // mirrors it top-level from the manifest; older registries only
+  // embed it inside latest.manifest, so read via pluginCategory().
   category?: string;
   latest?: {
     version: string;
@@ -75,6 +75,11 @@ const categoryNameKey: Record<string, string> = {
   examples: Localization.Admin.Plugins.Categories.examples,
   other: Localization.Admin.Plugins.Categories.other,
 };
+
+// A plugin's category, preferring the registry's top-level mirror and
+// falling back to the embedded manifest so catalogs from a registry
+// that predates the top-level field still filter.
+const pluginCategory = (p: RegistryPlugin) => p.category ?? p.latest?.manifest?.category;
 
 export type BrowseRegistryProps = {
   // Map of installed plugin slug -> currently-installed version, so
@@ -149,7 +154,10 @@ export const BrowseRegistry = ({
   // category Select is hidden in that case.
   const categoryOptions = useMemo(() => {
     const categories = new Set<string>();
-    registry.forEach(p => p.category && categories.add(p.category));
+    registry.forEach(p => {
+      const category = pluginCategory(p);
+      if (category) categories.add(category);
+    });
     return [...categories]
       .map(slug => ({
         value: slug,
@@ -162,7 +170,7 @@ export const BrowseRegistry = ({
     () =>
       registry.filter(p => {
         if (authorFilter && p.authorName !== authorFilter) return false;
-        if (categoryFilter && p.category !== categoryFilter) return false;
+        if (categoryFilter && pluginCategory(p) !== categoryFilter) return false;
         const perms = p.latest?.manifest?.permissions ?? [];
         // A plugin matches when it declares ALL selected permissions.
         return permissionFilter.every(perm => perms.includes(perm));
@@ -334,8 +342,8 @@ export const BrowseRegistry = ({
                         &middot; {readableBytes(plugin.latest.sizeBytes)}
                       </Text>
                     ) : null}
-                    {plugin.category && (
-                      <Tag className={s.categoryTag}>{categoryLabel(plugin.category)}</Tag>
+                    {pluginCategory(plugin) && (
+                      <Tag className={s.categoryTag}>{categoryLabel(pluginCategory(plugin))}</Tag>
                     )}
                   </div>
                   {plugin.authorName &&

--- a/web/i18n/en/translation.json
+++ b/web/i18n/en/translation.json
@@ -186,6 +186,22 @@
 			"title": "News & Updates from Owncast"
 		},
 		"Plugins": {
+			"Categories": {
+				"adminUtilities": "Admin utilities",
+				"analytics": "Analytics & stats",
+				"authentication": "Authentication",
+				"chatBots": "Chat bots",
+				"chatFilters": "Chat filters",
+				"examples": "Examples",
+				"games": "Games & fun",
+				"integrations": "Integrations",
+				"moderation": "Moderation",
+				"notifications": "Notifications",
+				"other": "Other",
+				"overlays": "Overlays & widgets",
+				"themes": "Themes",
+				"video": "Video & streaming"
+			},
 			"PermissionNames": {
 				"authGate": "Gate viewer access",
 				"chatFilter": "Filter chat messages",
@@ -238,7 +254,12 @@
 			"approveButton": "Approve",
 			"approveTooltip": "Approve the expanded permission set and load the plugin.",
 			"browseAuthor": "by {{name}}",
+			"browseClearFilters": "Clear filters",
 			"browseEmpty": "No plugins are available in the registry yet.",
+			"browseFilterAuthor": "Filter by author",
+			"browseFilterCategory": "Filter by category",
+			"browseFilterPermissions": "Filter by permissions",
+			"browseFilteredEmpty": "No plugins match the current filters.",
 			"browseInstall": "Install",
 			"browseInstalled": "Installed",
 			"browsePreviewAlt": "{{name}} preview screenshot",

--- a/web/tests/BrowseRegistryFilters.test.tsx
+++ b/web/tests/BrowseRegistryFilters.test.tsx
@@ -2,9 +2,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { BrowseRegistry, RegistryPlugin } from '../components/admin/plugins/BrowseRegistry';
 
 // rc-select's useOpen schedules its dropdown-close through
-// `new MessageChannel()` (port1.onmessage + port2.postMessage), which
-// jsdom does not provide. Node's worker_threads ports keep the process
-// alive, so fake just the surface rc-select uses with a timer.
+// `new MessageChannel()` (port1.onmessage + port2.postMessage). Node's
+// worker_threads-backed ports keep the jest process alive, so always
+// replace the channel with a timer-based fake that covers just the
+// surface rc-select uses.
 class TestMessageChannel {
   port1: { onmessage: ((ev: { data: unknown }) => void) | null } = { onmessage: null };
 
@@ -14,7 +15,7 @@ class TestMessageChannel {
     },
   };
 }
-globalThis.MessageChannel ??= TestMessageChannel as unknown as typeof MessageChannel;
+globalThis.MessageChannel = TestMessageChannel as unknown as typeof MessageChannel;
 
 jest.mock('next-export-i18n', () => ({
   useTranslation: () => ({
@@ -31,11 +32,12 @@ const plugins: RegistryPlugin[] = [
     latest: { version: '1.0.0', manifest: { permissions: ['chat.send', 'storage.kv'] } },
   },
   {
+    // Category only inside the embedded manifest: exercises the
+    // fallback for registries that predate the top-level field.
     slug: 'beta',
     name: 'Beta Plugin',
     authorName: 'Bob',
-    category: 'overlays',
-    latest: { version: '2.0.0', manifest: { permissions: ['chat.send'] } },
+    latest: { version: '2.0.0', manifest: { permissions: ['chat.send'], category: 'overlays' } },
   },
   {
     slug: 'gamma',
@@ -122,7 +124,16 @@ describe('BrowseRegistry filters', () => {
   });
 
   it('hides the category select when no plugin carries a category', () => {
-    renderRegistry(plugins.map(p => ({ ...p, category: undefined })));
+    renderRegistry(
+      plugins.map(p => ({
+        ...p,
+        category: undefined,
+        latest: p.latest && {
+          ...p.latest,
+          manifest: p.latest.manifest && { ...p.latest.manifest, category: undefined },
+        },
+      })),
+    );
     expect(screen.queryByText(CATEGORY_PLACEHOLDER)).toBeNull();
     expect(screen.getByText(AUTHOR_PLACEHOLDER)).toBeInTheDocument();
   });
@@ -130,5 +141,10 @@ describe('BrowseRegistry filters', () => {
   it('renders a category tag on cards that have one', () => {
     renderRegistry([plugins[0]]);
     expect(screen.getByText('Admin.Plugins.Categories.chatBots')).toBeInTheDocument();
+  });
+
+  it('renders a category tag from the embedded manifest fallback', () => {
+    renderRegistry([plugins[1]]);
+    expect(screen.getByText('Admin.Plugins.Categories.overlays')).toBeInTheDocument();
   });
 });

--- a/web/tests/BrowseRegistryFilters.test.tsx
+++ b/web/tests/BrowseRegistryFilters.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BrowseRegistry, RegistryPlugin } from '../components/admin/plugins/BrowseRegistry';
+
+// rc-select's useOpen schedules its dropdown-close through
+// `new MessageChannel()` (port1.onmessage + port2.postMessage), which
+// jsdom does not provide. Node's worker_threads ports keep the process
+// alive, so fake just the surface rc-select uses with a timer.
+class TestMessageChannel {
+  port1: { onmessage: ((ev: { data: unknown }) => void) | null } = { onmessage: null };
+
+  port2 = {
+    postMessage: (data: unknown) => {
+      setTimeout(() => this.port1.onmessage?.({ data }), 0);
+    },
+  };
+}
+globalThis.MessageChannel ??= TestMessageChannel as unknown as typeof MessageChannel;
+
+jest.mock('next-export-i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const plugins: RegistryPlugin[] = [
+  {
+    slug: 'alpha',
+    name: 'Alpha Plugin',
+    authorName: 'Alice',
+    category: 'chat-bots',
+    latest: { version: '1.0.0', manifest: { permissions: ['chat.send', 'storage.kv'] } },
+  },
+  {
+    slug: 'beta',
+    name: 'Beta Plugin',
+    authorName: 'Bob',
+    category: 'overlays',
+    latest: { version: '2.0.0', manifest: { permissions: ['chat.send'] } },
+  },
+  {
+    slug: 'gamma',
+    name: 'Gamma Plugin',
+    latest: { version: '3.0.0' },
+  },
+];
+
+const renderRegistry = (registry: RegistryPlugin[] = plugins) =>
+  render(
+    <BrowseRegistry
+      installedVersions={new Map()}
+      registry={registry}
+      registryLoading={false}
+      registryError={null}
+      onInstall={async () => {}}
+    />,
+  );
+
+// The t() mock is an identity function, so placeholders and option
+// labels render as their raw Localization keys.
+const PERMISSIONS_PLACEHOLDER = 'Admin.Plugins.browseFilterPermissions';
+const AUTHOR_PLACEHOLDER = 'Admin.Plugins.browseFilterAuthor';
+const CATEGORY_PLACEHOLDER = 'Admin.Plugins.browseFilterCategory';
+
+const openSelect = (placeholder: string) => {
+  // antd v6 renders the placeholder inside .ant-select-content; the
+  // dropdown opens on mousedown of the .ant-select root.
+  fireEvent.mouseDown(screen.getByText(placeholder).closest('.ant-select') as HTMLElement);
+};
+
+const clickOption = (title: string) => {
+  const option = document.querySelector(`.ant-select-item-option[title="${title}"]`);
+  expect(option).not.toBeNull();
+  fireEvent.click(option!);
+};
+
+const visiblePlugins = () =>
+  ['Alpha Plugin', 'Beta Plugin', 'Gamma Plugin'].filter(name => screen.queryByText(name) !== null);
+
+describe('BrowseRegistry filters', () => {
+  it('renders all plugins and the filter bar', () => {
+    renderRegistry();
+    expect(visiblePlugins()).toEqual(['Alpha Plugin', 'Beta Plugin', 'Gamma Plugin']);
+    expect(screen.getByText(PERMISSIONS_PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.getByText(AUTHOR_PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.getByText(CATEGORY_PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it('filters by permission requiring ALL selected permissions', () => {
+    renderRegistry();
+    openSelect(PERMISSIONS_PLACEHOLDER);
+    clickOption('Admin.Plugins.PermissionNames.chatSend');
+    expect(visiblePlugins()).toEqual(['Alpha Plugin', 'Beta Plugin']);
+    clickOption('Admin.Plugins.PermissionNames.storageKv');
+    expect(visiblePlugins()).toEqual(['Alpha Plugin']);
+  });
+
+  it('filters by author', () => {
+    renderRegistry();
+    openSelect(AUTHOR_PLACEHOLDER);
+    clickOption('Bob');
+    expect(visiblePlugins()).toEqual(['Beta Plugin']);
+  });
+
+  it('filters by category using taxonomy display names', () => {
+    renderRegistry();
+    openSelect(CATEGORY_PLACEHOLDER);
+    clickOption('Admin.Plugins.Categories.chatBots');
+    expect(visiblePlugins()).toEqual(['Alpha Plugin']);
+  });
+
+  it('shows the filtered-empty state and clears filters', () => {
+    renderRegistry();
+    // Alice + overlays matches nothing: Alice authored a chat-bot.
+    openSelect(AUTHOR_PLACEHOLDER);
+    clickOption('Alice');
+    openSelect(CATEGORY_PLACEHOLDER);
+    clickOption('Admin.Plugins.Categories.overlays');
+    expect(visiblePlugins()).toEqual([]);
+    expect(screen.getByText('Admin.Plugins.browseFilteredEmpty')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Admin.Plugins.browseClearFilters'));
+    expect(visiblePlugins()).toEqual(['Alpha Plugin', 'Beta Plugin', 'Gamma Plugin']);
+  });
+
+  it('hides the category select when no plugin carries a category', () => {
+    renderRegistry(plugins.map(p => ({ ...p, category: undefined })));
+    expect(screen.queryByText(CATEGORY_PLACEHOLDER)).toBeNull();
+    expect(screen.getByText(AUTHOR_PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it('renders a category tag on cards that have one', () => {
+    renderRegistry([plugins[0]]);
+    expect(screen.getByText('Admin.Plugins.Categories.chatBots')).toBeInTheDocument();
+  });
+});

--- a/web/types/localization.ts
+++ b/web/types/localization.ts
@@ -505,6 +505,11 @@ export const Localization = {
       browseUnavailableRetry: 'Admin.Plugins.browseUnavailableRetry',
       browsePreviewAlt: 'Admin.Plugins.browsePreviewAlt',
       browseAuthor: 'Admin.Plugins.browseAuthor',
+      browseFilterPermissions: 'Admin.Plugins.browseFilterPermissions',
+      browseFilterAuthor: 'Admin.Plugins.browseFilterAuthor',
+      browseFilterCategory: 'Admin.Plugins.browseFilterCategory',
+      browseFilteredEmpty: 'Admin.Plugins.browseFilteredEmpty',
+      browseClearFilters: 'Admin.Plugins.browseClearFilters',
       updateAvailable: 'Admin.Plugins.updateAvailable',
       updateConfirmTitle: 'Admin.Plugins.updateConfirmTitle',
       updateConfirmOk: 'Admin.Plugins.updateConfirmOk',
@@ -547,6 +552,25 @@ export const Localization = {
       notFoundTitle: 'Admin.Plugins.notFoundTitle',
       notFoundDescription: 'Admin.Plugins.notFoundDescription',
       errorTitle: 'Admin.Plugins.errorTitle',
+      // Display names for the canonical plugin category taxonomy. Slugs
+      // mirror the registry's category list; keep in lock-step with the
+      // categoryNameKey map in BrowseRegistry.tsx.
+      Categories: {
+        chatBots: 'Admin.Plugins.Categories.chatBots',
+        chatFilters: 'Admin.Plugins.Categories.chatFilters',
+        moderation: 'Admin.Plugins.Categories.moderation',
+        authentication: 'Admin.Plugins.Categories.authentication',
+        themes: 'Admin.Plugins.Categories.themes',
+        overlays: 'Admin.Plugins.Categories.overlays',
+        notifications: 'Admin.Plugins.Categories.notifications',
+        integrations: 'Admin.Plugins.Categories.integrations',
+        video: 'Admin.Plugins.Categories.video',
+        analytics: 'Admin.Plugins.Categories.analytics',
+        games: 'Admin.Plugins.Categories.games',
+        adminUtilities: 'Admin.Plugins.Categories.adminUtilities',
+        examples: 'Admin.Plugins.Categories.examples',
+        other: 'Admin.Plugins.Categories.other',
+      },
       // Permission identifiers mirror services/plugins/hostfns.go; keep
       // the keys here in lock-step with those constants.
       Permissions: {


### PR DESCRIPTION
The Browse plugins tab lists everything in the catalog with no way to narrow it down. As the registry grows that stops scaling, so this adds a filter bar: filter by the permissions a plugin asks for, by author, and by category.

- Permissions is a multi-select over the permissions declared across the loaded catalog, labeled with the same human-readable names the install confirmation uses. A plugin matches when it declares all of the selected permissions.
- Author and category are single selects. Options only come from what the catalog actually contains, so the controls never offer a choice that matches nothing.
- Category uses the registry's new category taxonomy (chat bots, authentication, themes, chat filters, moderation, overlays, notifications, integrations, video, analytics, games, admin utilities, examples). The registry side is in owncast/owncast-yp. Until the public registry starts sending categories the category select stays hidden, so this degrades cleanly against today's catalog. Cards show a category tag when one is present.
- Filtering everything away shows an empty state with a one-click "Clear filters" button.

All strings go through the localization system. Filtering is client-side over the already-fetched list, no new requests.

Added a jest test covering the filter combinations (permission AND semantics, author, category, clearing) and the hidden-category-select case, and extended the Storybook story data so the filters are exercisable there.

## Screenshots

Before:

<img width="700" alt="before, no filters" src="https://github.com/user-attachments/assets/b2ba6424-657f-496f-8aeb-d731ea6cce77" />

After, with the filter bar and category tags:

<img width="700" alt="after, filter bar and category tags" src="https://github.com/user-attachments/assets/d84be35c-3c4c-41d1-83ea-00e09016fb06" />

Filtered by category:

<img width="700" alt="filtered by category" src="https://github.com/user-attachments/assets/254d611e-f326-49f9-891f-7578345ad3ba" />

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
