### PR TITLE
Close restored database handles

### DIFF
--- a/utils/backup.go
+++ b/utils/backup.go
@@ -51,6 +51,7 @@ func Restore(backupFile string, databaseFile string) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 	if _, err := db.Exec(rawSQL); err != nil {
 		return err
 	}

--- a/utils/backup.go
+++ b/utils/backup.go
@@ -42,7 +42,11 @@ func Restore(backupFile string, databaseFile string) error {
 	rawSQL := b.String()
 
 	// nolint:gosec
-	if _, err := os.Create(databaseFile); err != nil {
+	f, err := os.Create(databaseFile)
+	if err != nil {
+		return errors.New("unable to write restored database")
+	}
+	if err := f.Close(); err != nil {
 		return errors.New("unable to write restored database")
 	}
 


### PR DESCRIPTION
The restore helper opens the restored SQLite database to execute the backup SQL, but never closes it. That leaves the file locked on Windows until the test process exits, so the temp directory cleanup fails.

Add a deferred close after opening the restored database. The existing backup and restore tests now pass repeatedly on Linux, including the race detector, and the full pre-push checks passed locally.

This is a small follow-up to the browser push SSRF work. It only fixes the test and runtime resource leak that was blocking the Windows Go test job.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->