### PR TITLE
Don't show the big unmute button when the viewer muted on purpose

### DIFF
--- a/test/automated/browser/cypress/e2e/online/07_online_unmute_button.cy.js
+++ b/test/automated/browser/cypress/e2e/online/07_online_unmute_button.cy.js
@@ -1,0 +1,74 @@
+import { setup } from '../../support/setup.js';
+import filterTests from '../../support/filterTests';
+
+setup();
+
+// The big unmute overlay must only appear when the player itself muted
+// playback (the muted autoplay fallback), never when the viewer muted on
+// purpose. A deliberate mute, in-session or restored from a previous visit,
+// keeps the player clean. Desktop-only: these tests click the control bar,
+// which stays hidden on mobile viewports until tapped.
+filterTests(['desktop'], () => {
+	describe('Big unmute button', () => {
+		// The autoplay test flips the instance config, so put it back for
+		// whoever runs after us against the same datastore.
+		after(() => {
+			cy.setConfig('autoplay', 'off');
+		});
+
+		it('Does not appear when the viewer mutes manually', () => {
+			cy.visit('http://localhost:8080', {
+				onBeforeLoad(win) {
+					win.localStorage.removeItem('owncast_volume');
+				},
+			});
+			cy.get('.vjs-big-play-button').click();
+			cy.get('video', { timeout: 15000 }).should(
+				($v) => expect($v[0].paused).to.be.false,
+			);
+			cy.get('.vjs-mute-control').click();
+			cy.get('video').should(($v) => expect($v[0].muted).to.be.true);
+			cy.get('.vjs-big-unmute-button').should('not.be.visible');
+		});
+
+		it('Does not appear when a persisted mute is restored', () => {
+			cy.visit('http://localhost:8080', {
+				onBeforeLoad(win) {
+					win.localStorage.setItem('owncast_volume', '0');
+				},
+			});
+			cy.get('.vjs-big-play-button').click();
+			cy.get('video', { timeout: 15000 }).should(
+				($v) => expect($v[0].paused).to.be.false,
+			);
+			cy.get('video').should(($v) => expect($v[0].volume).to.equal(0));
+			cy.get('.vjs-big-unmute-button').should('not.be.visible');
+		});
+
+		it('Appears when autoplay had to fall back to muted, and unmutes on click', () => {
+			cy.setConfig('autoplay', 'always');
+			cy.visit('http://localhost:8080', {
+				onBeforeLoad(win) {
+					win.localStorage.removeItem('owncast_volume');
+					// Mimic a browser that blocks audible autoplay so video.js
+					// takes its muted fallback path.
+					const original = win.HTMLMediaElement.prototype.play;
+					win.HTMLMediaElement.prototype.play = function play() {
+						if (!this.muted) {
+							return Promise.reject(
+								new win.DOMException('autoplay blocked', 'NotAllowedError'),
+							);
+						}
+						return original.call(this);
+					};
+				},
+			});
+			cy.get('video', { timeout: 15000 }).should(
+				($v) => expect($v[0].muted && !$v[0].paused).to.be.true,
+			);
+			cy.get('.vjs-big-unmute-button').should('be.visible').click();
+			cy.get('video').should(($v) => expect($v[0].muted).to.be.false);
+			cy.get('.vjs-big-unmute-button').should('not.be.visible');
+		});
+	});
+});

--- a/web/components/video/OwncastPlayer/OwncastPlayer.tsx
+++ b/web/components/video/OwncastPlayer/OwncastPlayer.tsx
@@ -49,6 +49,13 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
   const clockSkew = useAtomValue(clockSkewAtom);
   const { t } = useTranslation();
 
