### PR TITLE
Keep Renovate lockfiles compatible with CI

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -111,6 +111,9 @@
         "ts-jest": "^29.1.0",
         "typescript": "^6.0.0",
         "workbox-build": "^7.4.1"
+      },
+      "engines": {
+        "npm": "11.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,9 @@
   "name": "owncast-web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "npm": "11.6.2"
+  },
   "resolutions": {
     "babel-preset-current-node-syntax": "1.1.1"
   },


### PR DESCRIPTION
Renovate has been generating web lockfiles with a different npm version than CI. That leaves dependency PRs unable to complete `npm ci`, including the third-party license job.

- Pin the web package's npm engine to CI's npm version so Renovate resolves lockfiles with the same npm release.
- Regenerate the lockfile metadata.

Verified with CI's Node 24.12.0 and npm 11.6.2 using the production `npm ci` command. `npm run build` also passes.

<!-- REQUIRED-CHECKLIST:START - Do not remove this section -->

## Required checklist

- [x] I have personally tested these changes and verified they work as intended.
- [x] I understand the code I'm submitting and can explain how it works if asked.
- [x] I included a screenshot, logs, example payload to demonstrate the change, or it really doesn't need it.
- [x] This is a frontend change and it supports [translations](https://docs.owncast.dev/web-translations), or it's not a frontend change.
- [x] The code has been run through the proper linters and/or formatters for the language.
- [ ] There is an issue discussing this change and it's assigned to me.
<!-- REQUIRED-CHECKLIST:END -->