### PR TITLE
Include quote post content in plugin events

### DIFF
--- a/pluginhost/pluginevents.go
+++ b/pluginhost/pluginevents.go
@@ -205,23 +205,26 @@ func translateFediverseEvent(evt dispatcher.Event) []pluginEvent {
 			return nil
 		}
 		return []pluginEvent{{plugins.EventFediverseActivity, payload}}
-	case models.FediverseEngagementLike, models.FediverseEngagementRepost, models.FediverseEngagementQuote:
+	case models.FediverseEngagementLike, models.FediverseEngagementRepost:
 		payload, ok := evt.Payload.(*activityevents.FediverseEngagementEvent)
 		if !ok || payload == nil {
 			return nil
 		}
 		translated := *payload
 		translated.Actor.Handle = normalizeFediverseHandle(translated.Actor.Handle)
-		var eventType string
-		switch evt.Type {
-		case models.FediverseEngagementLike:
-			eventType = plugins.EventFediverseLike
-		case models.FediverseEngagementRepost:
+		eventType := plugins.EventFediverseLike
+		if evt.Type == models.FediverseEngagementRepost {
 			eventType = plugins.EventFediverseRepost
-		case models.FediverseEngagementQuote:
-			eventType = plugins.EventFediverseQuote
 		}
 		return []pluginEvent{{eventType, translated}}
+	case models.FediverseEngagementQuote:
+		payload, ok := evt.Payload.(*activityevents.FediverseQuoteEvent)
+		if !ok || payload == nil {
+			return nil
+		}
+		translated := *payload
+		translated.Actor.Handle = normalizeFediverseHandle(translated.Actor.Handle)
+		return []pluginEvent{{plugins.EventFediverseQuote, translated}}
 	case models.FediverseMention, models.FediverseReply:
 		payload, ok := evt.Payload.(*activityevents.FediverseInboundPostEvent)
 		if !ok || payload == nil {

--- a/pluginhost/pluginevents_test.go
+++ b/pluginhost/pluginevents_test.go
@@ -81,6 +81,20 @@ func TestTranslatePluginEvent_FediverseEvents(t *testing.T) {
 		}},
 		Language: "en",
 	}
+	quote := &activityevents.FediverseQuoteEvent{
+		Actor:       actor,
+		Target:      &activityevents.FediverseTarget{URL: "https://owncast.example/federation/post/quoted"},
+		Content:     "<p>Worth watching</p>",
+		ContentText: "Worth watching",
+		URL:         "https://social.example/posts/quote",
+		PostedAt:    "2026-07-10T13:00:00Z",
+		Attachments: []activityevents.FediverseAttachment{{
+			URL:       "https://social.example/media/quote.jpg",
+			MediaType: "image/jpeg",
+			Alt:       "A quoted stream",
+		}},
+		Language: "en",
+	}
 
 	tests := []struct {
 		name      string
@@ -128,9 +142,9 @@ func TestTranslatePluginEvent_FediverseEvents(t *testing.T) {
 		},
 		{
 			name:      "quote",
-			event:     dispatcher.Event{Type: models.FediverseEngagementQuote, Payload: engagement("https://owncast.example/federation/post/quoted")},
+			event:     dispatcher.Event{Type: models.FediverseEngagementQuote, Payload: quote},
 			eventType: "fediverse.quote",
-			json:      `{"actor":{"name":"Alice Example","handle":"@alice@social.example","url":"https://social.example/users/alice","image":"https://social.example/users/alice/avatar.png"},"target":{"url":"https://owncast.example/federation/post/quoted"}}`,
+			json:      `{"actor":{"name":"Alice Example","handle":"@alice@social.example","url":"https://social.example/users/alice","image":"https://social.example/users/alice/avatar.png"},"target":{"url":"https://owncast.example/federation/post/quoted"},"content":"\u003cp\u003eWorth watching\u003c/p\u003e","contentText":"Worth watching","url":"https://social.example/posts/quote","postedAt":"2026-07-10T13:00:00Z","attachments":[{"url":"https://social.example/media/quote.jpg","mediaType":"image/jpeg","alt":"A quoted stream"}],"language":"en"}`,
 		},
 	}
 

