### PR TITLE
Confine custom emoji deletion to the emoji directory

### DIFF
--- a/webserver/handlers/admin/emoji.go
+++ b/webserver/handlers/admin/emoji.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/owncast/owncast/config"
 	"github.com/owncast/owncast/utils"
@@ -82,14 +83,28 @@ func DeleteCustomEmoji(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetPath := filepath.Join(config.CustomEmojiPath, emoji.Name)
+	// The admin sends the emoji path relative to the emoji directory with a
+	// leading slash, and os.Root only accepts relative names.
+	name := strings.TrimPrefix(emoji.Name, "/")
 
-	if !filepath.IsLocal(targetPath) {
+	// Check the name that was sent rather than the result of joining it onto
+	// the emoji directory. Join cleans the ../ away first, which is what let
+	// traversal through the equivalent check here before.
+	if !filepath.IsLocal(name) {
 		webutils.WriteSimpleResponse(w, false, "Emoji path is not valid")
 		return
 	}
 
-	if err := os.Remove(targetPath); err != nil {
+	// Remove through a root handle so the emoji directory boundary holds even
+	// when a name that looks local resolves out of it through a symlink.
+	root, err := os.OpenRoot(config.CustomEmojiPath)
+	if err != nil {
+		webutils.WriteSimpleResponse(w, false, err.Error())
+		return
+	}
+	defer root.Close()
+
+	if err := root.Remove(name); err != nil {
 		if os.IsNotExist(err) {
 			webutils.WriteSimpleResponse(w, false, fmt.Sprintf("Emoji %q doesn't exist", emoji.Name))
 		} else {

--- a/webserver/handlers/admin/emoji_test.go
+++ b/webserver/handlers/admin/emoji_test.go
@@ -1,0 +1,153 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/owncast/owncast/config"
+)
+
+// deleteEmojiRequest posts a delete request for the given name and returns
+// whether the handler reported success.
+func deleteEmojiRequest(t *testing.T, name string) bool {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"name": name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/admin/emoji/delete", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	DeleteCustomEmoji(rec, req)
+
+	var response struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unable to read response %q: %v", rec.Body.String(), err)
+	}
+
+	return response.Success
+}
+
+// setupEmojiDir points the emoji directory at a temporary working directory
+// holding one emoji, the database, and the config file.
+func setupEmojiDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, config.CustomEmojiPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, config.CustomEmojiPath, "smiley.png"), []byte("emoji"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, config.DataDirectory, "owncast.db"), []byte("database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("config"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+func TestDeleteCustomEmojiRemovesEmoji(t *testing.T) {
+	dir := setupEmojiDir(t)
+
+	// The admin sends the path with a leading slash.
+	if !deleteEmojiRequest(t, "/smiley.png") {
+		t.Fatal("expected the emoji to be deleted")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, config.CustomEmojiPath, "smiley.png")); !os.IsNotExist(err) {
+		t.Error("emoji was not removed")
+	}
+}
+
+func TestDeleteCustomEmojiRemovesEmojiInSubdirectory(t *testing.T) {
+	dir := setupEmojiDir(t)
+
+	nested := filepath.Join(dir, config.CustomEmojiPath, "pack")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "wave.png"), []byte("emoji"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !deleteEmojiRequest(t, "/pack/wave.png") {
+		t.Fatal("expected the nested emoji to be deleted")
+	}
+
+	if _, err := os.Stat(filepath.Join(nested, "wave.png")); !os.IsNotExist(err) {
+		t.Error("nested emoji was not removed")
+	}
+}
+
+// Names that leave the emoji directory must be refused. filepath.Join cleans
+// ../ away, so checking the joined path let these through (GHSA-2p2g-5h44-ggp2).
+func TestDeleteCustomEmojiRefusesPathsOutsideEmojiDirectory(t *testing.T) {
+	names := []string{
+		"../../config.yaml",
+		"../owncast.db",
+		"/../../config.yaml",
+		"..",
+		".",
+		"",
+	}
+
+	for i, name := range names {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			t.Helper()
+			dir := setupEmojiDir(t)
+
+			if deleteEmojiRequest(t, name) {
+				t.Errorf("name %q was accepted", name)
+			}
+
+			for _, survivor := range []string{"config.yaml", filepath.Join(config.DataDirectory, "owncast.db")} {
+				if _, err := os.Stat(filepath.Join(dir, survivor)); err != nil {
+					t.Errorf("%s outside of the emoji directory was removed: %v", survivor, err)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(dir, config.CustomEmojiPath)); err != nil {
+				t.Errorf("emoji directory was removed: %v", err)
+			}
+		})
+	}
+}
+
+// A symlink inside the emoji directory must not become a way out of it.
+func TestDeleteCustomEmojiRefusesSymlinkedPathOutsideEmojiDirectory(t *testing.T) {
+	dir := setupEmojiDir(t)
+
+	outside := filepath.Join(dir, "outside")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, config.CustomEmojiPath, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	if deleteEmojiRequest(t, "/link/secret.txt") {
+		t.Error("a path through a symlink was accepted")
+	}
+
+	if _, err := os.Stat(secret); err != nil {
+		t.Errorf("file outside of the emoji directory was removed: %v", err)
+	}
+}


### PR DESCRIPTION
The custom emoji delete API could remove files that live outside of the emoji directory.

`DeleteCustomEmoji` joined the requested name onto `data/emoji` and then ran `filepath.IsLocal` on the result. `Join` cleans `../` away before that check happens, so by the time `IsLocal` looked at the path there was no traversal left in it to reject. A name like `../owncast.db` resolved to `data/owncast.db`, and `../../config.yaml` resolved to the config file next to the binary. Names that climbed above the working directory were rejected, so the reach was everything under it, which on a normal install is the whole thing.

Rather than reasoning about the string, the handler now opens an `os.Root` on the emoji directory and removes through that. The kernel-level root enforces the boundary, so `../` and paths that leave through a symlink are both refused. One wrinkle worth knowing about: the admin sends the emoji path with a leading slash (`/blob/ablobattention.gif`), and `os.Root` only accepts relative names, so that slash gets trimmed first. The built-in emoji ship in subdirectories, so reducing the name to `filepath.Base` would have broken deleting most of them.

- Remove emoji through an `os.Root` handle on the emoji directory instead of a joined path
- Trim the leading slash the admin sends, since `os.Root` names are relative
- Add tests for traversal, symlink escape, `.` and `..`, an empty name, and both the flat and nested delete the admin actually performs

The new tests fail against the old handler and pass against this one. I also ran a build against a real instance on an alternate port and walked the endpoint through it:

```text
../../config.yaml      -> {"message":"Emoji path is not valid","success":false}
../owncast.db          -> {"message":"Emoji path is not valid","success":false}
../../owncast          -> {"message":"Emoji path is not valid","success":false}
/blob/ablobattention.gif -> {"message":"Emoji \"/blob/ablobattention.gif\" has been deleted","success":true}
/thanks.png            -> {"message":"Emoji \"/thanks.png\" has been deleted","success":true}
/nope.png              -> {"message":"Emoji \"/nope.png\" doesn't exist","success":false}
```

`config.yaml`, `data/owncast.db`, and the binary were all still there afterwards, and the emoji list dropped by exactly the two emoji I deleted.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->
