### PR TITLE
Redirect video requests to the HLS stream

### DIFF
--- a/webserver/handlers/index.go
+++ b/webserver/handlers/index.go
@@ -5,9 +5,11 @@ import (
 	"crypto/md5" // nolint:gosec
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,7 +28,7 @@ func (h *Handlers) IndexHandler(w http.ResponseWriter, r *http.Request) {
 
 	isIndexRequest := r.URL.Path == "/" || filepath.Base(r.URL.Path) == "index.html" || filepath.Base(r.URL.Path) == ""
 
-	if utils.IsUserAgentAPlayer(r.UserAgent()) && isIndexRequest {
+	if isIndexRequest && (utils.IsUserAgentAPlayer(r.UserAgent()) || requestAcceptsVideo(r)) {
 		http.Redirect(w, r, "/hls/stream.m3u8", http.StatusTemporaryRedirect)
 		return
 	}
@@ -52,6 +54,32 @@ func (h *Handlers) IndexHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	serveWeb(w, r)
+}
+
+func requestAcceptsVideo(r *http.Request) bool {
+	for _, accept := range r.Header.Values("Accept") {
+		for _, mediaRange := range strings.Split(accept, ",") {
+			mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(mediaRange))
+			if err != nil {
+				continue
+			}
+
+			if quality, ok := params["q"]; ok {
+				q, err := strconv.ParseFloat(quality, 64)
+				if err != nil || q <= 0 || q > 1 {
+					continue
+				}
+			}
+
+			if strings.HasPrefix(mediaType, "video/") ||
+				mediaType == "application/vnd.apple.mpegurl" ||
+				mediaType == "application/x-mpegurl" {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (h *Handlers) renderIndexHtml(w http.ResponseWriter, r *http.Request, nonce string) {

--- a/webserver/handlers/index_test.go
+++ b/webserver/handlers/index_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestAcceptsVideo(t *testing.T) {
+	tests := []struct {
+		name   string
+		accept []string
+		want   bool
+	}{
+		{
+			name:   "video media type",
+			accept: []string{"video/mp4"},
+			want:   true,
+		},
+		{
+			name:   "video wildcard with parameters",
+			accept: []string{"text/html, video/*; q=0.5"},
+			want:   true,
+		},
+		{
+			name:   "HLS media type",
+			accept: []string{"application/vnd.apple.mpegurl"},
+			want:   true,
+		},
+		{
+			name:   "legacy HLS media type",
+			accept: []string{"application/x-mpegURL"},
+			want:   true,
+		},
+		{
+			name:   "separate video accept header",
+			accept: []string{"text/html", "video/webm"},
+			want:   true,
+		},
+		{
+			name:   "unacceptable video media type",
+			accept: []string{"video/mp4; q=0"},
+			want:   false,
+		},
+		{
+			name:   "invalid quality",
+			accept: []string{"video/mp4; q=2"},
+			want:   false,
+		},
+		{
+			name:   "web media types",
+			accept: []string{"text/html, application/xhtml+xml, image/avif"},
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			for _, accept := range test.accept {
+				req.Header.Add("Accept", accept)
+			}
+
+			if got := requestAcceptsVideo(req); got != test.want {
+				t.Errorf("requestAcceptsVideo() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIndexHandlerRedirectsVideoRequestToHLS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "video/mp4")
+	response := httptest.NewRecorder()
+
+	(&Handlers{}).IndexHandler(response, req)
+
+	if response.Code != http.StatusTemporaryRedirect {
+		t.Errorf("status = %d, want %d", response.Code, http.StatusTemporaryRedirect)
+	}
+	if location := response.Header().Get("Location"); location != "/hls/stream.m3u8" {
+		t.Errorf("Location = %q, want %q", location, "/hls/stream.m3u8")
+	}
+}


### PR DESCRIPTION
A request for the viewer root that accepts video now receives a temporary redirect to the HLS playlist instead of the web app.

- Recognize `video/*` plus the standard and legacy HLS media types in `Accept` headers.
- Ignore explicitly unacceptable or invalid video ranges.
- Keep the existing media-player user-agent redirect as a compatibility fallback.
- Add routing coverage for accepted and rejected media types, including multiple `Accept` headers.

`Accept: video/mp4` now returns `307 Temporary Redirect` with `Location: /hls/stream.m3u8`.

The pre-commit checks passed: gofumpt, golangci-lint, and `go test ./...`.

Fixes #5085

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->