### PR TITLE
feat(plugins): namespace emitted custom events

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -146,7 +146,12 @@ Owncast and plugins communicate through a shared dispatcher
   plugins' `filterChatMessage` handlers run on inbound messages before they're
   broadcast (redact, drop, rewrite).
 - Plugins can also **emit** custom events to each other; `env.Emit` is wired to
-  the runtime's live dispatcher after the manager starts.
+  the runtime's live dispatcher after the manager starts. `hostEmitEvent`
+  prefixes the emitted name with the calling plugin's slug (resolved by the
+  host, never supplied by the guest), so a plugin can only publish under
+  `<its-own-slug>.` and can neither forge a core event nor impersonate another
+  plugin. Subscriptions stay literal, so listening to
+  `other-plugin.something` still works.
 
 ## Lifecycle, persistence, and HTTP
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -149,8 +149,10 @@ Owncast and plugins communicate through a shared dispatcher
   the runtime's live dispatcher after the manager starts. `hostEmitEvent`
   prefixes the emitted name with the calling plugin's slug (resolved by the
   host, never supplied by the guest), so a plugin can only publish under
-  `<its-own-slug>.` and can neither forge a core event nor impersonate another
-  plugin. Subscriptions stay literal, so listening to
+  `<its-own-slug>.` and cannot impersonate another plugin. Composed names that
+  would equal a built-in event (a plugin slugged `chat` emitting
+  `message.received`) are rejected against `reservedEventTypes`, so core
+  events can't be forged either. Subscriptions stay literal, so listening to
   `other-plugin.something` still works.
 
 ## Lifecycle, persistence, and HTTP

--- a/services/plugins/dispatcher_test.go
+++ b/services/plugins/dispatcher_test.go
@@ -8,28 +8,6 @@ import (
 	"time"
 )
 
-// TestReservedEventTypes_CoversCoreEvents is the B4 guard: the set the emit
-// host function rejects must include every built-in event type, so a plugin
-// can't forge a core event onto other plugins. Catches a new Event* constant
-// added without updating the reserved set.
-func TestReservedEventTypes_CoversCoreEvents(t *testing.T) {
-	for _, e := range []string{
-		EventChatMessageReceived, EventChatUserJoined, EventChatUserParted,
-		EventChatUserRenamed, EventChatMessageModerated, EventChatCommand, EventStreamStarted,
-		EventStreamStopped, EventStreamTitleChanged, EventSSEConnect,
-		EventSSEDisconnect, EventTick, EventTimerFire, EventFediverseFollow,
-		EventFediverseLike, EventFediverseRepost, EventFediverseMention,
-		EventFediverseReply, EventFediverseQuote, EventFediverseActivity,
-	} {
-		if !reservedEventTypes[e] {
-			t.Errorf("core event %q must be reserved (plugins must not be able to emit it)", e)
-		}
-	}
-	if reservedEventTypes["my.plugin.custom"] {
-		t.Error("a plugin's custom event type must not be treated as reserved")
-	}
-}
-
 // TestFilterTimeoutErrorShape verifies the error-string the dispatcher
 // produces when CallWithContext returns a deadline-exceeded error. The
 // real Wazero-level cancellation is verified separately by integration

--- a/services/plugins/dispatcher_test.go
+++ b/services/plugins/dispatcher_test.go
@@ -8,6 +8,28 @@ import (
 	"time"
 )
 
