### PR TITLE
Add opt-in automatic HTTPS support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,17 @@ type Config struct {
 	// FollowerValidationInterval is how often the follower validation
 	// job runs. A zero value means use the package default.
 	FollowerValidationInterval time.Duration
+
+	// AutoHTTPSHost is the public hostname used for automatic HTTPS and
+	// for seeding the stored server URL. Populated by main.go from the
+	// OWNCAST_HOST_NAME environment variable.
+	AutoHTTPSHost string
+
+	// AutoHTTPSEnabled turns on the automatic HTTPS (Let's Encrypt)
+	// listeners when AutoHTTPSHost is also set. Populated by main.go from
+	// the OWNCAST_ENABLE_AUTO_HTTPS environment variable. Currently
+	// intended for packaged (apt) installs, which set both variables.
+	AutoHTTPSEnabled bool
 }
 
 // NewDefault returns a *Config populated with the default startup values.

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -183,6 +184,7 @@ func main() {
 	federatedserversrepository.SetGlobalInstance(federatedServersRepository)
 
 	handleCommandLineFlags(cfg, configRepository)
+	handleAutoHTTPSEnvironment(cfg, configRepository)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -483,6 +485,41 @@ func handleCommandLineFlags(cfg *config.Config, configRepository configrepositor
 		cfg.FollowerValidationInterval = time.Duration(*followerValidationIntervalSecs) * time.Second
 		log.Printf("Follower validation interval set to %v", cfg.FollowerValidationInterval)
 	}
+}
+
+// handleAutoHTTPSEnvironment reads the automatic HTTPS environment
+// variables. OWNCAST_HOST_NAME is the server's public hostname: when set it
+// is persisted as the stored server URL (https://<host>), following the same
+// persist-on-boot pattern as the command line flags above.
+// OWNCAST_ENABLE_AUTO_HTTPS additionally enables the automatic HTTPS
+// listeners (see webserver/router). Both are currently set by packaged
+// (apt) installs via /etc/default/owncast.
+func handleAutoHTTPSEnvironment(cfg *config.Config, configRepository configrepository.ConfigRepository) {
+	enabled := strings.EqualFold(os.Getenv("OWNCAST_ENABLE_AUTO_HTTPS"), "true")
+	host := strings.ToLower(strings.TrimSpace(os.Getenv("OWNCAST_HOST_NAME")))
+
+	if host == "" {
+		if enabled {
+			log.Errorln("OWNCAST_ENABLE_AUTO_HTTPS is set but OWNCAST_HOST_NAME is not. Automatic HTTPS is disabled.")
+		}
+		return
+	}
+
+	if strings.ContainsAny(host, "/:@ \t") {
+		log.Errorf("OWNCAST_HOST_NAME %q is not a bare hostname (no scheme, port or path). Automatic HTTPS is disabled.", host)
+		return
+	}
+
+	serverURL := "https://" + host
+	if existing := configRepository.GetServerURL(); existing != "" && existing != serverURL {
+		log.Infof("Replacing the stored server URL %s with %s from OWNCAST_HOST_NAME. Unset the environment variable to manage it in the admin.", existing, serverURL)
+	}
+	if err := configRepository.SetServerURL(serverURL); err != nil {
+		log.Errorln("Error saving the server URL from OWNCAST_HOST_NAME.", err)
+	}
+
+	cfg.AutoHTTPSHost = host
+	cfg.AutoHTTPSEnabled = enabled
 }
 
 func configureLogging(logDirectory string, enableDebugFeatures bool, enableVerboseLogging bool) {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -497,6 +498,7 @@ func handleCommandLineFlags(cfg *config.Config, configRepository configrepositor
 func handleAutoHTTPSEnvironment(cfg *config.Config, configRepository configrepository.ConfigRepository) {
 	enabled := strings.EqualFold(os.Getenv("OWNCAST_ENABLE_AUTO_HTTPS"), "true")
 	host := strings.ToLower(strings.TrimSpace(os.Getenv("OWNCAST_HOST_NAME")))
+	host = strings.TrimSuffix(host, ".")
 
 	if host == "" {
 		if enabled {
@@ -505,12 +507,13 @@ func handleAutoHTTPSEnvironment(cfg *config.Config, configRepository configrepos
 		return
 	}
 
-	if strings.ContainsAny(host, "/:@ \t") {
-		log.Errorf("OWNCAST_HOST_NAME %q is not a bare hostname (no scheme, port or path). Automatic HTTPS is disabled.", host)
+	serverURL := "https://" + host
+	parsedURL, err := url.Parse(serverURL)
+	if err != nil || parsedURL.Host != host || parsedURL.Hostname() != host {
+		log.Errorf("OWNCAST_HOST_NAME %q is not a bare hostname (no scheme, port, path, query, or fragment). Automatic HTTPS is disabled.", host)
 		return
 	}
 
-	serverURL := "https://" + host
 	if existing := configRepository.GetServerURL(); existing != "" && existing != serverURL {
 		log.Infof("Replacing the stored server URL %s with %s from OWNCAST_HOST_NAME. Unset the environment variable to manage it in the admin.", existing, serverURL)
 	}

--- a/main_autohttps_test.go
+++ b/main_autohttps_test.go
@@ -58,6 +58,14 @@ func TestHandleAutoHTTPSEnvironment(t *testing.T) {
 			wantServerURL: "https://live.example.com",
 		},
 		{
+			name:          "a trailing dot is removed",
+			hostName:      "Live.Example.COM.",
+			enable:        "true",
+			wantEnabled:   true,
+			wantHost:      "live.example.com",
+			wantServerURL: "https://live.example.com",
+		},
+		{
 			name:     "a url instead of a hostname is rejected",
 			hostName: "https://live.example.com",
 			enable:   "true",
@@ -65,6 +73,22 @@ func TestHandleAutoHTTPSEnvironment(t *testing.T) {
 		{
 			name:     "a hostname with a port is rejected",
 			hostName: "live.example.com:8080",
+			enable:   "true",
+		},
+		{
+			name:            "a hostname with a query is rejected",
+			hostName:        "live.example.com?unexpected=true",
+			enable:          "true",
+			presetServerURL: "https://old.example.com",
+		},
+		{
+			name:     "a hostname with a fragment is rejected",
+			hostName: "live.example.com#unexpected",
+			enable:   "true",
+		},
+		{
+			name:     "a hostname with internal whitespace is rejected",
+			hostName: "live.example.com\n.evil.example",
 			enable:   "true",
 		},
 		{

--- a/main_autohttps_test.go
+++ b/main_autohttps_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/owncast/owncast/config"
+	"github.com/owncast/owncast/persistence/configrepository"
+	"github.com/owncast/owncast/services/datastore"
+)
+
+func newTestConfigRepository(t *testing.T) configrepository.ConfigRepository {
+	t.Helper()
+	ds, err := datastore.SetupPersistence(":memory:", os.TempDir())
+	if err != nil {
+		t.Fatalf("failed to set up datastore: %v", err)
+	}
+	return configrepository.New(ds)
+}
+
+func TestHandleAutoHTTPSEnvironment(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostName        string
+		enable          string
+		wantEnabled     bool
+		wantHost        string
+		wantServerURL   string
+		presetServerURL string
+	}{
+		{
+			name: "neither set does nothing",
+		},
+		{
+			name:          "hostname alone seeds the server url without enabling",
+			hostName:      "live.example.com",
+			wantHost:      "live.example.com",
+			wantServerURL: "https://live.example.com",
+		},
+		{
+			name:   "enable alone does not enable",
+			enable: "true",
+		},
+		{
+			name:          "hostname and enable turn on automatic https",
+			hostName:      "live.example.com",
+			enable:        "true",
+			wantEnabled:   true,
+			wantHost:      "live.example.com",
+			wantServerURL: "https://live.example.com",
+		},
+		{
+			name:          "hostname is trimmed and lowercased",
+			hostName:      "  Live.Example.COM ",
+			enable:        "TRUE",
+			wantEnabled:   true,
+			wantHost:      "live.example.com",
+			wantServerURL: "https://live.example.com",
+		},
+		{
+			name:     "a url instead of a hostname is rejected",
+			hostName: "https://live.example.com",
+			enable:   "true",
+		},
+		{
+			name:     "a hostname with a port is rejected",
+			hostName: "live.example.com:8080",
+			enable:   "true",
+		},
+		{
+			name:            "a differing stored server url is overwritten",
+			hostName:        "live.example.com",
+			enable:          "true",
+			presetServerURL: "https://old.example.com",
+			wantEnabled:     true,
+			wantHost:        "live.example.com",
+			wantServerURL:   "https://live.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OWNCAST_HOST_NAME", tc.hostName)
+			t.Setenv("OWNCAST_ENABLE_AUTO_HTTPS", tc.enable)
+
+			repo := newTestConfigRepository(t)
+			if tc.presetServerURL != "" {
+				if err := repo.SetServerURL(tc.presetServerURL); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cfg := config.NewDefault()
+			handleAutoHTTPSEnvironment(cfg, repo)
+
+			if cfg.AutoHTTPSEnabled != tc.wantEnabled {
+				t.Errorf("AutoHTTPSEnabled = %v, want %v", cfg.AutoHTTPSEnabled, tc.wantEnabled)
+			}
+			if cfg.AutoHTTPSHost != tc.wantHost {
+				t.Errorf("AutoHTTPSHost = %q, want %q", cfg.AutoHTTPSHost, tc.wantHost)
+			}
+
+			wantStored := tc.wantServerURL
+			if wantStored == "" {
+				wantStored = tc.presetServerURL
+			}
+			if got := repo.GetServerURL(); got != wantStored {
+				t.Errorf("stored server URL = %q, want %q", got, wantStored)
+			}
+		})
+	}
+}

--- a/webserver/router/autotls.go
+++ b/webserver/router/autotls.go
@@ -1,0 +1,218 @@
+package router
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/owncast/owncast/config"
+	"github.com/owncast/owncast/utils"
+)
+
+// Automatic HTTPS: when enabled (OWNCAST_ENABLE_AUTO_HTTPS +
+// OWNCAST_HOST_NAME, currently set by packaged installs), Owncast attempts
+// to open ports 80 and 443 next to the regular web server port and obtains
+// a Let's Encrypt certificate on demand via ACME. The regular plain HTTP
+// listener is unaffected in every case: any failure here is logged and the
+// server continues HTTP-only.
+//
+// Certificates are issued lazily by autocert on the first TLS handshake for
+// the configured hostname and cached in the data directory, so restarts do
+// not contact the certificate authority. acmeFailureBackoff guards Let's
+// Encrypt's failed-validation rate limit (~5/hour per hostname) against
+// repeated handshakes (e.g. an operator refreshing their browser) while DNS
+// or reachability is still misconfigured.
+const acmeFailureBackoff = 20 * time.Minute
+
+type autoTLS struct {
+	host    string
+	manager *autocert.Manager
+	// lookup resolves a certificate for a handshake; it is
+	// manager.GetCertificate outside of tests.
+	lookup func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
+	mu          sync.Mutex
+	lastFailure time.Time
+	certLogged  bool
+}
+
+// startAutoHTTPS attempts to bring up the automatic HTTPS listeners,
+// serving handler over TLS on port 443 with an ACME challenge + redirect
+// listener on port 80. It never fails the caller.
+func startAutoHTTPS(cfg *config.Config, handler http.Handler) {
+	httpPort := envPortOr("OWNCAST_TLS_HTTP_PORT", 80)
+	httpsPort := envPortOr("OWNCAST_TLS_HTTPS_PORT", 443)
+
+	httpListener, httpsListener, err := bindAutoTLSListeners(cfg.WebServerIP, httpPort, httpsPort)
+	if err != nil {
+		logAutoTLSBindFailure(err)
+		return
+	}
+
+	at := newAutoTLS(cfg.AutoHTTPSHost)
+	go at.logDNSDiagnostic()
+
+	challengeServer := &http.Server{
+		ReadHeaderTimeout: 4 * time.Second,
+		Handler:           at.manager.HTTPHandler(nil),
+	}
+	go func() {
+		if err := challengeServer.Serve(httpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Warnln("Automatic HTTPS: the port 80 challenge listener stopped:", err)
+		}
+	}()
+
+	tlsConfig := at.manager.TLSConfig()
+	tlsConfig.GetCertificate = at.getCertificate
+	httpsServer := &http.Server{
+		ReadHeaderTimeout: 4 * time.Second,
+		Handler:           handler,
+		TLSConfig:         tlsConfig,
+	}
+	go func() {
+		if err := httpsServer.ServeTLS(httpsListener, "", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Warnln("Automatic HTTPS: the port 443 listener stopped:", err)
+		}
+	}()
+
+	log.Infof("Automatic HTTPS: listening for %s. A certificate will be requested with the first request.", at.host)
+}
+
+func newAutoTLS(host string) *autoTLS {
+	manager := &autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(host),
+		Cache:      autocert.DirCache(filepath.Join(config.DataDirectory, "certs")),
+	}
+
+	// Test and staging hook: point ACME at Pebble or the Let's Encrypt
+	// staging environment instead of production.
+	if directory := os.Getenv("OWNCAST_ACME_DIRECTORY"); directory != "" {
+		client := &acme.Client{DirectoryURL: directory}
+		if tlsConfig := utils.GetTLSConfig(); tlsConfig != nil {
+			client.HTTPClient = &http.Client{
+				Transport: &http.Transport{TLSClientConfig: tlsConfig},
+			}
+		}
+		manager.Client = client
+	}
+
+	at := &autoTLS{host: host, manager: manager}
+	at.lookup = manager.GetCertificate
+	return at
+}
+
+// getCertificate wraps autocert's certificate lookup with an in-memory
+// failure backoff. Cached certificates are served without any certificate
+// authority contact; only failed issuance attempts for the configured
+// hostname arm the backoff. Handshakes for other server names are rejected
+// by the host policy and never affect it.
+func (at *autoTLS) getCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if len(hello.SupportedProtos) == 1 && hello.SupportedProtos[0] == acme.ALPNProto {
+		return at.lookup(hello)
+	}
+
+	isConfiguredHost := strings.EqualFold(strings.TrimSuffix(hello.ServerName, "."), at.host)
+
+	if isConfiguredHost {
+		at.mu.Lock()
+		backingOff := !at.lastFailure.IsZero() && time.Since(at.lastFailure) < acmeFailureBackoff
+		at.mu.Unlock()
+		if backingOff {
+			return nil, errors.New("automatic HTTPS: pausing certificate requests after a recent failure")
+		}
+	}
+
+	cert, err := at.lookup(hello)
+
+	if !isConfiguredHost {
+		return cert, err
+	}
+
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	if err != nil {
+		at.lastFailure = time.Now()
+		log.Errorf("Automatic HTTPS: getting a certificate for %s failed: %v. Check that DNS for this hostname points at this server and that port 80 is reachable from the internet. The next attempt will be made in %v.", at.host, err, acmeFailureBackoff)
+		return nil, err
+	}
+	at.lastFailure = time.Time{}
+	if !at.certLogged {
+		at.certLogged = true
+		log.Infof("Automatic HTTPS: certificate for %s is active.", at.host)
+	}
+	return cert, nil
+}
+
+// bindAutoTLSListeners opens the challenge and TLS listeners together.
+// Binding is all-or-nothing: a half-working setup (challenges without TLS
+// or vice versa) would be harder to reason about than no TLS at all.
+func bindAutoTLSListeners(ip string, httpPort, httpsPort int) (net.Listener, net.Listener, error) {
+	httpListener, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(httpPort)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	httpsListener, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(httpsPort)))
+	if err != nil {
+		_ = httpListener.Close()
+		return nil, nil, err
+	}
+
+	return httpListener, httpsListener, nil
+}
+
+func logAutoTLSBindFailure(err error) {
+	switch {
+	case errors.Is(err, syscall.EADDRINUSE):
+		log.Infoln("Automatic HTTPS: ports 80 and/or 443 are already in use, so automatic HTTPS is disabled. If you are running a reverse proxy this is expected.")
+	case errors.Is(err, syscall.EACCES), errors.Is(err, syscall.EPERM):
+		log.Warnln("Automatic HTTPS: insufficient permission to open ports 80 and 443, so automatic HTTPS is disabled. Binding low ports requires the CAP_NET_BIND_SERVICE capability or equivalent.")
+	default:
+		log.Warnln("Automatic HTTPS: unable to open ports 80 and 443, so automatic HTTPS is disabled:", err)
+	}
+}
+
+// logDNSDiagnostic is an advisory-only check for the most common
+// first-boot problem: the hostname not resolving yet. It never blocks
+// certificate issuance — local resolution can fail (split-horizon DNS,
+// NAT) in setups where external ACME validation would still succeed.
+func (at *autoTLS) logDNSDiagnostic() {
+	const recheckInterval = 10 * time.Minute
+	for attempt := 0; ; attempt++ {
+		if _, err := net.LookupHost(at.host); err == nil {
+			if attempt > 0 {
+				log.Infof("Automatic HTTPS: %s now resolves in DNS.", at.host)
+			}
+			return
+		}
+		log.Warnf("Automatic HTTPS: %s does not resolve in DNS yet. HTTPS will start working once DNS for this hostname points at this server. Checking again in %v.", at.host, recheckInterval)
+		time.Sleep(recheckInterval)
+	}
+}
+
+// envPortOr supports overriding the privileged default ports in tests.
+func envPortOr(name string, defaultPort int) int {
+	value := os.Getenv(name)
+	if value == "" {
+		return defaultPort
+	}
+	port, err := strconv.Atoi(value)
+	if err != nil || port < 1 || port > 65535 {
+		log.Warnf("Ignoring invalid %s value %q.", name, value)
+		return defaultPort
+	}
+	return port
+}

--- a/webserver/router/autotls_test.go
+++ b/webserver/router/autotls_test.go
@@ -1,0 +1,245 @@
+package router
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/acme"
+)
+
+func TestBindAutoTLSListenersAllOrNothing(t *testing.T) {
+	// Occupy one port so the pair bind fails partway through.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	occupiedPort := occupied.Addr().(*net.TCPAddr).Port
+
+	// Find a free port for the http side.
+	free, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	freePort := free.Addr().(*net.TCPAddr).Port
+	free.Close()
+
+	httpLn, httpsLn, err := bindAutoTLSListeners("127.0.0.1", freePort, occupiedPort)
+	if err == nil {
+		httpLn.Close()
+		httpsLn.Close()
+		t.Fatal("expected an error when the https port is occupied")
+	}
+
+	// The successfully-bound http listener must have been released.
+	relisten, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(freePort)))
+	if err != nil {
+		t.Fatalf("http listener was not released after partial bind failure: %v", err)
+	}
+	relisten.Close()
+}
+
+func TestBindAutoTLSListenersSuccess(t *testing.T) {
+	a, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	portA := a.Addr().(*net.TCPAddr).Port
+	a.Close()
+	b, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	portB := b.Addr().(*net.TCPAddr).Port
+	b.Close()
+
+	httpLn, httpsLn, err := bindAutoTLSListeners("127.0.0.1", portA, portB)
+	if err != nil {
+		t.Fatalf("expected both listeners to bind: %v", err)
+	}
+	httpLn.Close()
+	httpsLn.Close()
+}
+
+func TestGetCertificateBackoff(t *testing.T) {
+	calls := 0
+	at := &autoTLS{host: "live.example.com"}
+	at.lookup = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		calls++
+		return nil, errors.New("issuance failed")
+	}
+
+	hello := &tls.ClientHelloInfo{ServerName: "live.example.com"}
+
+	// First failure reaches the lookup and arms the backoff.
+	if _, err := at.getCertificate(hello); err == nil {
+		t.Fatal("expected a failure")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 lookup call, got %d", calls)
+	}
+
+	// While backing off, handshakes fail without another lookup.
+	if _, err := at.getCertificate(hello); err == nil {
+		t.Fatal("expected a backoff error")
+	}
+	if calls != 1 {
+		t.Fatalf("backoff must prevent further lookups, got %d calls", calls)
+	}
+
+	// After the window elapses the lookup is retried.
+	at.mu.Lock()
+	at.lastFailure = time.Now().Add(-acmeFailureBackoff - time.Second)
+	at.mu.Unlock()
+	if _, err := at.getCertificate(hello); err == nil {
+		t.Fatal("expected a failure")
+	}
+	if calls != 2 {
+		t.Fatalf("expected a retry after the backoff window, got %d calls", calls)
+	}
+}
+
+func TestGetCertificateSuccessResetsBackoff(t *testing.T) {
+	cert := &tls.Certificate{}
+	fail := true
+	at := &autoTLS{host: "live.example.com"}
+	at.lookup = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		if fail {
+			return nil, errors.New("issuance failed")
+		}
+		return cert, nil
+	}
+	hello := &tls.ClientHelloInfo{ServerName: "live.example.com"}
+
+	if _, err := at.getCertificate(hello); err == nil {
+		t.Fatal("expected a failure")
+	}
+
+	// Simulate the window elapsing, then succeed.
+	at.mu.Lock()
+	at.lastFailure = time.Now().Add(-acmeFailureBackoff - time.Second)
+	at.mu.Unlock()
+	fail = false
+	got, err := at.getCertificate(hello)
+	if err != nil || got != cert {
+		t.Fatalf("expected the certificate, got %v / %v", got, err)
+	}
+
+	// Backoff must be cleared after success.
+	at.mu.Lock()
+	cleared := at.lastFailure.IsZero()
+	at.mu.Unlock()
+	if !cleared {
+		t.Fatal("a successful lookup must clear the failure backoff")
+	}
+}
+
+func TestGetCertificateOtherHostsDoNotArmBackoff(t *testing.T) {
+	at := &autoTLS{host: "live.example.com"}
+	at.lookup = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return nil, errors.New("host not configured")
+	}
+
+	// A scanner handshake with a foreign SNI fails but must not arm the
+	// backoff for the real hostname.
+	if _, err := at.getCertificate(&tls.ClientHelloInfo{ServerName: "scanner.example.net"}); err == nil {
+		t.Fatal("expected a failure for a foreign host")
+	}
+	at.mu.Lock()
+	armed := !at.lastFailure.IsZero()
+	at.mu.Unlock()
+	if armed {
+		t.Fatal("a foreign-host failure must not arm the backoff")
+	}
+}
+
+func TestGetCertificateACMEChallengeBypassesBackoff(t *testing.T) {
+	challengeCert := &tls.Certificate{}
+	calls := 0
+	at := &autoTLS{
+		host:        "live.example.com",
+		lastFailure: time.Now(),
+		lookup: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			calls++
+			return challengeCert, nil
+		},
+	}
+
+	hello := &tls.ClientHelloInfo{
+		ServerName:      "live.example.com",
+		SupportedProtos: []string{acme.ALPNProto},
+	}
+	got, err := at.getCertificate(hello)
+	if err != nil || got != challengeCert {
+		t.Fatalf("ACME challenge lookup must bypass issuance backoff, got %v / %v", got, err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected the ACME challenge lookup to run once, got %d calls", calls)
+	}
+}
+
+func TestGetCertificateACMEChallengeFailureDoesNotArmBackoff(t *testing.T) {
+	at := &autoTLS{
+		host: "live.example.com",
+		lookup: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return nil, errors.New("challenge certificate unavailable")
+		},
+	}
+
+	hello := &tls.ClientHelloInfo{
+		ServerName:      "live.example.com",
+		SupportedProtos: []string{acme.ALPNProto},
+	}
+	if _, err := at.getCertificate(hello); err == nil {
+		t.Fatal("expected the challenge lookup to fail")
+	}
+	at.mu.Lock()
+	armed := !at.lastFailure.IsZero()
+	at.mu.Unlock()
+	if armed {
+		t.Fatal("an ACME challenge lookup failure must not arm issuance backoff")
+	}
+}
+
+func TestGetCertificateMatchesTrailingDotSNI(t *testing.T) {
+	calls := 0
+	at := &autoTLS{host: "live.example.com"}
+	at.lookup = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		calls++
+		return nil, errors.New("issuance failed")
+	}
+
+	// A fully-qualified SNI with a trailing dot is the configured host.
+	if _, err := at.getCertificate(&tls.ClientHelloInfo{ServerName: "live.example.com."}); err == nil {
+		t.Fatal("expected a failure")
+	}
+	at.mu.Lock()
+	armed := !at.lastFailure.IsZero()
+	at.mu.Unlock()
+	if !armed {
+		t.Fatal("a trailing-dot SNI for the configured host must arm the backoff")
+	}
+}
+
+func TestEnvPortOr(t *testing.T) {
+	t.Setenv("OWNCAST_TLS_HTTP_PORT", "")
+	if got := envPortOr("OWNCAST_TLS_HTTP_PORT", 80); got != 80 {
+		t.Fatalf("empty value must return the default, got %d", got)
+	}
+	t.Setenv("OWNCAST_TLS_HTTP_PORT", "5080")
+	if got := envPortOr("OWNCAST_TLS_HTTP_PORT", 80); got != 5080 {
+		t.Fatalf("expected the override, got %d", got)
+	}
+	t.Setenv("OWNCAST_TLS_HTTP_PORT", "not-a-port")
+	if got := envPortOr("OWNCAST_TLS_HTTP_PORT", 80); got != 80 {
+		t.Fatalf("invalid value must return the default, got %d", got)
+	}
+	t.Setenv("OWNCAST_TLS_HTTP_PORT", "70000")
+	if got := envPortOr("OWNCAST_TLS_HTTP_PORT", 80); got != 80 {
+		t.Fatalf("out-of-range value must return the default, got %d", got)
+	}
+}