+  // A persisted volume of 0 is a mute the viewer chose on a previous visit
+  // (handleVolume stores muted as 0). Restoring it is a manual mute, not an
+  // autoplay one, so the big unmute overlay stays away. Read once at render;
+  // guarded because this runs during render (no window during SSR).
+  const savedVolume = typeof window !== 'undefined' ? getLocalStorage(PLAYER_VOLUME) : null;
+  const startedMutedByViewer = savedVolume !== null && Number(savedVolume) === 0;
+
   const setSavedVolume = () => {
     try {
       playerRef.current.volume(getLocalStorage(PLAYER_VOLUME) || 1);
@@ -216,16 +223,35 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
     }
     player.addChild(unmuteButton);
 
-    // Mirror the big play button: show a large, obvious unmute affordance only
-    // while the stream is autoplaying muted. When paused, the native big play
-    // button already covers that case, so this stays hidden.
+    // Show the big unmute affordance only while playback is inaudible *because
+    // the player muted it* (video.js's 'any' autoplay fallback, or an embed
+    // that asked to start muted). A viewer who muted deliberately, whether via
+    // the control bar, the "m" key, or a persisted mute restored from a
+    // previous visit (startedMutedByViewer), keeps a clean player: no giant
+    // overlay. The flag is cleared the moment the player becomes audible, so
+    // any later mute is by definition manual and never re-shows the button.
+    const inaudible = () => player.muted() || player.volume() === 0;
+    // Autoplay can win the race against this ready handler (the source is set
+    // at player construction), so seed the flag from current state: already
+    // playing inaudibly at ready means the player did it, since no user
+    // gesture can have happened yet.
+    let mutedByAutoplay = !startedMutedByViewer && !player.paused() && inaudible();
+
     const updateUnmuteButton = () => {
-      if (!player.paused() && (player.muted() || player.volume() === 0)) {
+      if (!inaudible()) {
+        mutedByAutoplay = false;
+      }
+      if (mutedByAutoplay && !player.paused() && inaudible()) {
         unmuteButton.show();
       } else {
         unmuteButton.hide();
       }
     };
+
+    player.on('autoplay-success', () => {
+      mutedByAutoplay = !startedMutedByViewer && inaudible();
+      updateUnmuteButton();
+    });
 
     player.on(['playing', 'pause', 'ended', 'volumechange'], updateUnmuteButton);
     updateUnmuteButton();
@@ -269,11 +295,11 @@ export const OwncastPlayer: FC<OwncastPlayerProps> = ({
   // as volume 0. Starting muted (embed request) or at volume 0 makes a
   // sound-only autoplay attempt succeed silently in Firefox, which allows
   // inaudible autoplay, so the mapping needs to know about it.
-  const savedVolume = typeof window !== 'undefined' ? getLocalStorage(PLAYER_VOLUME) : null;
+  const startsInaudible = initiallyMuted || startedMutedByViewer;
   const autoplayMode = autoplayModeForSetting(autoplay, {
     prefersReducedMotion,
     saveData: navConnection?.saveData === true,
-    startsInaudible: initiallyMuted || (savedVolume !== null && Number(savedVolume) === 0),
+    startsInaudible,
   });
 
   const videoJsOptions = {


### PR DESCRIPTION
<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->

The big unmute button that shows when a stream autoplays muted was also showing up when somebody muted the stream on purpose. If you just want to watch a stream muted you'd have a giant overlay sitting on top of the video the whole time.

Now the player keeps track of whether it was the one that muted playback. The overlay only shows when the muted autoplay fallback kicked in, and once the player becomes audible any later mute is treated as manual and the overlay never comes back.

- Track a "the player muted itself" flag in the unmute button setup, seeded at player ready and set by video.js's autoplay-success event.
- Treat a persisted volume of 0 as the viewer's own mute from a previous visit, so returning muted viewers don't get the overlay either.
- Embeds that ask to start muted still get the button, since that's a muted start the viewer didn't choose.
- Added browser tests covering all three paths: muting manually, coming back with a saved mute, and the real muted autoplay fallback.

No new strings, it reuses the existing localized unmute label.

Muted by autoplay, the unmute button shows like before:

![unmute-autoplay-muted.png](https://github.com/user-attachments/assets/7b6e9fa2-9cfb-4d36-84a9-49396955b46f)

Muted manually, the video stays clean:

![unmute-manual-muted.png](https://github.com/user-attachments/assets/5d3ffe99-8fb8-4cc7-93d2-df744409ca3d)