--- a/services/activitypub/events/fediverseInboundEvent.go
+++ b/services/activitypub/events/fediverseInboundEvent.go
@@ -13,10 +13,25 @@ type FediverseTarget struct {
 	URL string `json:"url"`
 }
 
-// FediverseEngagementEvent is the payload for inbound like, repost, and quote events.
+// FediverseEngagementEvent is the payload for inbound like and repost events.
 type FediverseEngagementEvent struct {
 	Actor  FediverseActor   `json:"actor"`
 	Target *FediverseTarget `json:"target,omitempty"`
+}
+
+// FediverseQuoteEvent is the payload for an accepted inbound quote request.
+// The post fields describe the remote quote post when its Note is embedded in
+// the request. URL is always present because it identifies the instrument.
+type FediverseQuoteEvent struct {
+	Actor       FediverseActor        `json:"actor"`
+	Target      *FediverseTarget      `json:"target"`
+	Content     string                `json:"content,omitempty"`
+	ContentText string                `json:"contentText,omitempty"`
+	URL         string                `json:"url"`
+	PostedAt    string                `json:"postedAt,omitempty"`
+	InReplyTo   string                `json:"inReplyTo,omitempty"`
+	Attachments []FediverseAttachment `json:"attachments,omitempty"`
+	Language    string                `json:"language,omitempty"`
 }
 
 // FediverseAttachment is media attached to an inbound post.