+// TestReservedEventTypes_CoversCoreEvents: the set hostEmitEvent rejects
+// after slug-prefixing must include every built-in event type, so a plugin
+// slugged like a core namespace (e.g. "chat") can't compose a forged core
+// event. Catches a new Event* constant added without updating the set.
+func TestReservedEventTypes_CoversCoreEvents(t *testing.T) {
+	for _, e := range []string{
+		EventChatMessageReceived, EventChatUserJoined, EventChatUserParted,
+		EventChatUserRenamed, EventChatMessageModerated, EventChatCommand, EventStreamStarted,
+		EventStreamStopped, EventStreamTitleChanged, EventSSEConnect,
+		EventSSEDisconnect, EventTick, EventTimerFire, EventFediverseFollow,
+		EventFediverseLike, EventFediverseRepost, EventFediverseMention,
+		EventFediverseReply, EventFediverseQuote, EventFediverseActivity,
+	} {
+		if !reservedEventTypes[e] {
+			t.Errorf("core event %q must be reserved (a plugin must not be able to compose it)", e)
+		}
+	}
+	if reservedEventTypes["my-plugin.custom"] {
+		t.Error("a plugin's custom event type must not be treated as reserved")
+	}
+}
+
 // TestFilterTimeoutErrorShape verifies the error-string the dispatcher
 // produces when CallWithContext returns a deadline-exceeded error. The
 // real Wazero-level cancellation is verified separately by integration

