### PR TITLE
Preserve custom CSS overrides with Ant Design

### DIFF
--- a/test/automated/browser/cypress/e2e/offline/05-offline_identifier_check.cy.js
+++ b/test/automated/browser/cypress/e2e/offline/05-offline_identifier_check.cy.js
@@ -37,4 +37,107 @@ filterTests(['desktop'], () => {
 			cy.get(modalContainer, { timeout: 2000 }).should('be.visible');
 		});
 	});
+
+	describe('Applies documented CSS variable customizations', () => {
+		before(() => {
+			cy.setConfig('appearance', {
+				'theme-color-action': 'blue',
+			});
+			cy.setConfig(
+				'customstyles',
+				`:root {
+					--theme-color-action: red;
+					--theme-color-components-primary-button-border: green;
+					--theme-text-display-font-family: monospace;
+					--theme-text-body-font-family: monospace;
+				}
+
+				#notify-button {
+					border-width: 4px;
+				}
+
+				#notify-button:focus {
+					background-color: rgb(0, 0, 255);
+				}`,
+			);
+			cy.visit('http://localhost:8080/');
+		});
+
+		after(() => {
+			cy.setConfig('customstyles', '');
+			cy.setConfig('appearance', {});
+		});
+
+		it('applies font variables to native and Ant Design elements', () => {
+			cy.get('body').should('have.css', 'font-family', 'monospace');
+			cy.get('#global-header-text').should(
+				'have.css',
+				'font-family',
+				'monospace',
+			);
+			cy.get('#notify-button').should('have.css', 'font-family', 'monospace');
+		});
+
+		it('lets custom variables override appearance variables', () => {
+			cy.document().then((document) => {
+				expect(
+					getComputedStyle(document.documentElement)
+						.getPropertyValue('--theme-color-action')
+						.trim(),
+				).to.equal('red');
+			});
+			cy.get('#notify-button').should(
+				'have.css',
+				'background-color',
+				'rgb(255, 0, 0)',
+			);
+		});
+
+		it('applies custom selectors with higher specificity than component styles', () => {
+			cy.get('#notify-button').should('have.css', 'border-width', '4px');
+		});
+
+		it('applies custom interactive state selectors', () => {
+			cy.get('#notify-button')
+				.focus()
+				.should('have.css', 'background-color', 'rgb(0, 0, 255)');
+		});
+
+		it('retains the cascade after a full page reload', () => {
+			cy.reload();
+			cy.get('#notify-button').should(
+				'have.css',
+				'background-color',
+				'rgb(255, 0, 0)',
+			);
+		});
+	});
+});
+
+filterTests(['mobile'], () => {
+	describe('Applies responsive custom CSS', () => {
+		before(() => {
+			cy.setConfig(
+				'customstyles',
+				`@media (max-width: 600px) {
+					#global-header-text {
+						color: rgb(0, 128, 0);
+					}
+				}`,
+			);
+			cy.visit('http://localhost:8080/');
+		});
+
+		after(() => {
+			cy.setConfig('customstyles', '');
+		});
+
+		it('applies media-query overrides at the mobile viewport', () => {
+			cy.get('#global-header-text').should(
+				'have.css',
+				'color',
+				'rgb(0, 128, 0)',
+			);
+		});
+	});
 });

--- a/test/automated/browser/cypress/e2e/offline/05-offline_identifier_check.cy.js
+++ b/test/automated/browser/cypress/e2e/offline/05-offline_identifier_check.cy.js
@@ -86,11 +86,9 @@ filterTests(['desktop'], () => {
 						.trim(),
 				).to.equal('red');
 			});
