### PR TITLE
test(web): cover personalized content refresh after first-time chat registration

### DIFF
--- a/web/tests/clientConfigStore.test.tsx
+++ b/web/tests/clientConfigStore.test.tsx
@@ -156,6 +156,33 @@ describe('ClientConfigStore', () => {
     expect(store.get(currentUserAtom).displayName).toBe('rando');
   });
 
+  it('refreshes personalized page content after first-time registration when chat is disabled', async () => {
+    // Server-rendered hydration delivers the anonymous visitor's config, so
+    // the only API config fetch is the post-registration refresh that picks
+    // up viewer-personalized plugin content (e.g. a viewer gate's page
+    // content keyed to the new access token).
+    hydrationWindow.configHydration = JSON.stringify({
+      ...testConfig,
+      chatDisabled: true,
+      extraPageContent: '<p>visitor</p>',
+    });
+    hydrationWindow.statusHydration = JSON.stringify(makeEmptyServerStatus());
+    const services = makeServices();
+    services.configService.getConfig.mockResolvedValue({
+      ...testConfig,
+      chatDisabled: true,
+      extraPageContent: '<p>registered viewer</p>',
+    });
+    const store = renderStore(services);
+
+    await waitFor(() => {
+      expect(store.get(clientConfigStateAtom).extraPageContent).toBe('<p>registered viewer</p>');
+    });
+    expect(services.chatService.registerUser).toHaveBeenCalledTimes(1);
+    expect(services.configService.getConfig).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('accessToken')).toBe('new-token');
+  });
+
   it('reuses a saved access token instead of re-registering', async () => {
     localStorage.setItem('accessToken', 'saved-token');
     const services = makeServices();


### PR DESCRIPTION
This rescues a test that was stranded in my working tree as an untracked `web/tests/ClientConfigStore.test.tsx`. That filename collides with the existing `clientConfigStore.test.tsx` from #5053 in casing only, which trips TypeScript's consistent-casing check (TS1149) and breaks every local `next build` while the file sits on disk. The test itself was worth keeping: nothing in the existing suite covered the personalized-content refresh path.

- Folds the scenario into the existing ClientConfigStore suite using its helpers: config arrives via server-rendered hydration with chat disabled and visitor page content, first-time chat registration completes, and the store makes exactly one config refetch that applies the viewer-personalized page content and stores the access token.
- The orphaned PascalCase file is deleted, so local web builds work again.

`jest` (11 tests in the suite), `tsc --noEmit`, eslint, and prettier all pass, and the pre-push web build succeeds again with the collision gone.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
