### PR TITLE
Handle concurrent ActivityPub follow deliveries

### DIFF
--- a/services/activitypub/inbox/engagement_events_test.go
+++ b/services/activitypub/inbox/engagement_events_test.go
@@ -422,6 +422,51 @@ func TestConcurrentQuoteDeliveriesPublishOnce(t *testing.T) {
 	}
 }
 
+func TestConcurrentPendingFollowDeliveriesSucceed(t *testing.T) {
+	service, persistenceService, _ := newEngagementTestService(t)
+	persistenceService.Datastore().DB.SetMaxOpenConns(1)
+	if err := configrepository.New(persistenceService.Datastore()).SetFederationIsPrivate(true); err != nil {
+		t.Fatal(err)
+	}
+	person := makeFakePerson()
+	follow := streams.NewActivityStreamsFollow()
+	id := streams.NewJSONLDIdProperty()
+	id.Set(mustParseURL("https://freedom.eagle/follow/concurrent"))
+	follow.SetJSONLDId(id)
+	follow.SetActivityStreamsActor(actorProperty(person))
+	follow.SetActivityStreamsObject(objectProperty("https://owncast.example/federation/user/streamer"))
+
+	const deliveries = 8
+	start := make(chan struct{})
+	errs := make(chan error, deliveries)
+	var wg sync.WaitGroup
+	wg.Add(deliveries)
+	for range deliveries {
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := service.handleFollowInboxRequest(context.Background(), follow); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent delivery: %v", err)
+	}
+
+	var followerCount int
+	if err := persistenceService.Datastore().DB.QueryRow(`SELECT count(*) FROM ap_followers`).Scan(&followerCount); err != nil {
+		t.Fatal(err)
+	}
+	if followerCount != 1 {
+		t.Fatalf("followers=%d, want 1", followerCount)
+	}
+}
+
 func TestDuplicateApprovedDirectoryFollowResendsAccept(t *testing.T) {
 	service, persistenceService, _ := newEngagementTestService(t)
 	person := makeFakePerson()

--- a/services/activitypub/inbox/follow.go
+++ b/services/activitypub/inbox/follow.go
@@ -46,13 +46,33 @@ func (s *Service) handleFollowInboxRequest(c context.Context, activity vocab.Act
 	}
 
 	localAccountName := s.configRepository.GetDefaultFederationUsername()
-	if handled, err := s.respondToExistingFollow(activity, follow, actorIRI, localAccountName); handled {
+	handled, err := s.createOrHandleFollow(c, activity, follow, followRequest, approved, actorIRI, localAccountName)
+	if err != nil {
 		return err
+	}
+	if handled {
+		return nil
+	}
+	return s.handleNewFollow(activity, followRequest, approved, actorIRI)
+}
+
+func (s *Service) createOrHandleFollow(c context.Context, activity vocab.ActivityStreamsFollow, follow *apmodels.ActivityPubActor, followRequest apmodels.ActivityPubActor, approved bool, actorIRI, localAccountName string) (bool, error) {
+	// The duplicate check and insert must be one critical section. Some
+	// ActivityPub servers deliver the same Follow concurrently.
+	ds := s.persistence.Datastore()
+	ds.DbLock.Lock()
+	defer ds.DbLock.Unlock()
+
+	if handled, err := s.respondToExistingFollow(activity, follow, actorIRI, localAccountName); handled {
+		return true, err
 	}
 	if err := s.addFollow(c, activity, followRequest, approved, localAccountName); err != nil {
-		return err
+		return false, err
 	}
+	return false, nil
+}
 
+func (s *Service) handleNewFollow(activity vocab.ActivityStreamsFollow, followRequest apmodels.ActivityPubActor, approved bool, actorIRI string) error {
 	objectIRI, err := apmodels.GetIRIStringFromObjectProperty(activity.GetActivityStreamsObject())
 	if err != nil {
 		return errors.Wrap(err, "follow activity is missing object IRI")
@@ -111,10 +131,18 @@ func (s *Service) respondToExistingFollow(activity vocab.ActivityStreamsFollow, 
 }
 
 func (s *Service) addFollow(c context.Context, activity vocab.ActivityStreamsFollow, follow apmodels.ActivityPubActor, approved bool, localAccountName string) error {
+	ds := s.persistence.Datastore()
 	if !approved {
-		if err := s.followers.Add(follow, false); err != nil {
-			log.Errorln("unable to save follow request", err)
+		tx, err := ds.DB.BeginTx(c, nil)
+		if err != nil {
+			return errors.Wrap(err, "beginning follow transaction")
+		}
+		defer func() { _ = tx.Rollback() }()
+		if err := s.followers.AddTx(c, tx, follow, false); err != nil {
 			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return errors.Wrap(err, "committing follow transaction")
 		}
 		return nil
 	}
@@ -123,9 +151,7 @@ func (s *Service) addFollow(c context.Context, activity vocab.ActivityStreamsFol
 	if err != nil {
 		return err
 	}
-	ds := s.persistence.Datastore()
-	ds.DbLock.Lock()
-	defer ds.DbLock.Unlock()
+
 	tx, err := ds.DB.BeginTx(c, nil)
 	if err != nil {
 		return errors.Wrap(err, "beginning follow transaction")


### PR DESCRIPTION
Fixes #5078.

A follower can deliver the same Follow activity more than once at the same time. Each handler used to check before the first insert committed, so the later writes reached SQLite and logged a unique-constraint failure.

- Keep the existing-follow lookup and first write in the same datastore critical section.
- Continue treating later deliveries as idempotent retries, including resending an Accept for an approved follower.
- Add a regression test that starts eight identical pending Follow deliveries and verifies one saved follower.

Ran `go test -race ./services/activitypub/inbox -run TestConcurrentPendingFollowDeliveriesSucceed -count=20`, `go test ./services/activitypub/...`, and `golangci-lint run ./services/activitypub/inbox/...`.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->