### PR TITLE
Bind ActivityPub signatures to request bodies

### DIFF
--- a/services/activitypub/inbox/worker.go
+++ b/services/activitypub/inbox/worker.go
@@ -172,28 +172,35 @@ func signedHeaders(signature string) (map[string]struct{}, error) {
 
 func verifyRequestBody(request *http.Request, body []byte) error {
 	digest := request.Header.Get("Digest")
-	parts := strings.SplitN(digest, "=", 2)
-	if len(parts) != 2 {
+	if digest == "" {
 		return errors.New("request body digest is missing or malformed")
 	}
 
-	var actual []byte
-	switch strings.ToUpper(parts[0]) {
-	case "SHA-256":
-		sum := sha256.Sum256(body)
-		actual = sum[:]
-	case "SHA-512":
-		sum := sha512.Sum512(body)
-		actual = sum[:]
-	default:
-		return errors.New("request body digest uses an unsupported algorithm")
+	for _, candidate := range strings.Split(digest, ",") {
+		parts := strings.SplitN(strings.TrimSpace(candidate), "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		var actual []byte
+		switch strings.ToUpper(strings.TrimSpace(parts[0])) {
+		case "SHA-256":
+			sum := sha256.Sum256(body)
+			actual = sum[:]
+		case "SHA-512":
+			sum := sha512.Sum512(body)
+			actual = sum[:]
+		default:
+			continue
+		}
+
+		expected, err := base64.StdEncoding.DecodeString(strings.TrimSpace(parts[1]))
+		if err == nil && subtle.ConstantTimeCompare(actual, expected) == 1 {
+			return nil
+		}
 	}
 
-	expected, err := base64.StdEncoding.DecodeString(parts[1])
-	if err != nil || subtle.ConstantTimeCompare(actual, expected) != 1 {
-		return errors.New("request body digest does not match")
-	}
-	return nil
+	return errors.New("request body digest does not match")
 }
 
 // Verify validates the HTTP signature of an inbound request against the
@@ -237,13 +244,12 @@ func (s *Service) Verify(request *http.Request, body []byte) (*url.URL, error) {
 	var algorithmString string
 	signatureComponents := strings.Split(signature, ",")
 	for _, component := range signatureComponents {
-		kv := strings.SplitN(component, "=", 2)
-		if len(kv) == 2 && kv[0] == "algorithm" {
+		kv := strings.SplitN(strings.TrimSpace(component), "=", 2)
+		if len(kv) == 2 && strings.EqualFold(strings.TrimSpace(kv[0]), "algorithm") {
 			algorithmString = kv[1]
 			break
 		}
 	}
-
 	algorithmString = strings.Trim(algorithmString, "\"")
 	if algorithmString == "" {
 		return nil, errors.New("Unable to determine algorithm to verify request")

--- a/services/activitypub/inbox/worker.go
+++ b/services/activitypub/inbox/worker.go
@@ -2,7 +2,11 @@ package inbox
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -20,7 +24,7 @@ import (
 )
 
 func (s *Service) handle(request apmodels.InboxRequest) {
-	keyOwner, err := s.Verify(request.Request)
+	keyOwner, err := s.Verify(request.Request, request.Body)
 	if err != nil {
 		log.Debugln("Error in attempting to verify request", err)
 		return
@@ -149,13 +153,56 @@ func requestDateWithinTolerance(request *http.Request) error {
 	return nil
 }
 
+func signedHeaders(signature string) (map[string]struct{}, error) {
+	headers := make(map[string]struct{})
+	for _, component := range strings.Split(signature, ",") {
+		kv := strings.SplitN(strings.TrimSpace(component), "=", 2)
+		if len(kv) != 2 {
+			return nil, errors.New("malformed HTTP signature parameter")
+		}
+		if strings.EqualFold(kv[0], "headers") {
+			for _, header := range strings.Fields(strings.Trim(kv[1], "\"")) {
+				headers[strings.ToLower(header)] = struct{}{}
+			}
+			return headers, nil
+		}
+	}
+	return headers, nil
+}
+
+func verifyRequestBody(request *http.Request, body []byte) error {
+	digest := request.Header.Get("Digest")
+	parts := strings.SplitN(digest, "=", 2)
+	if len(parts) != 2 {
+		return errors.New("request body digest is missing or malformed")
+	}
+
+	var actual []byte
+	switch strings.ToUpper(parts[0]) {
+	case "SHA-256":
+		sum := sha256.Sum256(body)
+		actual = sum[:]
+	case "SHA-512":
+		sum := sha512.Sum512(body)
+		actual = sum[:]
+	default:
+		return errors.New("request body digest uses an unsupported algorithm")
+	}
+
+	expected, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil || subtle.ConstantTimeCompare(actual, expected) != 1 {
+		return errors.New("request body digest does not match")
+	}
+	return nil
+}
+
 // Verify validates the HTTP signature of an inbound request against the
 // signing actor's public key and checks it against blocked domains/actors. On
 // success it returns the verified key owner's actor IRI (used by the caller to
 // bind the activity's actor to its signer); on failure it returns a nil IRI
 // and an error.
 // nolint: cyclop
-func (s *Service) Verify(request *http.Request) (*url.URL, error) {
+func (s *Service) Verify(request *http.Request, body []byte) (*url.URL, error) {
 	verifier, err := httpsig.NewVerifier(request)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create key verifier for request")
@@ -174,12 +221,24 @@ func (s *Service) Verify(request *http.Request) (*url.URL, error) {
 	if signature == "" {
 		return nil, errors.New("http signature header not found in request")
 	}
+	signed, err := signedHeaders(signature)
+	if err != nil {
+		return nil, err
+	}
+	for _, required := range []string{httpsig.RequestTarget, "host", "date", "digest"} {
+		if _, ok := signed[strings.ToLower(required)]; !ok {
+			return nil, errors.Errorf("http signature does not sign required header %q", required)
+		}
+	}
+	if err := verifyRequestBody(request, body); err != nil {
+		return nil, err
+	}
 
 	var algorithmString string
 	signatureComponents := strings.Split(signature, ",")
 	for _, component := range signatureComponents {
-		kv := strings.Split(component, "=")
-		if kv[0] == "algorithm" {
+		kv := strings.SplitN(component, "=", 2)
+		if len(kv) == 2 && kv[0] == "algorithm" {
 			algorithmString = kv[1]
 			break
 		}

--- a/services/activitypub/inbox/worker_test.go
+++ b/services/activitypub/inbox/worker_test.go
@@ -227,6 +227,8 @@ func TestVerifyRequestBody(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "matching digest", digest: digest, body: body},
+		{name: "whitespace", digest: " SHA-256 = " + base64.StdEncoding.EncodeToString(sum[:]) + " ", body: body},
+		{name: "multiple digests", digest: "SHA-512=invalid, " + digest, body: body},
 		{name: "changed body", digest: digest, body: []byte(`{"type":"Follow"}`), wantErr: true},
 		{name: "missing digest", body: body, wantErr: true},
 		{name: "malformed digest", digest: "SHA-256", body: body, wantErr: true},

--- a/services/activitypub/inbox/worker_test.go
+++ b/services/activitypub/inbox/worker_test.go
@@ -2,10 +2,13 @@ package inbox
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"code.superseriousbusiness.org/activity/streams"
@@ -209,6 +212,61 @@ func TestHandleVerifiedIngress(t *testing.T) {
 				t.Fatalf("payload = %q, want exact raw JSON %q", payload, tt.body)
 			}
 		})
+	}
+}
+
+func TestVerifyRequestBody(t *testing.T) {
+	body := []byte(`{"type":"Like"}`)
+	sum := sha256.Sum256(body)
+	digest := "SHA-256=" + base64.StdEncoding.EncodeToString(sum[:])
+
+	tests := []struct {
+		name    string
+		digest  string
+		body    []byte
+		wantErr bool
+	}{
+		{name: "matching digest", digest: digest, body: body},
+		{name: "changed body", digest: digest, body: []byte(`{"type":"Follow"}`), wantErr: true},
+		{name: "missing digest", body: body, wantErr: true},
+		{name: "malformed digest", digest: "SHA-256", body: body, wantErr: true},
+		{name: "unsupported algorithm", digest: "MD5=abc", body: body, wantErr: true},
+		{name: "invalid encoding", digest: "SHA-256=not-base64", body: body, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest("POST", "https://local.example/inbox", nil)
+			if tt.digest != "" {
+				request.Header.Set("Digest", tt.digest)
+			}
+			if err := verifyRequestBody(request, tt.body); (err != nil) != tt.wantErr {
+				t.Fatalf("verifyRequestBody() error = %v, want error: %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSignedHeaders(t *testing.T) {
+	signature := `keyId="https://remote.example/actor#key",headers="(request-target) host date digest",signature="abc"`
+	headers, err := signedHeaders(signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{"(request-target)", "host", "date", "digest"} {
+		if _, ok := headers[required]; !ok {
+			t.Errorf("signed headers missing %q", required)
+		}
+	}
+}
+
+func TestVerifyRequiresSignedDigest(t *testing.T) {
+	request := httptest.NewRequest("POST", "https://local.example/inbox", nil)
+	request.Header.Set("Signature", `keyId="https://remote.example/actor#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="abc"`)
+
+	_, err := (&Service{}).Verify(request, []byte(`{"type":"Like"}`))
+	if err == nil || !strings.Contains(err.Error(), `does not sign required header "digest"`) {
+		t.Fatalf("Verify() error = %v, want missing signed Digest error", err)
 	}
 }
 

--- a/test/automated/browser/cypress/support/remote-fediverse-server.js
+++ b/test/automated/browser/cypress/support/remote-fediverse-server.js
@@ -176,6 +176,7 @@ async function deliverSignedActivity(actor, inboxUrl, activity) {
 	const date = new Date().toUTCString();
 	const signingString = [
 		`(request-target): post ${url.pathname}`,
+		`host: ${url.host}`,
 		`date: ${date}`,
 		`digest: ${digest}`,
 	].join('\n');
@@ -189,9 +190,10 @@ async function deliverSignedActivity(actor, inboxUrl, activity) {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/activity+json',
+				Host: url.host,
 				Date: date,
 				Digest: digest,
-				Signature: `keyId="${actor.iri}#main-key",algorithm="rsa-sha256",headers="(request-target) date digest",signature="${signature}"`,
+				Signature: `keyId="${actor.iri}#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${signature}"`,
 			},
 			body,
 		});


### PR DESCRIPTION
ActivityPub inbox verification now checks that the signed Digest header matches the exact request body before processing an activity.

The verifier also requires the signature to cover `(request-target)`, `host`, `date`, and `digest`. Owncast already signs those headers for outbound ActivityPub requests. This prevents a valid signature from being reused with a different body.

Added coverage for matching, changed, missing, malformed, unsupported, and invalid body digests, plus rejection when Digest is not part of the signed header set.

This addresses GHSA-2xf4-24vg-253p. The existing actor-origin and Date freshness checks remain in place.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->