-			cy.get('#notify-button').should(
-				'have.css',
-				'background-color',
-				'rgb(255, 0, 0)',
-			);
+			cy.get('#notify-button')
+				.should('have.css', 'background-color', 'rgb(255, 0, 0)')
+				.and('have.css', 'border-color', 'rgb(0, 128, 0)');
 		});
 
 		it('applies custom selectors with higher specificity than component styles', () => {

--- a/web/components/theme/antd-default-theme.json
+++ b/web/components/theme/antd-default-theme.json
@@ -13,7 +13,7 @@
     "colorTextSecondary": "#5d5f72",
     "colorError": "#ff4b39",
     "colorWarning": "#ffc655",
-    "fontFamily": "Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif"
+    "fontFamily": "var(--theme-text-body-font-family)"
   },
   "components": {
     "Modal": {

--- a/web/styles/ant-overrides.scss
+++ b/web/styles/ant-overrides.scss
@@ -8,6 +8,25 @@
   height: auto;
 }
 
+// Keep public Owncast CSS variables authoritative for Ant Design buttons.
+.ant-btn.ant-btn-color-primary {
+  --ant-btn-color-base: var(--theme-color-components-primary-button-background);
+  --ant-btn-color-hover: var(--theme-color-action-hover);
+  --ant-btn-color-active: var(--theme-color-action-hover);
+}
+
+.ant-btn.ant-btn-color-primary.ant-btn-variant-solid {
+  --ant-btn-border-color: var(--theme-color-components-primary-button-border);
+  --ant-btn-text-color: var(--theme-color-components-primary-button-text);
+}
+
+.ant-btn.ant-btn-color-primary:disabled,
+.ant-btn.ant-btn-color-primary.ant-btn-disabled {
+  border-color: var(--theme-color-components-primary-button-border-disabled);
+  color: var(--theme-color-components-primary-button-text-disabled);
+  background: var(--theme-color-components-primary-button-background-disabled);
+}
+
 .ant-alert-error {
   .ant-alert-icon {
     color: var(--theme-color-palette-error);

--- a/web/styles/antd.css
+++ b/web/styles/antd.css
@@ -5292,9 +5292,7 @@ span.ant-typography-ellipsis-single-line {
   --ant-color-link: #6544e9;
   --ant-color-text-base: #000;
   --ant-color-bg-base: #fff;
-  --ant-font-family:
-    Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, 'Noto Sans', sans-serif;
+  --ant-font-family: var(--theme-text-body-font-family);
   --ant-font-family-code: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   --ant-font-size: 14px;
   --ant-line-width: 1px;
@@ -6158,9 +6156,7 @@ span.ant-typography-ellipsis-single-line {
   --ant-color-link: #6544e9;
   --ant-color-text-base: #000;
   --ant-color-bg-base: #fff;
-  --ant-font-family:
-    Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, 'Noto Sans', sans-serif;
+  --ant-font-family: var(--theme-text-body-font-family);
   --ant-font-family-code: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   --ant-font-size: 14px;
   --ant-line-width: 1px;
@@ -22650,9 +22646,7 @@ a[disabled] {
   --ant-color-link: #6544e9;
   --ant-color-text-base: #000;
   --ant-color-bg-base: #fff;
-  --ant-font-family:
-    Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, 'Noto Sans', sans-serif;
+  --ant-font-family: var(--theme-text-body-font-family);
   --ant-font-family-code: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   --ant-font-size: 14px;
   --ant-line-width: 1px;

--- a/web/tests/themeCascade.test.tsx
+++ b/web/tests/themeCascade.test.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import { ReactElement } from 'react';
+import { clientConfigStateAtom } from '../components/stores/ClientConfigStore';
+import { Theme } from '../components/theme/Theme';
+import { PluginTabFrame } from '../components/ui/PluginTabFrame/PluginTabFrame';
+import { ClientConfig, makeEmptyClientConfig } from '../interfaces/client-config.model';
+
+const CASCADE_VARIABLE = '--cascade-probe';
+const pluginStyles = `:root { ${CASCADE_VARIABLE}: plugin; }`;
+const appearanceVariables = { 'cascade-probe': 'appearance' };
+const customStyles = `:root { ${CASCADE_VARIABLE}: custom; }`;
+
+const renderWithConfig = (component: ReactElement, config: Partial<ClientConfig>) => {
+  const store = createStore();
+  store.set(clientConfigStateAtom, { ...makeEmptyClientConfig(), ...config });
+  return { store, ...render(<Provider store={store}>{component}</Provider>) };
+};
+
+const cascadeValue = (doc: Document) =>
+  doc.defaultView?.getComputedStyle(doc.documentElement).getPropertyValue(CASCADE_VARIABLE).trim();
+
+describe('theme cascade', () => {
+  it('orders plugin styles, appearance variables, and custom CSS on the viewer', () => {
+    const config = {
+      ...makeEmptyClientConfig(),
+      pluginStyles,
+      appearanceVariables,
+      customStyles,
+    };
+    const { store } = renderWithConfig(<Theme />, config);
+
+    expect(cascadeValue(document)).toBe('custom');
+
+    act(() => store.set(clientConfigStateAtom, { ...config, customStyles: '' }));
+    expect(cascadeValue(document)).toBe('appearance');
+
+    act(() =>
+      store.set(clientConfigStateAtom, {
+        ...config,
+        customStyles: '',
+        appearanceVariables: {},
+      }),
+    );
+    expect(cascadeValue(document)).toBe('plugin');
+  });
+
+  it.each([
+    ['plugin styles over author styles', { pluginStyles }, 'plugin'],
+    [
+      'appearance variables over plugin styles',
+      { pluginStyles, appearanceVariables },
+      'appearance',
+    ],
+    [
+      'custom CSS over appearance variables',
+      { pluginStyles, appearanceVariables, customStyles },
+      'custom',
+    ],
+  ])('applies %s inside plugin tabs', (_name, config, expected) => {
+    const { getByTitle } = renderWithConfig(
+      <PluginTabFrame content={`<style>:root { ${CASCADE_VARIABLE}: author; }</style>`} />,
+      config,
+    );
+    const frame = getByTitle('Plugin tab') as HTMLIFrameElement;
+    const doc = frame.contentDocument;
+    const win = frame.contentWindow;
+    expect(doc).not.toBeNull();
+    expect(win).not.toBeNull();
+
+    doc!.head.innerHTML = `<style>:root { ${CASCADE_VARIABLE}: author; }</style>`;
+    Object.defineProperty(win, 'ResizeObserver', {
+      configurable: true,
+      value: class ResizeObserver {
+        observe() {}
+        disconnect() {}
+      },
+    });
+    fireEvent.load(frame);
+
+    expect(cascadeValue(doc!)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #5161. Ant Design v6 components used a hardcoded font token and runtime token values could bypass the viewer's CSS variables. Documented custom CSS therefore changed native elements but not all Ant Design elements.

## Solution

- Make the Ant Design font token follow `--theme-text-body-font-family`.
- Keep primary Ant Design button colors and disabled states connected to Owncast CSS variables.
- Add cascade tests covering plugin styles, appearance variables, custom CSS, selector specificity, focus states, reload persistence, responsive rules, and plugin tab frames.
- Regenerate the extracted Ant Design stylesheet.

## Verification

- `npm test -- --runInBand tests/themeCascade.test.tsx` passed 4/4.
- Chrome desktop cascade checks passed 13/13.
- Chrome mobile responsive check passed 1/1.
- The full desktop offline browser group passed 29/29 before the expanded cascade assertions.
- TypeScript, ESLint, Prettier, production web build, Go tests, and plugin integration tests passed.
- Browser smoke output: body font `monospace`, header font `monospace`, button font `monospace`, button background `rgb(255, 0, 0)`, and button border `rgb(0, 128, 0)`.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [x] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->