### PR TITLE
Limit Fediverse OTP attempts

### DIFF
--- a/auth/fediverse/fediverse.go
+++ b/auth/fediverse/fediverse.go
@@ -104,7 +104,7 @@ func (s *Service) RegisterFediverseOTP(accessToken, userID, userDisplayName, acc
 	return r, true, nil
 }
 
-// ValidateFediverseOTP will verify a OTP code for an auth request.
+// ValidateFediverseOTP will verify an OTP code for an auth request.
 func (s *Service) ValidateFediverseOTP(accessToken, code string) (bool, *OTPRegistration) {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/auth/fediverse/fediverse.go
+++ b/auth/fediverse/fediverse.go
@@ -18,11 +18,13 @@ type OTPRegistration struct {
 	UserDisplayName string
 	Code            string
 	Account         string
+	FailedAttempts  int
 }
 
 const (
 	registrationTimeout = time.Minute * 10
 	maxPendingRequests  = 1000
+	maxOTPAttempts      = 5
 )
 
 // Service bundles the per-instance state for the Fediverse OTP flow.
@@ -102,13 +104,24 @@ func (s *Service) RegisterFediverseOTP(accessToken, userID, userDisplayName, acc
 	return r, true, nil
 }
 
-// ValidateFediverseOTP will verify a OTP code for a auth request.
+// ValidateFediverseOTP will verify a OTP code for an auth request.
 func (s *Service) ValidateFediverseOTP(accessToken, code string) (bool, *OTPRegistration) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	request, ok := s.pendingAuthRequests[accessToken]
-	if !ok || request.Code != code || time.Since(request.Timestamp) > registrationTimeout {
+	if !ok || time.Since(request.Timestamp) > registrationTimeout {
+		delete(s.pendingAuthRequests, accessToken)
+		return false, nil
+	}
+
+	if request.Code != code {
+		request.FailedAttempts++
+		if request.FailedAttempts >= maxOTPAttempts {
+			delete(s.pendingAuthRequests, accessToken)
+		} else {
+			s.pendingAuthRequests[accessToken] = request
+		}
 		return false, nil
 	}
 

--- a/auth/fediverse/fediverse_test.go
+++ b/auth/fediverse/fediverse_test.go
@@ -55,6 +55,49 @@ func TestOTPFlowValidation(t *testing.T) {
 	}
 }
 
+func TestOTPFlowLimitsFailedAttempts(t *testing.T) {
+	svc := New()
+	token := "attempt-limit-token"
+	registration, _, err := svc.RegisterFediverseOTP(token, userID, userDisplayName, account)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for attempt := 1; attempt < maxOTPAttempts; attempt++ {
+		if valid, _ := svc.ValidateFediverseOTP(token, "wrong-code"); valid {
+			t.Fatalf("wrong code succeeded on attempt %d", attempt)
+		}
+		pending, ok := svc.pendingAuthRequests[token]
+		if !ok {
+			t.Fatalf("request was removed before attempt limit on attempt %d", attempt)
+		}
+		if pending.FailedAttempts != attempt {
+			t.Fatalf("failed attempts = %d, want %d", pending.FailedAttempts, attempt)
+		}
+	}
+
+	if valid, _ := svc.ValidateFediverseOTP(token, registration.Code); !valid {
+		t.Fatal("correct code should succeed before the attempt limit")
+	}
+
+	exhaustedToken := "exhausted-attempt-token"
+	exhausted, _, err := svc.RegisterFediverseOTP(exhaustedToken, userID, userDisplayName, account)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 1; attempt <= maxOTPAttempts; attempt++ {
+		if valid, _ := svc.ValidateFediverseOTP(exhaustedToken, "wrong-code"); valid {
+			t.Fatalf("wrong code succeeded on attempt %d", attempt)
+		}
+	}
+	if _, ok := svc.pendingAuthRequests[exhaustedToken]; ok {
+		t.Fatal("request remained after the attempt limit")
+	}
+	if valid, _ := svc.ValidateFediverseOTP(exhaustedToken, exhausted.Code); valid {
+		t.Fatal("correct code succeeded after the attempt limit")
+	}
+}
+
 func TestSingleOTPFlowRequest(t *testing.T) {
 	svc := New()
 	r1, _, _ := svc.RegisterFediverseOTP(accessToken, userID, userDisplayName, account)


### PR DESCRIPTION
The Fediverse OTP flow now limits failed code attempts for each pending request.

A six-digit code remains valid for ten minutes, but five incorrect attempts now invalidate the request. Attempts are counted while holding the existing service lock, so concurrent guesses cannot bypass the limit. A new request can be started after the old one is invalidated.

Added coverage for attempts below the limit, successful validation after failed attempts, and invalidation after the fifth wrong code.

This addresses GHSA-5m4w-pwvc-qq24. The previously closed GHSA-jqrx-r2vr-f5x5 report covers the same root issue.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->