### PR TITLE
Set the OAuth gate test access mode explicitly

### DIFF
--- a/test/automated/auth/oauth-gate.test.js
+++ b/test/automated/auth/oauth-gate.test.js
@@ -65,6 +65,11 @@ beforeAll(async () => {
 		.post(`/api/admin/plugins/${SLUG}/enable`)
 		.auth(...ADMIN)
 		.expect(200);
+	await request
+		.post(`/api/admin/plugins/${SLUG}/auth-settings`)
+		.auth(...ADMIN)
+		.send({ accessMode: 'website-and-stream' })
+		.expect(200);
 	await sleep(1500);
 });
 


### PR DESCRIPTION
The OAuth gate test expects anonymous HLS requests to be blocked. It now explicitly selects website-and-stream, since the default gate policy keeps HLS public.

I ran test/automated/auth/run.sh. Both gate suites passed, 32 tests total. Prettier checks the updated test cleanly.

Fixes #5100

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I am submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really does not need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it is not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it is assigned to me.
<!-- REQUIRED-CHECKLIST:END -->