### PR TITLE
Use keys for plugin manifest tabs and admin pages

### DIFF
--- a/pluginhost/pluginhost.go
+++ b/pluginhost/pluginhost.go
@@ -638,7 +638,7 @@ func (p *Host) Tabs(r *http.Request) []models.PluginTab {
 		}
 		pluginSlug := l.Manifest.Slug
 		pluginPrefix := "/plugins/" + pluginSlug + "/"
-		for _, tab := range l.Manifest.Tabs {
+		for _, tab := range l.Manifest.OrderedTabs() {
 			var html string
 			if tab.Content != "" {
 				// Static: read from assets/.

--- a/services/plugins/manager.go
+++ b/services/plugins/manager.go
@@ -53,8 +53,8 @@ type Loaded struct {
 	WasmPath   string
 	PublicFS   fs.FS
 	AssetsFS   fs.FS
-	adminGlobs []glob.Glob // compiled from manifest.admin.pages[].path
-	adminPaths []string    // original path strings, used for "page gates descendants" prefix-matching
+	adminGlobs []glob.Glob // compiled from manifest.admin.pages keys
+	adminPaths []string    // original path keys, used for "page gates descendants" prefix-matching
 	plugin     *extism.Plugin
 	// releaseEngine drops this instance's reference on its shared compiled
 	// engine (nil for self-contained wasm). Called exactly once by Close,
@@ -439,10 +439,10 @@ type DiscoveredEntry struct {
 	// network.fetch; the host's load-time validator rejects
 	// network.fetch without an entry, so a present permission
 	// without a non-empty list never occurs.
-	AllowedHosts []string    `json:"allowedHosts,omitempty"`
-	LastError    string      `json:"lastError,omitempty"`
-	DiscoveredAt time.Time   `json:"discoveredAt"`
-	AdminPages   []AdminPage `json:"adminPages,omitempty"`
+	AllowedHosts []string             `json:"allowedHosts,omitempty"`
+	LastError    string               `json:"lastError,omitempty"`
+	DiscoveredAt time.Time            `json:"discoveredAt"`
+	AdminPages   map[string]AdminPage `json:"adminPages,omitempty"`
 	// Commands lists the plugin's chat commands for the admin details view.
 	// Derived by the SDK and reported via register(), so it's only known once
 	// the plugin is loaded — empty for discovered-but-not-loaded plugins.
@@ -1588,7 +1588,7 @@ func loadFromBytes(ctx context.Context, env *HostEnv, manifestBytes, artifactByt
 
 	var adminGlobs []glob.Glob
 	var adminPaths []string
-	for _, page := range manifest.Admin.Pages {
+	for _, page := range manifest.OrderedAdminPages() {
 		// Lower the pattern so admin-path matching is case-insensitive (see
 		// IsAdminPath); the request path is lowered there to match.
 		lowered := strings.ToLower(page.Path)

--- a/services/plugins/manifest.go
+++ b/services/plugins/manifest.go
@@ -1,10 +1,12 @@
 package plugins
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -109,24 +111,48 @@ type Manifest struct {
 	// on_page_content(slug, user) to get rendered HTML dynamically.
 	// Requires ui.modify.
 	ExtraPageContent *ExtraPageContent `json:"extraPageContent,omitempty"`
-	// Tabs declares viewer-page tabs the plugin contributes to the
-	// row of tabs Owncast renders next to chat (alongside built-ins
-	// like Followers). Each entry's `content` is a relative path to
-	// an HTML file under `assets/`; the host reads the bytes and
-	// inlines them into the tab body on /api/config. Path and
-	// extension rules match ExtraPageContent.
-	Tabs []Tab `json:"tabs,omitempty"`
+	// Tabs declares viewer-page tabs keyed by the slug passed to
+	// onTabContent. Each entry's `content` is a relative path to an HTML
+	// file under `assets/`; the host reads the bytes and inlines them into
+	// the tab body on /api/config. Path and extension rules match
+	// ExtraPageContent.
+	Tabs Tabs `json:"tabs,omitempty"`
 }
 
-// Tab declares one viewer-page tab. Title is the label shown in the
-// UI. Slug is the stable identifier passed to the plugin's
-// onTabContent handler. Content is the optional path to a static HTML
-// file under assets/; when omitted the host calls on_tab_content with
-// the slug to get rendered HTML.
+// Tab declares one viewer-page tab. Title is the label shown in the UI.
+// Content is the optional path to a static HTML file under assets/. When
+// omitted the host calls on_tab_content with the tab's map key.
 type Tab struct {
 	Title   string `json:"title"`
-	Slug    string `json:"slug"`
+	Slug    string `json:"-"`
 	Content string `json:"content,omitempty"`
+}
+
+func (tab *Tab) UnmarshalJSON(data []byte) error {
+	type tabAlias Tab
+	var decoded struct {
+		tabAlias
+		LegacySlug json.RawMessage `json:"slug"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.LegacySlug != nil {
+		return errors.New(`legacy "slug" member is not allowed; use the manifest.tabs object key`)
+	}
+	*tab = Tab(decoded.tabAlias)
+	return nil
+}
+
+type Tabs map[string]Tab
+
+func (tabs *Tabs) UnmarshalJSON(data []byte) error {
+	decoded, err := decodeUniqueObject[Tab](data, "manifest.tabs")
+	if err != nil {
+		return err
+	}
+	*tabs = decoded
+	return nil
 }
 
 // ExtraPageContent declares the plugin's contribution to the viewer
@@ -224,21 +250,79 @@ type ActionButton struct {
 }
 
 // AdminConfig declares admin-only surfaces a plugin exposes. The Owncast
-// admin web UI lists these in the "Plugins" section; each page renders the
-// plugin's content at /plugins/<name>/<path>. Paths declared here are
-// auth-gated by the host — unauthenticated requests get 401 before
-// reaching the plugin.
+// admin web UI lists these in the "Plugins" section. Pages are keyed by the
+// plugin-relative path that the host auth-gates and renders.
 type AdminConfig struct {
-	Pages []AdminPage `json:"pages,omitempty"`
+	Pages AdminPages `json:"pages,omitempty"`
 }
 
 type AdminPage struct {
 	Title string `json:"title"`
-	// Path is a glob (e.g. "/admin", "/admin/*"). Requests under
-	// /plugins/<name>/<rest> are checked against each glob and require
-	// admin authentication when any match.
-	Path string `json:"path"`
-	Icon string `json:"icon,omitempty"`
+	Path  string `json:"-"`
+	Icon  string `json:"icon,omitempty"`
+}
+
+func (page *AdminPage) UnmarshalJSON(data []byte) error {
+	type adminPageAlias AdminPage
+	var decoded struct {
+		adminPageAlias
+		LegacyPath json.RawMessage `json:"path"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.LegacyPath != nil {
+		return errors.New(`legacy "path" member is not allowed; use the manifest.admin.pages object key`)
+	}
+	*page = AdminPage(decoded.adminPageAlias)
+	return nil
+}
+
+type AdminPages map[string]AdminPage
+
+func (pages *AdminPages) UnmarshalJSON(data []byte) error {
+	decoded, err := decodeUniqueObject[AdminPage](data, "manifest.admin.pages")
+	if err != nil {
+		return err
+	}
+	*pages = decoded
+	return nil
+}
+
+func decodeUniqueObject[T any](data []byte, field string) (map[string]T, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if token == nil {
+		return nil, nil
+	}
+	if token != json.Delim('{') {
+		return nil, fmt.Errorf("%s must be an object", field)
+	}
+
+	values := make(map[string]T)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key := token.(string)
+		if _, exists := values[key]; exists {
+			return nil, fmt.Errorf("%s: duplicate key %q", field, key)
+		}
+
+		var value T
+		if err := decoder.Decode(&value); err != nil {
+			return nil, fmt.Errorf("%s[%q]: %w", field, key, err)
+		}
+		values[key] = value
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	return values, nil
 }
 
 func ParseManifest(b []byte) (*Manifest, error) {
@@ -383,19 +467,16 @@ func (m *Manifest) hasPermission(perm string) bool {
 }
 
 func (m *Manifest) validateAdminPages() error {
-	for i, page := range m.Admin.Pages {
+	for _, page := range m.OrderedAdminPages() {
 		if page.Title == "" {
-			return fmt.Errorf("manifest.admin.pages[%d].title is required", i)
-		}
-		if page.Path == "" {
-			return fmt.Errorf("manifest.admin.pages[%d].path is required", i)
+			return fmt.Errorf("manifest.admin.pages[%q].title is required", page.Path)
 		}
 		// Must be rooted. The auth gate matches request paths (which always
 		// start with "/") against this glob and its "<path>/" descendant prefix;
 		// an unrooted value like "admin" matches neither "/admin" nor
 		// "/admin/...", silently leaving the intended subtree unauthenticated.
 		if !strings.HasPrefix(page.Path, "/") {
-			return fmt.Errorf("manifest.admin.pages[%d].path %q must start with \"/\"", i, page.Path)
+			return fmt.Errorf("manifest.admin.pages key %q must start with \"/\"", page.Path)
 		}
 	}
 	return nil
@@ -581,40 +662,64 @@ func (m *Manifest) validateTabs() error {
 				"plugin paints inside Owncast's chrome")
 	}
 	seenTitles := make(map[string]bool, len(m.Tabs))
-	seenSlugs := make(map[string]bool, len(m.Tabs))
-	for i := range m.Tabs {
-		if strings.TrimSpace(m.Tabs[i].Title) == "" {
-			return fmt.Errorf("manifest.tabs[%d].title is required", i)
-		}
-		if seenTitles[m.Tabs[i].Title] {
-			return fmt.Errorf("manifest.tabs[%d].title %q is a duplicate; tab titles must be unique within a plugin", i, m.Tabs[i].Title)
-		}
-		seenTitles[m.Tabs[i].Title] = true
-		if strings.TrimSpace(m.Tabs[i].Slug) == "" {
-			if m.Tabs[i].Content == "" {
-				return fmt.Errorf("manifest.tabs[%d].slug is required", i)
-			}
-			derived, err := slugify(m.Tabs[i].Title)
-			if err != nil {
-				return fmt.Errorf("manifest.tabs[%d].slug is required and could not be derived from title %q: %w", i, m.Tabs[i].Title, err)
-			}
-			m.Tabs[i].Slug = derived
-		} else if err := validatePluginSlug(fmt.Sprintf("manifest.tabs[%d].slug", i), m.Tabs[i].Slug); err != nil {
+	for _, tab := range m.OrderedTabs() {
+		if err := validatePluginSlug("manifest.tabs key", tab.Slug); err != nil {
 			return err
 		}
-		if seenSlugs[m.Tabs[i].Slug] {
-			return fmt.Errorf("manifest.tabs[%d].slug %q is a duplicate; tab slugs must be unique within a plugin", i, m.Tabs[i].Slug)
+		if strings.TrimSpace(tab.Title) == "" {
+			return fmt.Errorf("manifest.tabs[%q].title is required", tab.Slug)
 		}
-		seenSlugs[m.Tabs[i].Slug] = true
-		if m.Tabs[i].Content != "" {
-			rewritten, err := rewritePluginAssetPath(m.Slug, m.Tabs[i].Content, ".html")
+		if seenTitles[tab.Title] {
+			return fmt.Errorf("manifest.tabs[%q].title %q is a duplicate; tab titles must be unique within a plugin", tab.Slug, tab.Title)
+		}
+		seenTitles[tab.Title] = true
+		if tab.Content != "" {
+			rewritten, err := rewritePluginAssetPath(m.Slug, tab.Content, ".html")
 			if err != nil {
-				return fmt.Errorf("manifest.tabs[%d].content: %w", i, err)
+				return fmt.Errorf("manifest.tabs[%q].content: %w", tab.Slug, err)
 			}
-			m.Tabs[i].Content = rewritten
+			tab.Content = rewritten
+			slug := tab.Slug
+			tab.Slug = ""
+			m.Tabs[slug] = tab
 		}
 	}
 	return nil
+}
+
+// OrderedTabs returns tabs in lexicographic slug order. JSON object order is
+// not part of the manifest contract, so every observable host surface uses
+// this deterministic order.
+func (m *Manifest) OrderedTabs() []Tab {
+	keys := sortedMapKeys(m.Tabs)
+	tabs := make([]Tab, 0, len(keys))
+	for _, slug := range keys {
+		tab := m.Tabs[slug]
+		tab.Slug = slug
+		tabs = append(tabs, tab)
+	}
+	return tabs
+}
+
+// OrderedAdminPages returns admin pages in lexicographic path order.
+func (m *Manifest) OrderedAdminPages() []AdminPage {
+	keys := sortedMapKeys(m.Admin.Pages)
+	pages := make([]AdminPage, 0, len(keys))
+	for _, path := range keys {
+		page := m.Admin.Pages[path]
+		page.Path = path
+		pages = append(pages, page)
+	}
+	return pages
+}
+
+func sortedMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // validatePluginSlug checks that s is a non-empty, valid plugin-style

--- a/services/plugins/manifest_test.go
+++ b/services/plugins/manifest_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -237,21 +238,68 @@ func TestParseManifest_AdminPage_MustBeRooted(t *testing.T) {
 	// rejected at load.
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "stats", "version": "1.0",
-		"admin": {"pages": [{"title": "Dash", "path": "admin"}]}
+		"admin": {"pages": {"admin": {"title": "Dash"}}}
 	}`))
 	if err == nil {
 		t.Fatal("expected error: unrooted admin page path")
 	}
-	if !strings.Contains(err.Error(), "must start with") {
-		t.Errorf("error should explain the rooting requirement, got: %v", err)
+	if !strings.Contains(err.Error(), `key "admin" must start with "/"`) {
+		t.Errorf("error should identify the invalid path key, got: %v", err)
 	}
 
 	// A rooted path is accepted.
 	if _, err := ParseManifest([]byte(`{
 		"api": "1", "name": "stats", "version": "1.0",
-		"admin": {"pages": [{"title": "Dash", "path": "/admin/*"}]}
+		"admin": {"pages": {"/admin/*": {"title": "Dash"}}}
 	}`)); err != nil {
 		t.Errorf("rooted admin page path should be valid, got: %v", err)
+	}
+}
+
+func TestParseManifest_AdminPage_RequiresTitle(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
+		"api": "1", "name": "stats", "version": "1.0",
+		"admin": {"pages": {"/admin": {"title": ""}}}
+	}`))
+	if err == nil {
+		t.Fatal("expected error: admin page title is required")
+	}
+	if !strings.Contains(err.Error(), `manifest.admin.pages["/admin"].title is required`) {
+		t.Errorf("error should identify the admin page key, got: %v", err)
+	}
+}
+
+func TestParseManifest_AdminPages_RejectsDuplicatePathKeys(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
+		"api": "1", "name": "stats", "version": "1.0",
+		"admin": {"pages": {
+			"/admin": {"title": "First"},
+			"/admin": {"title": "Second"}
+		}}
+	}`))
+	if err == nil {
+		t.Fatal("expected error: duplicate admin page path key")
+	}
+	if !strings.Contains(err.Error(), `manifest.admin.pages: duplicate key "/admin"`) {
+		t.Errorf("error should identify the duplicate admin page key, got: %v", err)
+	}
+}
+
+func TestParseManifest_AdminPages_RejectsLegacyPathMember(t *testing.T) {
+	for _, path := range []string{"/admin", "/different"} {
+		_, err := ParseManifest([]byte(fmt.Sprintf(`{
+			"api": "1", "name": "stats", "version": "1.0",
+			"admin": {"pages": {
+				"/admin": {"title": "Admin", "path": %q}
+			}}
+		}`, path)))
+		if err == nil {
+			t.Fatalf("expected legacy path member %q to be rejected", path)
+		}
+		if !strings.Contains(err.Error(), `manifest.admin.pages["/admin"]`) ||
+			!strings.Contains(err.Error(), `legacy "path" member`) {
+			t.Errorf("error should identify the keyed page and legacy member, got: %v", err)
+		}
 	}
 }
 
@@ -407,7 +455,7 @@ func TestParseManifest_AdminPages_NoUIModifyRequired(t *testing.T) {
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "stats", "version": "1.0",
 		"permissions": ["http.serve"],
-		"admin": {"pages": [{"title": "x", "path": "/admin"}]}
+		"admin": {"pages": {"/admin": {"title": "x"}}}
 	}`))
 	if err != nil {
 		t.Errorf("admin.pages should not require ui.modify: %v", err)
@@ -702,14 +750,14 @@ func TestParseManifest_ExtraPageContent_RejectsNonHtmlExtension(t *testing.T) {
 	}
 }
 
-func TestParseManifest_Tabs_RewritesContentPaths(t *testing.T) {
+func TestParseManifest_Tabs_RewritesContentPathsAndOrdersBySlug(t *testing.T) {
 	m, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
 		"permissions": ["ui.modify"],
-		"tabs": [
-			{ "title": "Music", "slug": "music", "content": "music.html" },
-			{ "title": "Photos", "slug": "photos", "content": "/photos.html" }
-		]
+		"tabs": {
+			"photos": { "title": "Photos", "content": "/photos.html" },
+			"music": { "title": "Music", "content": "music.html" }
+		}
 	}`))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -718,46 +766,116 @@ func TestParseManifest_Tabs_RewritesContentPaths(t *testing.T) {
 		{Title: "Music", Slug: "music", Content: "/plugins/tabbed/music.html"},
 		{Title: "Photos", Slug: "photos", Content: "/plugins/tabbed/photos.html"},
 	}
-	if len(m.Tabs) != len(want) {
-		t.Fatalf("tabs count: got %d want %d", len(m.Tabs), len(want))
+	got := m.OrderedTabs()
+	if len(got) != len(want) {
+		t.Fatalf("tabs count: got %d want %d", len(got), len(want))
 	}
 	for i, w := range want {
-		if m.Tabs[i] != w {
-			t.Errorf("tabs[%d] = %+v, want %+v", i, m.Tabs[i], w)
+		if got[i] != w {
+			t.Errorf("tabs[%d] = %+v, want %+v", i, got[i], w)
 		}
 	}
 }
 
-func TestParseManifest_Tabs_AcceptsLegacyStaticTabsWithoutSlugs(t *testing.T) {
-	m, err := ParseManifest([]byte(`{
+func TestParseManifest_Tabs_RejectsDuplicateSlugKeys(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
 		"permissions": ["ui.modify"],
-		"tabs": [
-			{ "title": "Music", "content": "music.html" },
-			{ "title": "Schedule", "content": "/schedule.html" }
-		]
+		"tabs": {
+			"music": {"title": "First"},
+			"music": {"title": "Second"}
+		}
+	}`))
+	if err == nil {
+		t.Fatal("expected error: duplicate tab slug key")
+	}
+	if !strings.Contains(err.Error(), `manifest.tabs: duplicate key "music"`) {
+		t.Errorf("error should identify the duplicate tab key, got: %v", err)
+	}
+}
+
+func TestParseManifest_Tabs_RejectsLegacySlugMember(t *testing.T) {
+	for _, slug := range []string{"music", "different"} {
+		_, err := ParseManifest([]byte(fmt.Sprintf(`{
+			"api": "1", "name": "tabbed", "version": "1.0",
+			"permissions": ["ui.modify"],
+			"tabs": {
+				"music": {"title": "Music", "slug": %q}
+			}
+		}`, slug)))
+		if err == nil {
+			t.Fatalf("expected legacy slug member %q to be rejected", slug)
+		}
+		if !strings.Contains(err.Error(), `manifest.tabs["music"]`) ||
+			!strings.Contains(err.Error(), `legacy "slug" member`) {
+			t.Errorf("error should identify the keyed tab and legacy member, got: %v", err)
+		}
+	}
+}
+
+func TestParseManifest_KeyedValuesAllowUnknownMembers(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
+		"api": "1", "name": "future", "version": "1.0",
+		"permissions": ["ui.modify"],
+		"tabs": {"music": {"title": "Music", "futureTabField": true}},
+		"admin": {"pages": {"/admin": {"title": "Admin", "futurePageField": true}}}
+	}`))
+	if err != nil {
+		t.Fatalf("unknown keyed value members should remain forward-compatible: %v", err)
+	}
+}
+
+func TestParseManifest_AdminPages_OrdersByPath(t *testing.T) {
+	m, err := ParseManifest([]byte(`{
+		"api": "1", "name": "admin", "version": "1.0",
+		"admin": {"pages": {
+			"/settings": {"title": "Settings"},
+			"/admin": {"title": "Admin", "icon": "gear"}
+		}}
 	}`))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	want := []Tab{
-		{Title: "Music", Slug: "music", Content: "/plugins/tabbed/music.html"},
-		{Title: "Schedule", Slug: "schedule", Content: "/plugins/tabbed/schedule.html"},
+	want := []AdminPage{
+		{Title: "Admin", Path: "/admin", Icon: "gear"},
+		{Title: "Settings", Path: "/settings"},
 	}
-	if len(m.Tabs) != len(want) {
-		t.Fatalf("tabs count: got %d want %d", len(m.Tabs), len(want))
+	got := m.OrderedAdminPages()
+	if len(got) != len(want) {
+		t.Fatalf("admin pages count: got %d want %d", len(got), len(want))
 	}
 	for i, w := range want {
-		if m.Tabs[i] != w {
-			t.Errorf("tabs[%d] = %+v, want %+v", i, m.Tabs[i], w)
+		if got[i] != w {
+			t.Errorf("admin pages[%d] = %+v, want %+v", i, got[i], w)
 		}
+	}
+}
+
+func TestParseManifest_RejectsArrayTabs(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
+		"api": "1", "name": "tabbed", "version": "1.0",
+		"permissions": ["ui.modify"],
+		"tabs": [{ "title": "Music", "slug": "music", "content": "music.html" }]
+	}`))
+	if err == nil {
+		t.Fatal("expected array-form tabs to be rejected")
+	}
+}
+
+func TestParseManifest_RejectsArrayAdminPages(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
+		"api": "1", "name": "admin", "version": "1.0",
+		"admin": {"pages": [{ "title": "Admin", "path": "/admin" }]}
+	}`))
+	if err == nil {
+		t.Fatal("expected array-form admin pages to be rejected")
 	}
 }
 
 func TestParseManifest_Tabs_RequiresUIModify(t *testing.T) {
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
-		"tabs": [{ "title": "Music", "slug": "music", "content": "music.html" }]
+		"tabs": {"music": { "title": "Music", "content": "music.html" }}
 	}`))
 	if err == nil {
 		t.Fatal("expected error when tabs is set without ui.modify")
@@ -771,13 +889,30 @@ func TestParseManifest_Tabs_RequiresTitle(t *testing.T) {
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
 		"permissions": ["ui.modify"],
-		"tabs": [{ "title": "", "slug": "music", "content": "music.html" }]
+		"tabs": {"music": { "title": "", "content": "music.html" }}
 	}`))
 	if err == nil {
 		t.Fatal("expected error when tab.title is empty")
 	}
-	if !strings.Contains(err.Error(), "title is required") {
-		t.Errorf("error should call out title, got: %v", err)
+	if !strings.Contains(err.Error(), `manifest.tabs["music"].title is required`) {
+		t.Errorf("error should identify the tab key, got: %v", err)
+	}
+}
+
+func TestParseManifest_Tabs_RejectsInvalidSlugKeyDeterministically(t *testing.T) {
+	_, err := ParseManifest([]byte(`{
+		"api": "1", "name": "tabbed", "version": "1.0",
+		"permissions": ["ui.modify"],
+		"tabs": {
+			"z_bad": { "title": "Z" },
+			"a_bad": { "title": "A" }
+		}
+	}`))
+	if err == nil {
+		t.Fatal("expected error: invalid tab slug key")
+	}
+	if !strings.Contains(err.Error(), `"a_bad"`) {
+		t.Errorf("validation should report the lexicographically first invalid key, got: %v", err)
 	}
 }
 
@@ -785,10 +920,10 @@ func TestParseManifest_Tabs_RejectsDuplicateTitles(t *testing.T) {
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
 		"permissions": ["ui.modify"],
-		"tabs": [
-			{ "title": "Music", "slug": "music-a", "content": "a.html" },
-			{ "title": "Music", "slug": "music-b", "content": "b.html" }
-		]
+		"tabs": {
+			"music-a": { "title": "Music", "content": "a.html" },
+			"music-b": { "title": "Music", "content": "b.html" }
+		}
 	}`))
 	if err == nil {
 		t.Fatal("expected error: duplicate tab titles")
@@ -802,7 +937,7 @@ func TestParseManifest_Tabs_RejectsCrossPluginPath(t *testing.T) {
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
 		"permissions": ["ui.modify"],
-		"tabs": [{ "title": "Other", "slug": "other", "content": "/plugins/some-other-plugin/x.html" }]
+		"tabs": {"other": { "title": "Other", "content": "/plugins/some-other-plugin/x.html" }}
 	}`))
 	if err == nil {
 		t.Fatal("expected error: cross-plugin tab content path")
@@ -816,7 +951,7 @@ func TestParseManifest_Tabs_RejectsNonHtmlExtension(t *testing.T) {
 	_, err := ParseManifest([]byte(`{
 		"api": "1", "name": "tabbed", "version": "1.0",
 		"permissions": ["ui.modify"],
-		"tabs": [{ "title": "Bad", "slug": "bad", "content": "music.txt" }]
+		"tabs": {"bad": { "title": "Bad", "content": "music.txt" }}
 	}`))
 	if err == nil {
 		t.Fatal("expected error: only .html extension allowed for tabs")

--- a/test/automated/plugins/run.sh
+++ b/test/automated/plugins/run.sh
@@ -84,6 +84,19 @@ trap plugins_finish EXIT
 echo "Installing plugin SDK build dependencies..."
 (cd "${SDK_DIR}/sdks/js" && npm install --no-audit --no-fund)
 
+# Package examples with a host binary built against this core checkout. The
+# released binary can lag pre-release manifest changes shared with SDK main.
+(
+	HOST_WORK_DIR="$(mktemp -d)"
+	trap 'rm -rf "$HOST_WORK_DIR"' EXIT
+	cd "$HOST_WORK_DIR"
+	go work init "$REPO_ROOT" "${SDK_DIR}/host-runtime"
+	cd "${SDK_DIR}/host-runtime"
+	GOWORK="${HOST_WORK_DIR}/go.work" go build \
+		-o "${SDK_DIR}/sdks/js/bin/.cache/owncast-plugin-test" \
+		./cmd/owncast-plugin-test
+)
+
 echo "Building example plugins..."
 rm -rf "$PLUGIN_DIR"
 mkdir -p "$PLUGIN_DIR"

--- a/web/components/admin/MainLayout.tsx
+++ b/web/components/admin/MainLayout.tsx
@@ -351,7 +351,7 @@ export const MainLayout: FC<MainLayoutProps> = ({ children }) => {
         // enumerate plugin identifiers at build time. Sidebar labels use
         // the human-readable display name.
         ...plugins
-          .filter(p => p.enabled && (p.adminPages?.length ?? 0) > 0)
+          .filter(p => p.enabled && Object.keys(p.adminPages ?? {}).length > 0)
           .map(p => ({
             key: `/admin/plugins/configure?id=${p.slug}`,
             label: (

--- a/web/components/admin/plugins/PluginDetail.tsx
+++ b/web/components/admin/plugins/PluginDetail.tsx
@@ -156,8 +156,8 @@ export const PluginDetail = ({ plugin }: PluginDetailProps) => {
   const { t } = useTranslation();
   const uniquePages = useMemo(() => {
     const seen = new Set<string>();
-    return (plugin.adminPages ?? [])
-      .map(page => ({ ...page, url: pluginAdminUrl(plugin.slug, page.path) }))
+    return Object.entries(plugin.adminPages ?? {})
+      .map(([path, page]) => ({ ...page, url: pluginAdminUrl(plugin.slug, path) }))
       .filter(page => {
         if (seen.has(page.url)) return false;
         seen.add(page.url);

--- a/web/interfaces/plugin.ts
+++ b/web/interfaces/plugin.ts
@@ -88,7 +88,7 @@ export interface Plugin {
   allowedHosts?: string[];
   lastError?: string;
   discoveredAt: string;
-  adminPages?: PluginAdminPage[];
+  adminPages?: Record<string, PluginAdminPage>;
   // config is the plugin's manifest-declared settings schema (key → field).
   // The admin auto-renders an editable form from it; saved values are read
   // back by the plugin via owncast.config.get(). Absent when the plugin
@@ -123,11 +123,9 @@ export interface PluginCommand {
   modOnly?: boolean;
 }
 
-// PluginAdminPage is a single admin-only page declared in a plugin's
-// manifest.admin.pages entry. The body is rendered as an iframe to
-// /plugins/<slug><path>.
+// PluginAdminPage is one admin-only page declared in the
+// manifest.admin.pages object. Its object key is the plugin-relative path.
 export interface PluginAdminPage {
   title: string;
-  path: string;
   icon?: string;
 }


### PR DESCRIPTION
This changes plugin manifest tabs and admin pages from arrays with repeated identifiers to objects keyed by those identifiers.

- Parse `tabs` by tab slug and `admin.pages` by plugin-relative path
- Reject legacy per-value `slug` and `path` members and duplicate keys
- Update pluginhost consumers, admin types, examples, and manifest documentation

I ran the core Go tests and web production build. The keyed manifest examples and admin page flow were also exercised through the plugin scenario and browser checks.

Fixes #5087

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

**Do not remove this section.** These checkboxes are required and validated.

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->