### PR TITLE
Preserve moderator identity in plugin moderation events

### DIFF
--- a/pluginhost/pluginevents_test.go
+++ b/pluginhost/pluginevents_test.go
@@ -279,6 +279,7 @@ func TestTranslateWebhookEvent_VisibilityFansOutPerMessage(t *testing.T) {
 	evt := webhooks.WebhookEvent{
 		Type: models.VisibiltyToggled,
 		EventData: &webhooks.WebhookVisibilityToggleEventData{
+			User:       &models.User{ID: "moderator-id"},
 			Visible:    false,
 			MessageIDs: []string{"a", "b", "c"},
 		},
@@ -294,6 +295,9 @@ func TestTranslateWebhookEvent_VisibilityFansOutPerMessage(t *testing.T) {
 		}
 		if mod.MessageID != id || mod.Visible {
 			t.Errorf("event %d = %+v want id %q visible false", i, mod, id)
+		}
+		if mod.Moderator == nil || mod.Moderator.ID != "moderator-id" {
+			t.Errorf("event %d moderator = %+v, want moderator-id", i, mod.Moderator)
 		}
 	}
 }

--- a/pluginhost/pluginhost.go
+++ b/pluginhost/pluginhost.go
@@ -1744,7 +1744,7 @@ func wireChatModerationHostFns(env *plugins.HostEnv, deps Deps) {
 	chatSvc := deps.Chat
 
 	env.DeleteMessage = func(pluginName, messageID string) error {
-		if err := chatSvc.SetMessagesVisibility([]string{messageID}, false); err != nil {
+		if err := chatSvc.SetMessagesVisibility([]string{messageID}, false, nil); err != nil {
 			return err
 		}
 		return nil

--- a/services/chat/messages.go
+++ b/services/chat/messages.go
@@ -5,11 +5,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/owncast/owncast/models"
 	"github.com/owncast/owncast/services/chat/events"
 )
 
 // SetMessagesVisibility sets the visibility of multiple messages by ID.
-func (s *Service) SetMessagesVisibility(messageIDs []string, visibility bool) error {
+func (s *Service) SetMessagesVisibility(messageIDs []string, visibility bool, moderator *models.User) error {
 	// Save new message visibility
 	if err := s.chatMessageRepository.SetMessageVisibilityForMessageIDs(messageIDs, visibility); err != nil {
 		log.Errorln(err)
@@ -22,6 +23,7 @@ func (s *Service) SetMessagesVisibility(messageIDs []string, visibility bool) er
 		MessageIDs: messageIDs,
 		Visible:    visibility,
 	}
+	event.User = moderator
 	event.Event.SetDefaults()
 
 	payload := event.GetBroadcastPayload()

--- a/services/chat/messages_test.go
+++ b/services/chat/messages_test.go
@@ -81,7 +81,7 @@ func TestSetMessagesVisibilityIncludesModeratorInWebhookEvent(t *testing.T) {
 	if !ok {
 		t.Fatalf("event data type = %T, want *WebhookVisibilityToggleEventData", received.EventData)
 	}
-	if payload.User != moderator {
-		t.Fatalf("moderator = %#v, want %#v", payload.User, moderator)
+	if payload.User == nil || payload.User.ID != moderator.ID {
+		t.Fatalf("moderator = %#v, want ID %q", payload.User, moderator.ID)
 	}
 }

--- a/services/chat/messages_test.go
+++ b/services/chat/messages_test.go
@@ -1,0 +1,87 @@
+package chat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/owncast/owncast/models"
+	"github.com/owncast/owncast/persistence/chatmessagerepository"
+	"github.com/owncast/owncast/persistence/configrepository"
+	"github.com/owncast/owncast/persistence/webhookrepository"
+	"github.com/owncast/owncast/services/chat/events"
+	"github.com/owncast/owncast/services/dispatcher"
+	"github.com/owncast/owncast/services/webhooks"
+)
+
+type moderationTestChatRepository struct{}
+
+func (moderationTestChatRepository) SaveUserMessage(events.UserMessageEvent)             {}
+func (moderationTestChatRepository) SaveFederatedAction(events.FediverseEngagementEvent) {}
+func (moderationTestChatRepository) SaveEvent(string, *string, string, string, *time.Time, time.Time, *string, *string, *string, *string) {
+}
+func (moderationTestChatRepository) GetChatModerationHistory() []interface{} { return nil }
+func (moderationTestChatRepository) GetChatHistory() []interface{}           { return nil }
+func (moderationTestChatRepository) GetMessagesFromUser(string) ([]events.UserMessageEvent, error) {
+	return nil, nil
+}
+
+func (moderationTestChatRepository) GetMessageIdsForUserID(string) ([]string, error) {
+	return nil, nil
+}
+
+func (moderationTestChatRepository) SetMessageVisibilityForMessageIDs([]string, bool) error {
+	return nil
+}
+func (moderationTestChatRepository) GetMessagesCount() int64 { return 0 }
+
+var _ chatmessagerepository.ChatMessageRepository = moderationTestChatRepository{}
+
+type moderationTestConfig struct {
+	configrepository.ConfigRepository
+}
+
+func (moderationTestConfig) GetServerURL() string { return "http://owncast.test" }
+
+type moderationTestWebhookRepository struct {
+	webhookrepository.WebhookRepository
+}
+
+func (moderationTestWebhookRepository) GetWebhooksForEvent(models.EventType) []models.Webhook {
+	return nil
+}
+
+func TestSetMessagesVisibilityIncludesModeratorInWebhookEvent(t *testing.T) {
+	eventDispatcher := dispatcher.New()
+	var received webhooks.WebhookEvent
+	eventDispatcher.AddListener(func(_ context.Context, event dispatcher.Event) {
+		received = event.Payload.(webhooks.WebhookEvent)
+	})
+
+	webhookService := webhooks.New(webhooks.Deps{
+		GetStatus:         func() models.Status { return models.Status{Online: true} },
+		ConfigRepository:  moderationTestConfig{},
+		WebhookRepository: moderationTestWebhookRepository{},
+		Events:            eventDispatcher,
+	})
+	chatService := New(Deps{
+		ChatMessageRepository: moderationTestChatRepository{},
+		Webhooks:              webhookService,
+	})
+	moderator := &models.User{
+		ID:          "moderator-id",
+		DisplayName: "Moderator",
+	}
+
+	if err := chatService.SetMessagesVisibility([]string{"message-id"}, false, moderator); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, ok := received.EventData.(*webhooks.WebhookVisibilityToggleEventData)
+	if !ok {
+		t.Fatalf("event data type = %T, want *WebhookVisibilityToggleEventData", received.EventData)
+	}
+	if payload.User != moderator {
+		t.Fatalf("moderator = %#v, want %#v", payload.User, moderator)
+	}
+}

--- a/webserver/handlers/admin/chat.go
+++ b/webserver/handlers/admin/chat.go
@@ -16,6 +16,7 @@ import (
 	"github.com/owncast/owncast/services/chat/events"
 	"github.com/owncast/owncast/utils"
 	"github.com/owncast/owncast/webserver/handlers/generated"
+	"github.com/owncast/owncast/webserver/router/middleware"
 	webutils "github.com/owncast/owncast/webserver/utils"
 )
 
@@ -46,7 +47,7 @@ func (a *Admin) UpdateMessageVisibility(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := a.chat.SetMessagesVisibility(*request.IdArray, *request.Visible); err != nil {
+	if err := a.chat.SetMessagesVisibility(*request.IdArray, *request.Visible, middleware.UserFromRequest(r)); err != nil {
 		webutils.WriteSimpleResponse(w, false, err.Error())
 		return
 	}
@@ -126,7 +127,7 @@ func (a *Admin) UpdateUserEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := a.updateUserStatus(request); err != nil {
+	if err := a.updateUserStatus(request, middleware.UserFromRequest(r)); err != nil {
 		webutils.WriteSimpleResponse(w, false, err.Error())
 		return
 	}
@@ -141,7 +142,7 @@ func (a *Admin) UpdateUserEnabled(w http.ResponseWriter, r *http.Request) {
 	webutils.WriteSimpleResponse(w, true, fmt.Sprintf("%s enabled: %t", *request.UserId, *request.Enabled))
 }
 
-func (a *Admin) updateUserStatus(request generated.UpdateUserEnabledJSONBody) error {
+func (a *Admin) updateUserStatus(request generated.UpdateUserEnabledJSONBody, moderator *models.User) error {
 	if err := a.userRepository.SetEnabled(*request.UserId, *request.Enabled); err != nil {
 		log.Errorln("error changing user enabled status", err)
 		return err
@@ -153,7 +154,7 @@ func (a *Admin) updateUserStatus(request generated.UpdateUserEnabledJSONBody) er
 	}
 
 	if !*request.Enabled && len(messageIDs) > 0 {
-		if err := a.chat.SetMessagesVisibility(messageIDs, *request.Enabled); err != nil {
+		if err := a.chat.SetMessagesVisibility(messageIDs, *request.Enabled, moderator); err != nil {
 			log.Errorln("error changing user messages visibility", err)
 			return err
 		}

--- a/webserver/router/middleware/auth.go
+++ b/webserver/router/middleware/auth.go
@@ -16,8 +16,8 @@ import (
 
 type userContextKey struct{}
 
-// UserFromRequest returns the authenticated user attached by user-token
-// middleware, or nil when the request was not authenticated that way.
+// UserFromRequest returns the moderator attached by
+// RequireUserModerationScopeAccesstoken, or nil for other authentication paths.
 func UserFromRequest(r *http.Request) *models.User {
 	user, _ := r.Context().Value(userContextKey{}).(*models.User)
 	return user

--- a/webserver/router/middleware/auth.go
+++ b/webserver/router/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"crypto/subtle"
 	"net"
 	"net/http"
@@ -12,6 +13,15 @@ import (
 	"github.com/owncast/owncast/models"
 	"github.com/owncast/owncast/utils"
 )
+
+type userContextKey struct{}
+
+// UserFromRequest returns the authenticated user attached by user-token
+// middleware, or nil when the request was not authenticated that way.
+func UserFromRequest(r *http.Request) *models.User {
+	user, _ := r.Context().Value(userContextKey{}).(*models.User)
+	return user
+}
 
 // ExternalAccessTokenHandlerFunc is a function that is called after validing access.
 type ExternalAccessTokenHandlerFunc func(models.ExternalAPIUser, http.ResponseWriter, *http.Request)
@@ -239,7 +249,6 @@ func (m *Middleware) RequireUserModerationScopeAccesstoken(handler http.HandlerF
 			accessDenied(w)
 			return
 		}
-
 		// A user is required to use the websocket
 		user := m.userRepository.GetUserByToken(accessToken)
 		if user == nil || !user.IsEnabled() || !user.IsModerator() {
@@ -247,6 +256,10 @@ func (m *Middleware) RequireUserModerationScopeAccesstoken(handler http.HandlerF
 			return
 		}
 
+		// Keep the authenticated moderator attached to the request so handlers
+		// can attribute moderation events without re-reading untrusted request
+		// parameters.
+		r = r.WithContext(context.WithValue(r.Context(), userContextKey{}, user))
 		handler(w, r)
 	})
 }

--- a/webserver/router/middleware/auth_moderation_test.go
+++ b/webserver/router/middleware/auth_moderation_test.go
@@ -38,7 +38,7 @@ func TestRequireUserModerationScopeAttachesAuthenticatedUser(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if got != moderator {
-		t.Fatalf("authenticated user = %#v, want %#v", got, moderator)
+	if got == nil || got.ID != moderator.ID {
+		t.Fatalf("authenticated user = %#v, want ID %q", got, moderator.ID)
 	}
 }

--- a/webserver/router/middleware/auth_moderation_test.go
+++ b/webserver/router/middleware/auth_moderation_test.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/owncast/owncast/models"
+	"github.com/owncast/owncast/persistence/userrepository"
+)
+
+type moderationUserRepository struct {
+	userrepository.UserRepository
+	user *models.User
+}
+
+func (r moderationUserRepository) GetUserByToken(string) *models.User { return r.user }
+
+var _ userrepository.UserRepository = moderationUserRepository{}
+
+func TestRequireUserModerationScopeAttachesAuthenticatedUser(t *testing.T) {
+	moderator := &models.User{
+		ID:     "moderator-id",
+		Scopes: []string{models.ModeratorScopeKey},
+	}
+	middleware := &Middleware{
+		userRepository: moderationUserRepository{user: moderator},
+	}
+	var got *models.User
+	handler := middleware.RequireUserModerationScopeAccesstoken(func(_ http.ResponseWriter, r *http.Request) {
+		got = UserFromRequest(r)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/messagevisibility?accessToken=token", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got != moderator {
+		t.Fatalf("authenticated user = %#v, want %#v", got, moderator)
+	}
+}


### PR DESCRIPTION
Chat moderation events now preserve the moderator who changed message visibility.

The moderation middleware already validates the user. It now keeps that user on the request so the chat service can include it in the event delivered to plugins. Message visibility changes initiated by plugins or the admin remain unattributed.

- Carry the validated moderator through the moderation request context.
- Include the moderator in visibility events, including messages hidden when a user is disabled.
- Add coverage for request propagation, chat event creation, and plugin payload translation.

`go test ./...` passes with 40 packages containing tests. Focused golangci-lint passes with 0 issues.

Fixes #5124

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->