### PR TITLE
Generate names for registered plugin users

### DIFF
--- a/pluginhost/pluginhost.go
+++ b/pluginhost/pluginhost.go
@@ -1936,6 +1936,13 @@ func validateProfileURL(profileURL string) error {
 	return nil
 }
 
+func generatedDisplayName(displayName string) string {
+	if displayName == "" {
+		return utils.GeneratePhrase()
+	}
+	return displayName
+}
+
 // wireAuthHostFns wires the viewer-authentication host functions: register an
 // authenticated user for an external (plugin-provided) identity, and mint a
 // signed gate session for them.
@@ -1966,7 +1973,7 @@ func wireAuthHostFns(env *plugins.HostEnv, deps Deps) {
 		if existing := users.GetUserByPluginAuth(pluginName, req.AuthID); existing != nil {
 			userID = existing.ID
 		} else {
-			user, _, err := users.CreateAnonymousUser(req.DisplayName)
+			user, _, err := users.CreateAnonymousUser(generatedDisplayName(req.DisplayName))
 			if err != nil {
 				return "", err
 			}

--- a/pluginhost/register_test.go
+++ b/pluginhost/register_test.go
@@ -1,6 +1,7 @@
 package pluginhost
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/owncast/owncast/models"
@@ -82,14 +83,22 @@ func TestRegisterUser(t *testing.T) {
 		t.Fatalf("re-register: got %q err=%v, want %q", again, err, id)
 	}
 
-	// A different plugin with the same raw authId is a distinct user. (A new-user
-	// registration must carry a display name; CreateAnonymousUser rejects empty.)
-	other, err := env.RegisterUser("discord-auth", plugins.UserRegisterRequest{AuthID: "583231", DisplayName: "octocat"})
+	// A different plugin with the same raw authId creates a distinct user. A
+	// nullable display name receives a generated name.
+	var nullDisplayName plugins.UserRegisterRequest
+	if err := json.Unmarshal([]byte(`{"authId":"583231","displayName":null}`), &nullDisplayName); err != nil {
+		t.Fatalf("decode nullable display name: %v", err)
+	}
+	other, err := env.RegisterUser("discord-auth", nullDisplayName)
 	if err != nil {
 		t.Fatalf("other plugin register: %v", err)
 	}
 	if other == id {
 		t.Error("a different plugin must not resolve to the same user")
+	}
+
+	if user := users.GetUserByPluginAuth("discord-auth", "583231"); user == nil || user.DisplayName == "" {
+		t.Error("missing display name was not generated")
 	}
 
 	// A disallowed scope is rejected, and no orphan user is left behind.


### PR DESCRIPTION
Fixes #5107.

A plugin can omit `displayName` or send `null` when registering a user. The host now supplies its normal generated name before creating that user.

- Generate a display name for new plugin-authenticated users when the request has none.
- Add a regression test that decodes `displayName: null` and verifies the persisted user has a name.

```
$ go test ./...
go test: 39 packages ok, 25 no tests

$ golangci-lint run ./pluginhost/...
0 issues.
```

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->