--- a/webserver/router/router.go
+++ b/webserver/router/router.go
@@ -129,15 +129,20 @@ func Start(cfg *config.Config, enableVerboseLogging bool, h *handlers.Handlers, 
 	compress, _ := httpcompression.DefaultAdapter() // Use the default configuration
 	handler := compress(m)
 
-	if cfg.AutoHTTPSEnabled && cfg.AutoHTTPSHost != "" {
-		startAutoHTTPS(cfg, handler)
-	}
-
 	server := &http.Server{
 		Addr:              net.JoinHostPort(ip, strconv.Itoa(port)),
 		ReadHeaderTimeout: 4 * time.Second,
 		Handler:           handler,
 		Protocols:         protocols,
+	}
+
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return err
+	}
+
+	if cfg.AutoHTTPSEnabled && cfg.AutoHTTPSHost != "" {
+		startAutoHTTPS(cfg, handler)
 	}
 
 	if ip != "0.0.0.0" {
@@ -147,7 +152,7 @@ func Start(cfg *config.Config, enableVerboseLogging bool, h *handlers.Handlers, 
 	}
 	log.Infoln("Configure this server by visiting /admin.")
 
-	return server.ListenAndServe()
+	return server.Serve(listener)
 }
 
 func addStaticFileEndpoints(r chi.Router, h *handlers.Handlers, apc *apcontrollers.Controllers) {

--- a/webserver/router/router.go
+++ b/webserver/router/router.go
@@ -1,8 +1,9 @@
 package router
 
 import (
-	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -126,10 +127,16 @@ func Start(cfg *config.Config, enableVerboseLogging bool, h *handlers.Handlers, 
 	protocols.SetUnencryptedHTTP2(true)
 
 	compress, _ := httpcompression.DefaultAdapter() // Use the default configuration
+	handler := compress(m)
+
+	if cfg.AutoHTTPSEnabled && cfg.AutoHTTPSHost != "" {
+		startAutoHTTPS(cfg, handler)
+	}
+
 	server := &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", ip, port),
+		Addr:              net.JoinHostPort(ip, strconv.Itoa(port)),
 		ReadHeaderTimeout: 4 * time.Second,
-		Handler:           compress(m),
+		Handler:           handler,
 		Protocols:         protocols,
 	}
 


### PR DESCRIPTION
This adds an opt-in automatic HTTPS path for packaged installs without changing existing Owncast deployments. It is the core work needed before the Debian package can configure HTTPS during install. The normal port 8080 listener stays available, and automatic HTTPS remains off unless both environment variables are set.

- Read `OWNCAST_HOST_NAME` and `OWNCAST_ENABLE_AUTO_HTTPS` at startup.
- Seed the stored Server URL from the configured hostname so federation and generated URLs use HTTPS.
- Bind ports 80 and 443 as an all-or-nothing pair. A bind failure logs why automatic HTTPS was skipped and leaves port 8080 alone.
- Serve the same Owncast handler over HTTPS and use port 80 for ACME challenges and redirects.
- Use `x/crypto/acme/autocert`, which is already a dependency, with certificates cached under `data/certs`.
- Back off for 20 minutes after a failed issuance attempt so browser refreshes do not burn through the failed-validation limit.
- Keep TLS-ALPN challenge handshakes outside that backoff and log advisory DNS and certificate status messages.
- Add unit tests for the environment gate, Server URL seeding, listener cleanup, issuance backoff, foreign SNI, and TLS-ALPN challenge behavior.

I tested the full issuance path against Pebble 2.7.0 with `owncast.127.0.0.1.nip.io`:

```text
Automatic HTTPS: listening for owncast.127.0.0.1.nip.io. A certificate will be requested with the first request.
Automatic HTTPS: certificate for owncast.127.0.0.1.nip.io is active.
HTTPS 200 1836 bytes
HTTP 302 -> https://owncast.127.0.0.1.nip.io/somepage
Plain 200
```

The certificate was reused from `data/certs` after restarting Owncast without another ACME request. `go test ./...` passes across 40 packages. The changed packages pass golangci-lint with zero issues. The full repo lint currently reaches an existing `ineffassign` finding in `services/webhooks/workerpool.go:124`.

Refs #922

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