--- a/services/activitypub/events/fediverseInboundEvent.go
+++ b/services/activitypub/events/fediverseInboundEvent.go
@@ -21,7 +21,7 @@ type FediverseEngagementEvent struct {
 
 // FediverseQuoteEvent is the payload for an accepted inbound quote request.
 // The post fields describe the remote quote post when its Note is embedded in
-// the request. URL is always present because it identifies the instrument.
+// the request. URL is its public permalink when available, otherwise its IRI.
 type FediverseQuoteEvent struct {
 	Actor       FediverseActor        `json:"actor"`
 	Target      *FediverseTarget      `json:"target"`

--- a/services/activitypub/inbox/engagement_events_test.go
+++ b/services/activitypub/inbox/engagement_events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"code.superseriousbusiness.org/activity/streams"
 	"code.superseriousbusiness.org/activity/streams/vocab"
@@ -120,6 +121,30 @@ func assertEngagementEvent(t *testing.T, published []dispatcher.Event, eventType
 	}
 }
 
+func assertQuoteEvent(t *testing.T, published []dispatcher.Event, target, quotePost string) *activityevents.FediverseQuoteEvent {
+	t.Helper()
+	if len(published) != 1 {
+		t.Fatalf("published %d events, want 1", len(published))
+	}
+	if published[0].Type != models.FediverseEngagementQuote {
+		t.Fatalf("event type = %q, want %q", published[0].Type, models.FediverseEngagementQuote)
+	}
+	payload, ok := published[0].Payload.(*activityevents.FediverseQuoteEvent)
+	if !ok || payload == nil {
+		t.Fatalf("payload type = %T, want *events.FediverseQuoteEvent", published[0].Payload)
+	}
+	if payload.Actor.Name != "Mr Foo" || payload.Actor.Handle != "foodawg@freedom.eagle" {
+		t.Fatalf("unexpected actor payload: %+v", payload.Actor)
+	}
+	if payload.Target == nil || payload.Target.URL != target {
+		t.Fatalf("target = %+v, want %q", payload.Target, target)
+	}
+	if payload.URL != quotePost {
+		t.Fatalf("quote post URL = %q, want %q", payload.URL, quotePost)
+	}
+	return payload
+}
+
 func TestEngagementPublishesWithChatDisplayDisabledAndSkipsDuplicates(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -223,6 +248,36 @@ func quoteRequest(inbox string) vocab.GoToSocialQuoteRequest {
 	return activity
 }
 
+func quoteRequestWithEmbeddedNote(inbox string) vocab.GoToSocialQuoteRequest {
+	activity := quoteRequest(inbox)
+	note := streams.NewActivityStreamsNote()
+
+	id := streams.NewJSONLDIdProperty()
+	id.SetIRI(mustParseURL("https://remote.example/posts/quote"))
+	note.SetJSONLDId(id)
+
+	attributedTo := streams.NewActivityStreamsAttributedToProperty()
+	attributedTo.AppendIRI(mustParseURL("https://freedom.eagle/user/mrfoo"))
+	note.SetActivityStreamsAttributedTo(attributedTo)
+
+	content := streams.NewActivityStreamsContentProperty()
+	content.AppendXMLSchemaString("<p>This stream is worth watching.</p>")
+	note.SetActivityStreamsContent(content)
+
+	postURL := streams.NewActivityStreamsUrlProperty()
+	postURL.AppendIRI(mustParseURL("https://remote.example/@mrfoo/quote"))
+	note.SetActivityStreamsUrl(postURL)
+
+	published := streams.NewActivityStreamsPublishedProperty()
+	published.Set(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC))
+	note.SetActivityStreamsPublished(published)
+
+	instrument := streams.NewActivityStreamsInstrumentProperty()
+	instrument.AppendActivityStreamsNote(note)
+	activity.SetActivityStreamsInstrument(instrument)
+	return activity
+}
+
 func TestQuotePublishesOnlyAfterSuccessfulAccept(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		service, persistenceService, published := newEngagementTestService(t)
@@ -234,7 +289,48 @@ func TestQuotePublishesOnlyAfterSuccessfulAccept(t *testing.T) {
 		if err := service.handleQuoteRequestInboxRequest(context.Background(), quoteRequest("https://remote.example/inbox")); err != nil {
 			t.Fatal(err)
 		}
-		assertEngagementEvent(t, *published, models.FediverseEngagementQuote, target)
+		assertQuoteEvent(t, *published, target, "https://remote.example/posts/quote")
+	})
+
+	t.Run("embedded quote post content", func(t *testing.T) {
+		service, persistenceService, published := newEngagementTestService(t)
+		const target = "https://owncast.example/federation/quoted"
+		if err := persistenceService.AddToOutbox(target, []byte(`{"type":"Note"}`), "Note", false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := service.handleQuoteRequestInboxRequest(context.Background(), quoteRequestWithEmbeddedNote("https://remote.example/inbox")); err != nil {
+			t.Fatal(err)
+		}
+		event := assertQuoteEvent(t, *published, target, "https://remote.example/@mrfoo/quote")
+		if event.Content != "<p>This stream is worth watching.</p>" || event.ContentText != "This stream is worth watching." {
+			t.Fatalf("unexpected quote content: %+v", event)
+		}
+		if event.PostedAt != "2026-07-10T12:00:00Z" {
+			t.Fatalf("postedAt = %q, want 2026-07-10T12:00:00Z", event.PostedAt)
+		}
+	})
+
+	t.Run("untrusted embedded quote content is omitted", func(t *testing.T) {
+		service, persistenceService, published := newEngagementTestService(t)
+		const target = "https://owncast.example/federation/quoted"
+		if err := persistenceService.AddToOutbox(target, []byte(`{"type":"Note"}`), "Note", false); err != nil {
+			t.Fatal(err)
+		}
+
+		activity := quoteRequestWithEmbeddedNote("https://remote.example/inbox")
+		note := activity.GetActivityStreamsInstrument().At(0).GetActivityStreamsNote()
+		attributedTo := streams.NewActivityStreamsAttributedToProperty()
+		attributedTo.AppendIRI(mustParseURL("https://remote.example/users/someone-else"))
+		note.SetActivityStreamsAttributedTo(attributedTo)
+
+		if err := service.handleQuoteRequestInboxRequest(context.Background(), activity); err != nil {
+			t.Fatal(err)
+		}
+		event := assertQuoteEvent(t, *published, target, "https://remote.example/posts/quote")
+		if event.Content != "" || event.ContentText != "" || event.PostedAt != "" {
+			t.Fatalf("untrusted quote metadata was exposed: %+v", event)
+		}
 	})
 
 	t.Run("replay retries accept without republishing", func(t *testing.T) {

--- a/services/activitypub/inbox/quote.go
+++ b/services/activitypub/inbox/quote.go
@@ -79,9 +79,37 @@ func (s *Service) handleQuoteRequestInboxRequest(c context.Context, activity voc
 	if !claimed {
 		return nil
 	}
-	s.publishFediverseEvent(c, models.FediverseEngagementQuote, &activityevents.FediverseEngagementEvent{
-		Actor:  fediverseActorFromResolvedActor(actor),
-		Target: &activityevents.FediverseTarget{URL: quotedPostIRI.String()},
-	})
+	s.publishFediverseEvent(c, models.FediverseEngagementQuote, quoteEventPayload(
+		activity.GetActivityStreamsInstrument(),
+		actor,
+		quotePostIRI.String(),
+		quotedPostIRI.String(),
+	))
 	return nil
+}
+
+func quoteEventPayload(instrument vocab.ActivityStreamsInstrumentProperty, actor apmodels.ActivityPubActor, quotePostIRI, quotedPostIRI string) *activityevents.FediverseQuoteEvent {
+	event := &activityevents.FediverseQuoteEvent{
+		Actor:  fediverseActorFromResolvedActor(actor),
+		Target: &activityevents.FediverseTarget{URL: quotedPostIRI},
+		URL:    quotePostIRI,
+	}
+	if instrument == nil || instrument.Len() == 0 || instrument.At(0) == nil || !instrument.At(0).IsActivityStreamsNote() {
+		return event
+	}
+
+	note := instrument.At(0).GetActivityStreamsNote()
+	if note == nil || validateNoteAttribution(note.GetActivityStreamsAttributedTo(), actor.ActorIriString()) != nil {
+		return event
+	}
+
+	post := createPostPayload(note, quotePostIRI, firstInReplyToIRI(note.GetActivityStreamsInReplyTo()), actor)
+	event.Content = post.Content
+	event.ContentText = post.ContentText
+	event.URL = post.URL
+	event.PostedAt = post.PostedAt
+	event.InReplyTo = post.InReplyTo
+	event.Attachments = post.Attachments
+	event.Language = post.Language
+	return event
 }


### PR DESCRIPTION
Quote plugin events now include the remote post itself, so plugins can use the quote caption and permalink instead of only seeing which local post was quoted.

- Keep the existing `actor` and `target` fields
- Add the quote post `url`, rendered content, plain text, publication time, attachments, language, and reply metadata
- Include post metadata when the requesting server embeds its `Note` in the `QuoteRequest`
- Keep `fediverse.quote` delivery working when the request contains only an instrument IRI
- Ignore embedded post content whose attribution does not match the requesting actor

Example payload:

```json
{
  "actor": {"handle": "@alice@example.social"},
  "target": {"url": "https://stream.example/federation/post-id"},
  "content": "<p>Worth watching</p>",
  "contentText": "Worth watching",
  "url": "https://example.social/@alice/quote-id",
  "postedAt": "2026-07-10T12:00:00Z"
}
```

I ran the ActivityPub inbox, plugin dispatcher, and plugin service tests, built all Go packages, and ran all 68 JavaScript and Python SDK example scenarios against this worktree.

Fixes #5103

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->