--- a/services/plugins/event_namespacing_test.go
+++ b/services/plugins/event_namespacing_test.go
@@ -1,0 +1,234 @@
+package plugins
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Custom plugin events are namespaced by the host, not by the plugin. The
+// emitting plugin passes a suffix and hostEmitEvent prefixes it with the slug
+// that resolveCaller derived from the wasm call, which the guest cannot
+// influence. These tests pin the three properties that follow from that:
+//
+//  1. a plugin can only publish under "<its-own-slug>.",
+//  2. it therefore cannot impersonate another plugin's custom event, and
+//  3. it cannot forge a core host event either, because a prefixed name can
+//     never equal one (this is what makes the old reservedEventTypes
+//     allowlist unnecessary).
+//
+// The tests deliberately assert on the FULL set of deliveries rather than
+// "the good one arrived": a forged delivery is an extra entry, so an
+// exact-set comparison is what actually catches a regression.
+
+// drainSends returns every chat send recorded so far and clears the buffer,
+// so one loaded plugin pair can serve several scenarios.
+func drainSends(sends *[]ChatSendRequest, mu *sync.Mutex) []string {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make([]string, 0, len(*sends))
+	for _, s := range *sends {
+		out = append(out, s.Text)
+	}
+	*sends = (*sends)[:0]
+	sort.Strings(out)
+	return out
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// receiverScript builds a plugin that subscribes to every name in names and
+// reports each delivery as "got:<subscribed name>:<payload.n>". Subscribing to
+// both the honest and the forged spelling of an event is the point: only the
+// honest one may ever fire.
+func receiverScript(names []string) string {
+	return `
+const { definePlugin, owncast } = require("@owncast/plugin-sdk");
+const names = ["` + strings.Join(names, `","`) + `"];
+const on = {};
+for (const n of names) {
+  on[n] = function (payload) {
+    owncast.chat.send("got:" + n + ":" + (payload && payload.n));
+  };
+}
+module.exports = definePlugin({ on });`
+}
+
+// TestEmitIsNamespacedByCallerSlug drives one emitter through several event
+// names. The emitter emits whatever the chat body says, so a single load
+// covers the honest case, the impersonation attempt, and the core-event
+// forgery attempt.
+func TestEmitIsNamespacedByCallerSlug(t *testing.T) {
+	ctx := context.Background()
+	compiledEngines.resetForTest(ctx)
+	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
+
+	env, sends, mu := captureEnv()
+
+	// Emits the chat body verbatim as the event-name suffix.
+	emitter := loadShared(t, ctx, env, RuntimeJavaScript, "emitter", `
+const { definePlugin, owncast } = require("@owncast/plugin-sdk");
+module.exports = definePlugin({
+  onChatMessage(msg) { owncast.events.emit(msg.body, { n: 7 }); },
+});`, []string{PermEmitEvent})
+	defer emitter.Close(ctx)
+
+	// Every honest name the emitter can produce, paired with the spelling an
+	// attacker would need the host to accept.
+	receiver := loadShared(t, ctx, env, RuntimeJavaScript, "receiver",
+		receiverScript([]string{
+			"emitter.ping", "ping",
+			"emitter.victim.alert", "victim.alert",
+			"emitter.chat.message.received", "chat.message.received",
+			"emitter.orders.created", "orders.created",
+		}), []string{PermChatSend})
+	defer receiver.Close(ctx)
+
+	d := NewLiveDispatcher(func() []*Loaded { return []*Loaded{emitter, receiver} })
+	env.Emit = d.Dispatch
+
+	// The receiver also subscribes to the real chat.message.received, so every
+	// scenario sees exactly one host-originated delivery on top of the custom
+	// one. Its absence would mean core dispatch broke; a second copy would mean
+	// a plugin managed to forge it.
+	const coreDelivery = "got:chat.message.received:undefined"
+
+	for _, tc := range []struct {
+		name string
+		emit string
+		want []string
+	}{
+		{
+			name: "plain suffix is prefixed with the emitter slug",
+			emit: "ping",
+			want: []string{coreDelivery, "got:emitter.ping:7"},
+		},
+		{
+			name: "dotted suffix keeps its hierarchy under the slug",
+			emit: "orders.created",
+			want: []string{coreDelivery, "got:emitter.orders.created:7"},
+		},
+		{
+			name: "cannot impersonate another plugin's namespace",
+			emit: "victim.alert",
+			want: []string{coreDelivery, "got:emitter.victim.alert:7"},
+		},
+		{
+			name: "cannot forge a core host event",
+			emit: "chat.message.received",
+			want: []string{coreDelivery, "got:emitter.chat.message.received:7"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d.Dispatch(ctx, EventChatMessageReceived, chatPayload("alice", tc.emit))
+			got := drainSends(sends, mu)
+			sort.Strings(tc.want)
+			if !sameStrings(got, tc.want) {
+				t.Fatalf("emit(%q)\n got:  %q\n want: %q", tc.emit, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEmitFromPythonIsNamespaced covers the same guarantee through the Python
+// engine. The prefix is applied host-side, so both SDKs must land on it
+// without either one cooperating.
+func TestEmitFromPythonIsNamespaced(t *testing.T) {
+	ctx := context.Background()
+	compiledEngines.resetForTest(ctx)
+	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
+
+	env, sends, mu := captureEnv()
+
+	// Tries to publish directly into another plugin's namespace.
+	emitter := loadShared(t, ctx, env, RuntimePython, "py-emitter", `
+@plugin.on_chat_message
+def handle(msg):
+    owncast.events.emit("victim.alert", {"n": 7})
+`, []string{PermEmitEvent})
+	defer emitter.Close(ctx)
+
+	receiver := loadShared(t, ctx, env, RuntimeJavaScript, "receiver",
+		receiverScript([]string{"py-emitter.victim.alert", "victim.alert"}),
+		[]string{PermChatSend})
+	defer receiver.Close(ctx)
+
+	d := NewLiveDispatcher(func() []*Loaded { return []*Loaded{emitter, receiver} })
+	env.Emit = d.Dispatch
+	d.Dispatch(ctx, EventChatMessageReceived, chatPayload("alice", "hi"))
+
+	want := []string{"got:py-emitter.victim.alert:7"}
+	if got := drainSends(sends, mu); !sameStrings(got, want) {
+		t.Fatalf("python emit\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestEmitWithoutPermissionDispatchesNothing pins the permission gate ahead of
+// the prefixing: resolveCaller rejects the call, so no event reaches the
+// dispatcher at all, prefixed or not.
+func TestEmitWithoutPermissionDispatchesNothing(t *testing.T) {
+	ctx := context.Background()
+	compiledEngines.resetForTest(ctx)
+	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
+
+	env, sends, mu := captureEnv()
+
+	// No events.emit in the manifest. The call raises inside the guest, which
+	// is swallowed here so the scenario reports on deliveries, not on the
+	// guest-side error shape.
+	emitter := loadShared(t, ctx, env, RuntimeJavaScript, "unprivileged", `
+const { definePlugin, owncast } = require("@owncast/plugin-sdk");
+module.exports = definePlugin({
+  onChatMessage() {
+    try { owncast.events.emit("ping", { n: 7 }); } catch (e) {}
+  },
+});`, nil)
+	defer emitter.Close(ctx)
+
+	receiver := loadShared(t, ctx, env, RuntimeJavaScript, "receiver",
+		receiverScript([]string{"unprivileged.ping", "ping"}),
+		[]string{PermChatSend})
+	defer receiver.Close(ctx)
+
+	d := NewLiveDispatcher(func() []*Loaded { return []*Loaded{emitter, receiver} })
+	env.Emit = d.Dispatch
+	d.Dispatch(ctx, EventChatMessageReceived, chatPayload("alice", "hi"))
+
+	if got := drainSends(sends, mu); len(got) != 0 {
+		t.Fatalf("expected no delivery without events.emit, got %q", got)
+	}
+}
+
+// TestSubscriptionsAreNotRewritten is the counterpart to the namespacing: only
+// the emit side is touched. Subscriptions stay literal, otherwise a subscriber
+// could never name the plugin it wants to hear from and cross-plugin events
+// would stop being deliverable at all.
+func TestSubscriptionsAreNotRewritten(t *testing.T) {
+	ctx := context.Background()
+	compiledEngines.resetForTest(ctx)
+	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
+
+	env, _, _ := captureEnv()
+	receiver := loadShared(t, ctx, env, RuntimeJavaScript, "receiver",
+		receiverScript([]string{"emitter.ping"}), []string{PermChatSend})
+	defer receiver.Close(ctx)
+
+	if !subscribed(receiver.Manifest.Subscriptions.Notify, "emitter.ping") {
+		t.Fatalf("subscription was rewritten, notify = %+v", receiver.Manifest.Subscriptions.Notify)
+	}
+	if subscribed(receiver.Manifest.Subscriptions.Notify, "receiver.emitter.ping") {
+		t.Fatal("subscription was prefixed with the subscriber slug; cross-plugin events would never match")
+	}
+}

--- a/services/plugins/event_namespacing_test.go
+++ b/services/plugins/event_namespacing_test.go
@@ -267,3 +267,51 @@ module.exports = definePlugin({
 		t.Fatalf("forged core event reached subscribers\n got:  %q\n want: %q", got, want)
 	}
 }
+
+// TestEmitCannotSpoofAnotherPluginsEvents is issue #5093's scenario run
+// against this design. The attacker wants events under the victim's name to
+// fire with attacker-controlled payloads. Under host-side emit prefixing the
+// attempt dispatches as "attacker.victim.foo", so "victim.foo" only ever
+// fires when the victim itself emits - and registration squatting gains the
+// attacker nothing, because subscribing to "victim.foo" only ever yields
+// events the victim really sent.
+func TestEmitCannotSpoofAnotherPluginsEvents(t *testing.T) {
+	ctx := context.Background()
+	compiledEngines.resetForTest(ctx)
+	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
+
+	env, sends, mu := captureEnv()
+
+	// Emits under its own name when told to.
+	victim := loadShared(t, ctx, env, RuntimeJavaScript, "victim", `
+const { definePlugin, owncast } = require("@owncast/plugin-sdk");
+module.exports = definePlugin({
+  onChatMessage(msg) { if (msg.body === "victim") owncast.events.emit("foo", { n: 1 }); },
+});`, []string{PermEmitEvent})
+	defer victim.Close(ctx)
+
+	// Tries to emit the victim's fully qualified name.
+	attacker := loadShared(t, ctx, env, RuntimeJavaScript, "attacker", `
+const { definePlugin, owncast } = require("@owncast/plugin-sdk");
+module.exports = definePlugin({
+  onChatMessage(msg) { if (msg.body === "attacker") owncast.events.emit("victim.foo", { n: 2 }); },
+});`, []string{PermEmitEvent})
+	defer attacker.Close(ctx)
+
+	listener := loadShared(t, ctx, env, RuntimeJavaScript, "listener",
+		receiverScript([]string{"victim.foo", "attacker.victim.foo"}), []string{PermChatSend})
+	defer listener.Close(ctx)
+
+	d := NewLiveDispatcher(func() []*Loaded { return []*Loaded{victim, attacker, listener} })
+	env.Emit = d.Dispatch
+
+	d.Dispatch(ctx, EventChatMessageReceived, chatPayload("alice", "victim"))
+	if got, want := drainSends(sends, mu), []string{"got:victim.foo:1"}; !sameStrings(got, want) {
+		t.Fatalf("genuine victim emit\n got:  %q\n want: %q", got, want)
+	}
+
+	d.Dispatch(ctx, EventChatMessageReceived, chatPayload("alice", "attacker"))
+	if got, want := drainSends(sends, mu), []string{"got:attacker.victim.foo:2"}; !sameStrings(got, want) {
+		t.Fatalf("spoof attempt must surface under the attacker's own name only\n got:  %q\n want: %q", got, want)
+	}
+}

--- a/services/plugins/event_namespacing_test.go
+++ b/services/plugins/event_namespacing_test.go
@@ -11,13 +11,14 @@ import (
 // Custom plugin events are namespaced by the host, not by the plugin. The
 // emitting plugin passes a suffix and hostEmitEvent prefixes it with the slug
 // that resolveCaller derived from the wasm call, which the guest cannot
-// influence. These tests pin the three properties that follow from that:
+// influence. These tests pin the properties that follow from that:
 //
 //  1. a plugin can only publish under "<its-own-slug>.",
 //  2. it therefore cannot impersonate another plugin's custom event, and
-//  3. it cannot forge a core host event either, because a prefixed name can
-//     never equal one (this is what makes the old reservedEventTypes
-//     allowlist unnecessary).
+//  3. it cannot forge a core host event: the prefix keeps almost every
+//     composed name distinct from the built-ins, and hostEmitEvent rejects
+//     the residual collisions (a plugin slugged "chat" composing
+//     "chat.message.received") against reservedEventTypes.
 //
 // The tests deliberately assert on the FULL set of deliveries rather than
 // "the good one arrived": a forged delivery is an extra entry, so an
@@ -230,5 +231,39 @@ func TestSubscriptionsAreNotRewritten(t *testing.T) {
 	}
 	if subscribed(receiver.Manifest.Subscriptions.Notify, "receiver.emitter.ping") {
 		t.Fatal("subscription was prefixed with the subscriber slug; cross-plugin events would never match")
+	}
+}
+
+// TestEmitCannotComposeCoreEventName closes the gap the slug prefix leaves
+// open: a plugin whose slug matches a core name's first segment could
+// otherwise compose an exact built-in name and have it fan out as if the
+// host originated it. The emitter here is slugged "chat" and emits
+// "message.received"; the composed "chat.message.received" must be dropped,
+// so the receiver sees only the genuine host dispatch.
+func TestEmitCannotComposeCoreEventName(t *testing.T) {
+	ctx := context.Background()
+	compiledEngines.resetForTest(ctx)
+	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
+
+	env, sends, mu := captureEnv()
+
+	emitter := loadShared(t, ctx, env, RuntimeJavaScript, "chat", `
+const { definePlugin, owncast } = require("@owncast/plugin-sdk");
+module.exports = definePlugin({
+  onChatMessage() { owncast.events.emit("message.received", { n: 7 }); },
+});`, []string{PermEmitEvent})
+	defer emitter.Close(ctx)
+
+	receiver := loadShared(t, ctx, env, RuntimeJavaScript, "receiver",
+		receiverScript([]string{"chat.message.received"}), []string{PermChatSend})
+	defer receiver.Close(ctx)
+
+	d := NewLiveDispatcher(func() []*Loaded { return []*Loaded{emitter, receiver} })
+	env.Emit = d.Dispatch
+	d.Dispatch(ctx, EventChatMessageReceived, chatPayload("alice", "hi"))
+
+	want := []string{"got:chat.message.received:undefined"}
+	if got := drainSends(sends, mu); !sameStrings(got, want) {
+		t.Fatalf("forged core event reached subscribers\n got:  %q\n want: %q", got, want)
 	}
 }

--- a/services/plugins/events.go
+++ b/services/plugins/events.go
@@ -2,7 +2,8 @@ package plugins
 
 // Built-in Owncast event types. These mirror the SDK's `Events` const so the
 // host and plugins agree on names without typo risk. Plugin-emitted custom
-// events are arbitrary strings; define those at the call site.
+// events are arbitrary strings, which hostEmitEvent prefixes with the emitting
+// plugin's slug, so they can never collide with the names below.
 const (
 	// Chat events.
 	EventChatMessageReceived  = "chat.message.received"
@@ -48,30 +49,3 @@ const (
 	EventFediverseQuote    = "fediverse.quote"
 	EventFediverseActivity = "fediverse.activity"
 )
-
-// reservedEventTypes are the built-in event types the host originates. A
-// plugin's owncast.emit must not forge them: emitting e.g.
-// "chat.message.received" would deliver a fake core event to every other
-// plugin's on_event handler. Plugin-emitted custom events use any other string.
-var reservedEventTypes = map[string]bool{
-	EventChatMessageReceived:  true,
-	EventChatUserJoined:       true,
-	EventChatUserParted:       true,
-	EventChatUserRenamed:      true,
-	EventChatMessageModerated: true,
-	EventChatCommand:          true,
-	EventStreamStarted:        true,
-	EventStreamStopped:        true,
-	EventStreamTitleChanged:   true,
-	EventSSEConnect:           true,
-	EventSSEDisconnect:        true,
-	EventTick:                 true,
-	EventTimerFire:            true,
-	EventFediverseFollow:      true,
-	EventFediverseLike:        true,
-	EventFediverseRepost:      true,
-	EventFediverseMention:     true,
-	EventFediverseReply:       true,
-	EventFediverseQuote:       true,
-	EventFediverseActivity:    true,
-}

--- a/services/plugins/events.go
+++ b/services/plugins/events.go
@@ -3,7 +3,7 @@ package plugins
 // Built-in Owncast event types. These mirror the SDK's `Events` const so the
 // host and plugins agree on names without typo risk. Plugin-emitted custom
 // events are arbitrary strings, which hostEmitEvent prefixes with the emitting
-// plugin's slug, so they can never collide with the names below.
+// plugin's slug and then checks against reservedEventTypes below.
 const (
 	// Chat events.
 	EventChatMessageReceived  = "chat.message.received"
@@ -49,3 +49,33 @@ const (
 	EventFediverseQuote    = "fediverse.quote"
 	EventFediverseActivity = "fediverse.activity"
 )
+
+// reservedEventTypes are the built-in event types the host originates. The
+// emit path prefixes every plugin-emitted name with the caller's slug, which
+// keeps plugin events out of this set in almost every case - but not all: a
+// plugin whose slug matches a core name's first segment can compose an exact
+// core name (slug "chat" emitting "message.received" yields
+// "chat.message.received"). hostEmitEvent rejects any composed name found in
+// this set, so a forged core event never reaches the dispatcher.
+var reservedEventTypes = map[string]bool{
+	EventChatMessageReceived:  true,
+	EventChatUserJoined:       true,
+	EventChatUserParted:       true,
+	EventChatUserRenamed:      true,
+	EventChatMessageModerated: true,
+	EventChatCommand:          true,
+	EventStreamStarted:        true,
+	EventStreamStopped:        true,
+	EventStreamTitleChanged:   true,
+	EventSSEConnect:           true,
+	EventSSEDisconnect:        true,
+	EventTick:                 true,
+	EventTimerFire:            true,
+	EventFediverseFollow:      true,
+	EventFediverseLike:        true,
+	EventFediverseRepost:      true,
+	EventFediverseMention:     true,
+	EventFediverseReply:       true,
+	EventFediverseQuote:       true,
+	EventFediverseActivity:    true,
+}

--- a/services/plugins/hostfns.go
+++ b/services/plugins/hostfns.go
@@ -1842,12 +1842,18 @@ func hostEmitEvent(env *HostEnv) extism.HostFunction {
 			}
 			// Namespace the event with the caller's slug, which the host
 			// resolved above and the guest never supplies. A plugin can
-			// therefore only publish under "<its-own-slug>.", so it can
-			// neither impersonate another plugin's custom event nor forge a
-			// core event like "chat.message.received" (a prefixed name can
-			// never equal one). Subscriptions stay literal, so a subscriber
-			// names the sender it wants to hear from.
+			// therefore only publish under "<its-own-slug>.", so it cannot
+			// impersonate another plugin's custom events. Subscriptions stay
+			// literal, so a subscriber names the sender it wants to hear from.
 			eventType = pluginName + "." + eventType
+			// The prefix alone does not rule out core-event forgery: a plugin
+			// whose slug matches a core name's first segment can compose an
+			// exact built-in name (slug "chat" + "message.received"). Reject
+			// any composed name that lands in the reserved set.
+			if reservedEventTypes[eventType] {
+				fmt.Fprintf(os.Stderr, "owncast_emit_event from %s: composed name %q is a reserved host event type and was dropped\n", pluginName, eventType)
+				return
+			}
 			payloadBytes, err := p.ReadBytes(stack[1])
 			if err != nil {
 				return

--- a/services/plugins/hostfns.go
+++ b/services/plugins/hostfns.go
@@ -476,14 +476,16 @@ func BuildHostFunctions(env *HostEnv) []extism.HostFunction {
 	// Chat send fns resolve both slug and chat display name at call time:
 	// slug routes to the right bot user, display name is what chat viewers
 	// see.
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostSendChat(env),
 		hostSendChatAction(env),
 		hostSendChatSystem(env),
 		hostSendChatTo(env),
 	)
 	fns = append(fns, hostEmitEvent(env))
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostStreamCurrent(env),
 		hostServerInfo(env),
 		hostServerSocials(env),
@@ -493,23 +495,27 @@ func BuildHostFunctions(env *HostEnv) []extism.HostFunction {
 		hostServerTags(env),
 	)
 	fns = append(fns, hostChatHistory(env))
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostDeleteMessage(env),
 		hostKickClient(env),
 	)
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostSendDiscord(env),
 		hostSendBrowserPush(env),
 		hostSendFediverse(env),
 	)
 	fns = append(fns, hostChatClients(env))
 	fns = append(fns, hostUsersList(env), hostUserGet(env))
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostUsersRegister(env),
 		hostAuthGrantSession(env),
 		hostAuthEndSession(env),
 	)
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostUserSetEnabled(env),
 		hostBanIP(env),
 	)
@@ -528,7 +534,8 @@ func BuildHostFunctions(env *HostEnv) []extism.HostFunction {
 	fns = append(fns, hostConfigGet(env))
 	// Asset reading is ambient: a plugin reads only files it shipped itself.
 	fns = append(fns, hostAssetRead())
-	fns = append(fns,
+	fns = append(
+		fns,
 		hostAddActions(env),
 		hostClearActions(env),
 	)
@@ -1833,10 +1840,14 @@ func hostEmitEvent(env *HostEnv) extism.HostFunction {
 			if err != nil {
 				return
 			}
-			if reservedEventTypes[eventType] {
-				fmt.Fprintf(os.Stderr, "owncast_emit_event from %s: %q is a reserved host event type and cannot be emitted by a plugin\n", pluginName, eventType)
-				return
-			}
+			// Namespace the event with the caller's slug, which the host
+			// resolved above and the guest never supplies. A plugin can
+			// therefore only publish under "<its-own-slug>.", so it can
+			// neither impersonate another plugin's custom event nor forge a
+			// core event like "chat.message.received" (a prefixed name can
+			// never equal one). Subscriptions stay literal, so a subscriber
+			// names the sender it wants to hear from.
+			eventType = pluginName + "." + eventType
 			payloadBytes, err := p.ReadBytes(stack[1])
 			if err != nil {
 				return

--- a/services/plugins/shared_engine_test.go
+++ b/services/plugins/shared_engine_test.go
@@ -293,12 +293,13 @@ func TestEmitSelfSubscriptionDoesNotDeadlock(t *testing.T) {
 	t.Cleanup(func() { compiledEngines.resetForTest(ctx) })
 
 	env, _, _ := captureEnv()
-	// Emits "ping" on every chat message AND subscribes (notify) to "ping".
+	// Emits "ping" on every chat message AND subscribes (notify) to its
+	// host-namespaced event.
 	script := `
 const { definePlugin, owncast } = require("@owncast/plugin-sdk");
 module.exports = definePlugin({
   onChatMessage(msg) { owncast.events.emit("ping", {}); },
-  on: { ping(payload) {} },
+  on: { "echoer.ping"(payload) {} },
 });`
 	loaded := loadShared(t, ctx, env, RuntimeJavaScript, "echoer", script, []string{PermEmitEvent})
 	defer loaded.Close(ctx)


### PR DESCRIPTION
Closes #5093

## The problem

Plugins namespace their own custom events today, on the honor system. Nothing stops `plugin_two` from emitting `plugin_one.foo`, so a subscriber has no way to know who really sent an event. Our own examples don't follow the convention: `relay` emits a bare `announcement.broadcast`.

## The fix

The host now owns the namespace. `owncast_emit_event` prefixes every emitted name with the calling plugin's slug, resolved host-side from the wasm call, so the guest can't supply or override it:

```js
// in the "relay" plugin
owncast.events.emit("announcement.broadcast", payload);
// dispatched as: relay.announcement.broadcast

// subscriber, in any other plugin
on: {
  "relay.announcement.broadcast"(payload) { ... }
}
```

Two consequences, which are exactly the two things #5093 asks for:

1. **No spoofing.** An event named `relay.*` can only have come from `relay`. If another plugin tries `emit("relay.announcement.broadcast")`, it dispatches as `attacker.relay.announcement.broadcast` and no subscriber of the real name hears it.
2. **Uniform namespacing.** Every custom event is `<slug>.<name>`, enforced rather than documented.

Core events are protected too. Slugs like `chat` are legal, so a plugin slugged `chat` emitting `message.received` would otherwise compose the real `chat.message.received`. The host rejects any composed name in `reservedEventTypes`.

Subscriptions stay literal: you subscribe to the sender's full `<slug>.<event>` name, which is what keeps plugin-to-plugin composition working.

## Relationship to the issue text

The issue suggests prefixing the *subscription* side (a plugin registers `foo`, the host stores `plugin_one.foo`) and keeping emit fully qualified. That variant gives each plugin exclusive ownership of its hook names, but it leaves emission anonymous: any plugin could still emit `plugin_one.foo` with a fake payload, and the receiver couldn't tell. Prefixing at emit closes that instead, and subscribing to `relay.announcement.broadcast` still gives the receiver a single trusted sender.

Not addressed here: subscriptions are public. Any plugin can listen to any custom event, the same as core events. Private or targeted delivery is an access-control feature, happy to open a separate issue if that's wanted.

## Tests

`services/plugins/event_namespacing_test.go`, driven through the real JS and Python engines:

- `TestEmitCannotSpoofAnotherPluginsEvents` runs the issue's scenario: a spoof attempt surfaces only under the attacker's own name.
- `TestEmitIsNamespacedByCallerSlug` asserts the exact delivery set for plain, dotted, impersonating, and core-colliding names.
- `TestEmitCannotComposeCoreEventName` covers the slug-`chat` composition case.
- `TestEmitFromPythonIsNamespaced`, `TestEmitWithoutPermissionDispatchesNothing`, `TestSubscriptionsAreNotRewritten`.

`go vet ./services/plugins` and `go test ./services/plugins -count=1` pass. Mutation-checked: removing the prefix or disabling the reserved-name check fails the corresponding tests.

## Follow-up in the SDK

owncast/plugin-sdk#15 updates the docs, types, and relay/announcer examples. It can only land after a release carrying this change is pinned in the SDK's `host-runtime/go.mod`.
